### PR TITLE
Fix translation display when lyrics lack translations

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/ui/component/AppleMusicLyric.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/component/AppleMusicLyric.kt
@@ -388,8 +388,17 @@ fun AppleMusicLyric(
                     }
 
                     val transText = translatedLyrics?.let { list ->
-                        val t = if (isActive) (currentTimeMs + lyricOffsetMs) else line.startTimeMs
-                        list.lastOrNull { t >= it.startTimeMs && t < it.endTimeMs }?.text
+                        if (list.isEmpty()) return@let null
+
+                        val targetTime = if (isActive) (currentTimeMs + lyricOffsetMs) else line.startTimeMs
+                        val matchedLine = list.lastOrNull { targetTime >= it.startTimeMs && targetTime < it.endTimeMs }
+                            ?: list.lastOrNull { targetTime >= it.startTimeMs }
+
+                        val tolerance = 1_500L
+                        val isTimeAligned = matchedLine != null &&
+                            matchedLine.startTimeMs >= line.startTimeMs - tolerance
+
+                        if (isTimeAligned) matchedLine?.text else null
                     }
                     val shouldShowTranslation = (isUserScrolling || isActive) && !transText.isNullOrBlank()
 


### PR DESCRIPTION
## Summary
- prevent the lyrics view from reusing the previous translation when the current line has no translation
- align translated lines to their lyric lines within a short tolerance window

## Testing
- `./gradlew :app:lint` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ce787968f48320bce07f6dd2984fa1