### PR TITLE
fix: serialize YouTube prefetch resolution to avoid EJS lock contention

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -293,6 +293,7 @@ object PlayerManager {
     val playlistsFlow: StateFlow<List<LocalPlaylist>> = _playlistsFlow
 
     internal var playJob: Job? = null
+    internal var currentYouTubePrefetchJob: Job? = null
     internal val youtubeStreamWarmupJobs = ConcurrentHashMap<String, Job>()
     @Volatile
     internal var playbackRequestToken = 0L
@@ -507,6 +508,8 @@ object PlayerManager {
         playbackRequestToken += 1
         playJob?.cancel()
         playJob = null
+        currentYouTubePrefetchJob?.cancel()
+        currentYouTubePrefetchJob = null
         updateResumePlaybackRequested(false)
         restoredShouldResumePlayback = false
         restoredResumePositionMs = 0L

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManagerPlaybackExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManagerPlaybackExtensions.kt
@@ -369,11 +369,12 @@ internal fun PlayerManager.playAtIndex(
     }
 
     playJob?.cancel()
+    currentYouTubePrefetchJob?.cancel()
+    currentYouTubePrefetchJob = null
     playbackRequestToken += 1
     val requestToken = playbackRequestToken
     clearPendingSeekPosition()
     _playbackPositionMs.value = 0L
-    maybeWarmCurrentAndUpcomingYouTubeMusic(index)
     playJob = ioScope.launch {
         val result = resolveSongUrl(song)
         if (requestToken != playbackRequestToken || !isActive) {
@@ -512,14 +513,6 @@ private fun PlayerManager.maybeAutoMatchBiliMetadata(song: SongItem, requestToke
 
         replaceMetadataFromSearch(latestSong, candidate, isAuto = true)
     }
-}
-
-private fun PlayerManager.maybeWarmCurrentAndUpcomingYouTubeMusic(currentSongIndex: Int) {
-    prefetchYouTubeQueueWindow(
-        playlist = currentPlaylist,
-        startIndex = currentSongIndex,
-        source = "play_at_index"
-    )
 }
 
 private fun PlayerManager.maybeWarmNextYouTubeMusicAfterCurrentResolved() {
@@ -1096,6 +1089,8 @@ internal fun PlayerManager.stopPlaybackPreservingQueueImpl(clearMediaUrl: Boolea
     playbackRequestToken += 1
     playJob?.cancel()
     playJob = null
+    currentYouTubePrefetchJob?.cancel()
+    currentYouTubePrefetchJob = null
     lastHandledTrackEndKey = null
     updateResumePlaybackRequested(false)
     lastAutoTrackAdvanceAtMs = 0L

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManagerYouTubePrefetchExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManagerYouTubePrefetchExtensions.kt
@@ -7,9 +7,11 @@ import androidx.media3.datasource.cache.CacheDataSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
 import moe.ouom.neriplayer.core.api.youtube.YouTubePlayableStreamType
+import moe.ouom.neriplayer.core.player.prefetch.YouTubePrefetchRunner
+import moe.ouom.neriplayer.core.player.prefetch.YouTubePrefetchTask
 import moe.ouom.neriplayer.core.player.policy.resolveYouTubeWarmupTargets
 import moe.ouom.neriplayer.ui.viewmodel.playlist.SongItem
 import moe.ouom.neriplayer.util.NPLogger
@@ -19,6 +21,15 @@ private const val YOUTUBE_WARMUP_MIN_PREFETCH_BYTES = 256L * 1024L
 private const val YOUTUBE_WARMUP_FIRST_TRACK_PREFETCH_BYTES = 1536L * 1024L
 private const val YOUTUBE_WARMUP_SECOND_TRACK_PREFETCH_BYTES = 1024L * 1024L
 private const val YOUTUBE_WARMUP_FOLLOWING_TRACK_PREFETCH_BYTES = 512L * 1024L
+private const val YOUTUBE_PREFETCH_MAX_CONCURRENCY = 1
+
+private data class YouTubePrefetchSpec(
+    val videoId: String,
+    val preferredQuality: String,
+    val slot: Int,
+    val windowSize: Int,
+    val source: String
+)
 
 internal fun PlayerManager.prefetchYouTubeQueueWindowImpl(
     playlist: List<SongItem>,
@@ -38,25 +49,27 @@ internal fun PlayerManager.prefetchYouTubeQueueWindowImpl(
         "NERI-PlayerManager",
         "prefetchYouTubeQueueWindow: source=$source, startIndex=$startIndex, ids=${targets.prefetchVideoIds.joinToString()}, preferredQuality=${targets.preferredQuality}"
     )
-    targets.prefetchVideoIds.forEachIndexed { slot, videoId ->
-        scheduleYouTubePlayableAudioWarmup(
+    val specs = targets.prefetchVideoIds.mapIndexed { slot, videoId ->
+        YouTubePrefetchSpec(
             videoId = videoId,
             preferredQuality = targets.preferredQuality,
             slot = slot,
             windowSize = targets.prefetchVideoIds.size,
             source = source
         )
-    }
+    }.associateBy { it.videoId }
+    currentYouTubePrefetchJob?.cancel()
+    currentYouTubePrefetchJob = YouTubePrefetchRunner(
+        task = YouTubePrefetchTask { videoId ->
+            val spec = specs[videoId] ?: return@YouTubePrefetchTask
+            prefetchYouTubePlayableAudio(spec)
+        },
+        maxConcurrency = YOUTUBE_PREFETCH_MAX_CONCURRENCY
+    ).launch(ioScope, targets.prefetchVideoIds)
 }
 
-private fun PlayerManager.scheduleYouTubePlayableAudioWarmup(
-    videoId: String,
-    preferredQuality: String,
-    slot: Int,
-    windowSize: Int,
-    source: String
-) {
-    val cacheKey = computeYouTubeCacheKey(videoId, preferredQuality)
+private suspend fun PlayerManager.prefetchYouTubePlayableAudio(spec: YouTubePrefetchSpec) {
+    val cacheKey = computeYouTubeCacheKey(spec.videoId, spec.preferredQuality)
     if (checkExoPlayerCache(cacheKey)) {
         return
     }
@@ -64,61 +77,63 @@ private fun PlayerManager.scheduleYouTubePlayableAudioWarmup(
     if (existingJob?.isActive == true) {
         return
     }
-    lateinit var createdJob: Job
-    createdJob = ioScope.launch {
-        val startedAtMs = System.currentTimeMillis()
-        try {
-            val playableAudio = youtubeMusicPlaybackRepository.getBestPlayableAudio(
-                videoId = videoId,
-                preferredQualityOverride = preferredQuality,
-                forceRefresh = false,
-                requireDirect = false,
-                preferM4a = false
-            ) ?: return@launch
-            invalidateMismatchedCachedResource(
-                cacheKey = cacheKey,
-                expectedContentLength = playableAudio.contentLength
-            )
-            if (checkExoPlayerCache(cacheKey)) {
-                return@launch
-            }
-            if (playableAudio.streamType != YouTubePlayableStreamType.DIRECT) {
-                NPLogger.d(
-                    "NERI-PlayerManager",
-                    "skip media prefetch for non-direct YouTube stream: videoId=$videoId, type=${playableAudio.streamType}, source=$source"
-                )
-                return@launch
-            }
-            val targetBytes = resolveYouTubeWarmupPrefetchBytes(
-                slot = slot,
-                windowSize = windowSize,
-                contentLength = playableAudio.contentLength
-            )
-            if (targetBytes <= 0L) {
-                return@launch
-            }
-            val prefetchedBytes = prefetchIntoPlayerCache(
-                url = playableAudio.url,
-                cacheKey = cacheKey,
-                targetBytes = targetBytes
-            )
+    val createdJob = currentCoroutineContext()[Job]
+    if (createdJob != null) {
+        youtubeStreamWarmupJobs[cacheKey] = createdJob
+    }
+    val startedAtMs = System.currentTimeMillis()
+    try {
+        val playableAudio = youtubeMusicPlaybackRepository.getBestPlayableAudio(
+            videoId = spec.videoId,
+            preferredQualityOverride = spec.preferredQuality,
+            forceRefresh = false,
+            requireDirect = false,
+            preferM4a = false
+        ) ?: return
+        invalidateMismatchedCachedResource(
+            cacheKey = cacheKey,
+            expectedContentLength = playableAudio.contentLength
+        )
+        if (checkExoPlayerCache(cacheKey)) {
+            return
+        }
+        if (playableAudio.streamType != YouTubePlayableStreamType.DIRECT) {
             NPLogger.d(
                 "NERI-PlayerManager",
-                "YouTube media prefetch finished: videoId=$videoId, cacheKey=$cacheKey, slot=$slot, source=$source, prefetchedBytes=$prefetchedBytes, targetBytes=$targetBytes, contentLength=${playableAudio.contentLength}, elapsedMs=${System.currentTimeMillis() - startedAtMs}"
+                "skip media prefetch for non-direct YouTube stream: videoId=${spec.videoId}, type=${playableAudio.streamType}, source=${spec.source}"
             )
-        } catch (error: Exception) {
-            if (error is CancellationException) {
-                throw error
-            }
-            NPLogger.w(
-                "NERI-PlayerManager",
-                "YouTube media prefetch failed: videoId=$videoId, cacheKey=$cacheKey, slot=$slot, source=$source, error=${error.message}"
-            )
-        } finally {
+            return
+        }
+        val targetBytes = resolveYouTubeWarmupPrefetchBytes(
+            slot = spec.slot,
+            windowSize = spec.windowSize,
+            contentLength = playableAudio.contentLength
+        )
+        if (targetBytes <= 0L) {
+            return
+        }
+        val prefetchedBytes = prefetchIntoPlayerCache(
+            url = playableAudio.url,
+            cacheKey = cacheKey,
+            targetBytes = targetBytes
+        )
+        NPLogger.d(
+            "NERI-PlayerManager",
+            "YouTube media prefetch finished: videoId=${spec.videoId}, cacheKey=$cacheKey, slot=${spec.slot}, source=${spec.source}, prefetchedBytes=$prefetchedBytes, targetBytes=$targetBytes, contentLength=${playableAudio.contentLength}, elapsedMs=${System.currentTimeMillis() - startedAtMs}"
+        )
+    } catch (error: Exception) {
+        if (error is CancellationException) {
+            throw error
+        }
+        NPLogger.w(
+            "NERI-PlayerManager",
+            "YouTube media prefetch failed: videoId=${spec.videoId}, cacheKey=$cacheKey, slot=${spec.slot}, source=${spec.source}, error=${error.message}"
+        )
+    } finally {
+        if (createdJob != null) {
             youtubeStreamWarmupJobs.remove(cacheKey, createdJob)
         }
     }
-    youtubeStreamWarmupJobs[cacheKey] = createdJob
 }
 
 private fun resolveYouTubeWarmupPrefetchBytes(

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/YouTubePrefetchRunner.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/YouTubePrefetchRunner.kt
@@ -1,0 +1,41 @@
+package moe.ouom.neriplayer.core.player.prefetch
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+
+fun interface YouTubePrefetchTask {
+    suspend fun prefetch(videoId: String)
+}
+
+class YouTubePrefetchRunner(
+    private val task: YouTubePrefetchTask,
+    private val maxConcurrency: Int = 1
+) {
+    init {
+        require(maxConcurrency > 0) { "maxConcurrency must be positive" }
+    }
+
+    fun launch(scope: CoroutineScope, videoIds: List<String>): Job = scope.launch {
+        val semaphore = Semaphore(maxConcurrency)
+        supervisorScope {
+            videoIds.forEach { videoId ->
+                launch {
+                    semaphore.withPermit {
+                        try {
+                            task.prefetch(videoId)
+                        } catch (error: CancellationException) {
+                            throw error
+                        } catch (_: Exception) {
+                            // Individual prefetch failures should not abort the rest of the batch.
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/prefetch/YouTubePrefetchRunnerTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/prefetch/YouTubePrefetchRunnerTest.kt
@@ -1,0 +1,95 @@
+package moe.ouom.neriplayer.core.player.prefetch
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.max
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class YouTubePrefetchRunnerTest {
+
+    @Test
+    fun `prefetch concurrency never exceeds maxConcurrency`() = runTest {
+        val task = FakePrefetchTask(delayMs = 1_000)
+        val runner = YouTubePrefetchRunner(task = task, maxConcurrency = 1)
+
+        runner.launch(this, listOf("a", "b", "c"))
+        advanceUntilIdle()
+
+        assertEquals(1, task.maxConcurrencyObserved.get())
+    }
+
+    @Test
+    fun `all videoIds are prefetched exactly once`() = runTest {
+        val task = FakePrefetchTask(delayMs = 1_000)
+        val runner = YouTubePrefetchRunner(task = task, maxConcurrency = 1)
+
+        runner.launch(this, listOf("a", "b", "c"))
+        advanceUntilIdle()
+
+        assertEquals(listOf("a", "b", "c"), task.finished.toList())
+    }
+
+    @Test
+    fun `a failing prefetch does not abort the rest`() = runTest {
+        val task = FakePrefetchTask(delayMs = 1_000, failingVideoIds = setOf("b"))
+        val runner = YouTubePrefetchRunner(task = task, maxConcurrency = 1)
+
+        runner.launch(this, listOf("a", "b", "c"))
+        advanceUntilIdle()
+
+        assertEquals(listOf("a", "c"), task.finished.toList())
+        assertEquals(listOf("b"), task.failed.toList())
+    }
+
+    @Test
+    fun `cancelling the returned job stops pending prefetch`() = runTest {
+        val task = FakePrefetchTask(delayMs = 10_000)
+        val runner = YouTubePrefetchRunner(task = task, maxConcurrency = 1)
+
+        val job = runner.launch(this, listOf("a", "b", "c"))
+        advanceTimeBy(1)
+        job.cancel(CancellationException("test cancellation"))
+        advanceUntilIdle()
+
+        assertTrue(task.started.contains("a"))
+        assertFalse(task.started.contains("b"))
+        assertFalse(task.started.contains("c"))
+    }
+
+    private class FakePrefetchTask(
+        private val delayMs: Long,
+        private val failingVideoIds: Set<String> = emptySet()
+    ) : YouTubePrefetchTask {
+        private val active = AtomicInteger(0)
+        val maxConcurrencyObserved = AtomicInteger(0)
+        val started = Collections.synchronizedList(mutableListOf<String>())
+        val finished = Collections.synchronizedList(mutableListOf<String>())
+        val failed = Collections.synchronizedList(mutableListOf<String>())
+
+        override suspend fun prefetch(videoId: String) {
+            started.add(videoId)
+            val now = active.incrementAndGet()
+            maxConcurrencyObserved.updateAndGet { max(it, now) }
+            try {
+                delay(delayMs)
+                if (videoId in failingVideoIds) {
+                    failed.add(videoId)
+                    error("boom")
+                }
+                finished.add(videoId)
+            } finally {
+                active.decrementAndGet()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 描述 / Description

并发预取 YouTube Music 队列窗口时，多首歌曲的解析会同时争用 EJS 签名求解器中的全局锁（`YouTubeEjsChallengeSolver` 内部以 `synchronized` 串行化），导致当前正在播放/即将播放的那首歌的地址解析被一并排队拖慢。在快速切歌时，旧的预取任务不会被取消，新旧窗口叠加后并发度进一步升高，使当前曲解析时间显著恶化。

本 PR 引入一个轻量的预取执行器 `YouTubePrefetchRunner`，对 YouTube 预取做并发限流（默认 `maxConcurrency=1`，即串行），并在切歌时取消上一批预取任务，从而消除 EJS 锁争用对当前曲解析的拖累。本次改动只触及 YouTube 预取调度层，不改变解析算法、ExoPlayer 缓存、其它音源（Bilibili / 网易云）或 UI。

This PR adds a lightweight `YouTubePrefetchRunner` that throttles YouTube prefetch concurrency (default `maxConcurrency=1`, i.e. serial) and cancels the previous prefetch batch on track change. This removes EJS signature-solver lock contention that was slowing down resolution of the currently-playing track. The change is scoped to the YouTube prefetch scheduling layer only — no changes to the resolution algorithm, ExoPlayer cache, other providers, or UI.

## 类型 / Type

- [x] Bug 修复 / Bug Fix
- [ ] 新功能 / New Feature
- [ ] 文档更新 / Documentation Update
- [ ] 其他（请描述）/ Other (please describe):

## 修复或解决的问题 / Issues Fixed or Closed by This PR

手机端播放 YouTube Music 时，切歌后当前曲地址解析耗时过长（弱网/多歌曲场景下可达数十秒），根因为并发预取在 EJS 签名求解器全局锁上的争用。

## 清单 / Checklist

- [x] 我已阅读并遵循贡献指南 / I have read and followed the contribution guidelines
- [x] 我已在本地测试这些更改 / I have tested these changes locally
- [x] 我已更新相关文档或注释（如适用） / I have updated relevant documentation or comments (if applicable)

## 其他信息 / Additional Information

### 根因 / Root cause

EJS 签名求解器对所有 challenge 串行求解（`synchronized` 全局锁）。当一个预取窗口同时发起 N 首歌的解析时，N 首歌的 challenge（每首 2 个：signature + throttling）会在该锁上排队；如果用户正在等待其中某一首（当前曲/下一曲）出声，它的解析就会被同窗口里其它预取目标的 challenge 一起拖慢。快速连续切歌时旧预取未取消，并发度叠加后进一步放大该效应。

### 修复 / Fix

- 新增 `core/player/prefetch/YouTubePrefetchRunner`：用 `Semaphore(maxConcurrency)` 对一批预取目标做并发限流，单个目标失败不影响其余目标（`supervisorScope` + 吞掉非取消异常）。
- `PlayerManagerYouTubePrefetchExtensions` 接入该执行器，默认 `maxConcurrency=1`（串行预取）。
- 每次发起新预取窗口前取消上一批预取任务（`currentYouTubePrefetchJob?.cancel()`），避免切歌时新旧窗口叠加。

### 实测效果 / Measured effect

在同一台设备、同一会话内对比「无本改动」与「有本改动」两个构建，对 bootstrap 已预热（warm）后的单首解析耗时观察到清晰的「并发度—解析耗时」关系：

| 场景 | 同时解析的歌曲数 | warm 解析耗时（中位） |
|---|---|---|
| 无本改动，单首无竞争 | 1 | ~8s |
| 无本改动，一窗口 4 路并行 | 4 | ~17–22s |
| 无本改动，快速切歌致两窗口叠加 | 8 | ~25–34s |
| 本改动（串行 + 切歌取消） | 1 | ~7–13s |

无本改动时，曾观测到快速连切后当前曲解析被预取雪崩拖到约 32s 才出声；本改动将并发严格限制为 1 并在切歌时取消旧预取，使该雪崩在架构上无法发生，当前曲解析稳定回到 warm 基线区间。

> 注：上述绝对耗时受测试网络（经代理、含若干超时）影响，存在噪声；但「并发度越高、解析越慢」「串行后回到 warm 基线」这一结构性结论不依赖网速。单首无竞争解析在两种构建下均为 ~8s，说明本改动未触及解析热路径、无回归。

> 再注：测试基于临时 log 代码，这些 log 代码并未提交污染主仓库。

### 验证 / Verification

- `:app:testDebugUnitTest --tests *YouTubePrefetchRunnerTest*` 通过（覆盖并发上限、失败隔离、批次完成等）。
- `:app:assembleDebug` 构建通过。
