### PR TITLE
Fix/meizu21pro statusbar lyrics

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
@@ -149,6 +149,7 @@ private data class PlaybackNotificationSnapshot(
     val requiresInteractiveFavoriteConfirmation: Boolean,
     val largeIconReady: Boolean,
     val coverSource: String?,
+    val statusBarLyricLine: String?,
 )
 
 private data class PlaybackMetadataSnapshot(
@@ -1481,6 +1482,12 @@ class AudioPlayerService : Service() {
         } else {
             song?.displayArtist() ?: ""
         }
+        val currentStatusBarLyricLine = if (statusBarLyricsEnable) {
+            PlayerManager.externalBluetoothLyricLineFlow.value
+                ?.takeIf { it.isNotBlank() && it != "null" }
+        } else {
+            null
+        }
         return PlaybackNotificationSnapshot(
             songKey = song?.stableKey(),
             title = song?.displayName() ?: "NeriPlayer",
@@ -1491,6 +1498,7 @@ class AudioPlayerService : Service() {
             requiresInteractiveFavoriteConfirmation = requiresInteractiveFavoriteConfirmation(song),
             largeIconReady = currentNotificationLargeIcon != null,
             coverSource = currentCoverSource,
+            statusBarLyricLine = currentStatusBarLyricLine,
         )
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
@@ -80,7 +80,6 @@ import moe.ouom.neriplayer.core.di.AppContainer
 import moe.ouom.neriplayer.core.download.GlobalDownloadManager
 import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.core.player.PlayerManager.externalBluetoothLyricLineFlow
-import moe.ouom.neriplayer.core.player.PlayerManager.statusBarLyricsEnable
 import moe.ouom.neriplayer.core.player.audio.focus.StartupAudioFocusController
 import moe.ouom.neriplayer.core.player.lifecycle.recoverUsbExclusivePlaybackIfUnhealthy
 import moe.ouom.neriplayer.core.player.persistence.preloadRestoredStateSnapshot
@@ -149,7 +148,7 @@ private data class PlaybackNotificationSnapshot(
     val requiresInteractiveFavoriteConfirmation: Boolean,
     val largeIconReady: Boolean,
     val coverSource: String?,
-    val statusBarLyricLine: String?,
+    val statusBarLyricState: StatusBarLyricNotificationState,
 )
 
 private data class PlaybackMetadataSnapshot(
@@ -495,6 +494,10 @@ class AudioPlayerService : Service() {
     private var isForegroundStarted = false
     private var lastNotificationSnapshot: PlaybackNotificationSnapshot? = null
     private var lastMetadataSnapshot: PlaybackMetadataSnapshot? = null
+    private var statusBarLyricState = resolveStatusBarLyricNotificationState(
+        enabled = false,
+        line = null,
+    )
     private var usbExclusiveKeepAliveJob: Job? = null
     private var usbExclusiveKeepAliveTick: Long = 0L
     private var lastUsbExclusiveKeepAliveAtMs: Long = 0L
@@ -1064,8 +1067,12 @@ class AudioPlayerService : Service() {
         }
 
         serviceScope.launch {
-            externalBluetoothLyricLineFlow.collectSafely("statusBarLyricLineFlow") {
-                if (statusBarLyricsEnable) {
+            statusBarLyricNotificationStateFlow(
+                enabledFlow = AppContainer.settingsRepo.statusBarLyricsEnabledFlow,
+                lineFlow = externalBluetoothLyricLineFlow,
+            ).collectSafely("statusBarLyricNotificationStateFlow") { state ->
+                if (statusBarLyricState != state) {
+                    statusBarLyricState = state
                     updateNotification()
                 }
             }
@@ -1355,11 +1362,8 @@ class AudioPlayerService : Service() {
         builder.addAction(R.drawable.round_skip_next_24, getString(R.string.player_next), nextIntent)
 
         builder.setContentTitle(song?.displayName() ?: "NeriPlayer")
-        val statusBarLyricLine = externalBluetoothLyricLineFlow.value
-            ?.takeIf { it.isNotBlank() && it != "null" }
-        if (statusBarLyricsEnable && statusBarLyricLine != null) {
-            builder.setTicker(statusBarLyricLine)
-        }
+        val currentStatusBarLyricState = statusBarLyricState
+        currentStatusBarLyricState.line?.let(builder::setTicker)
 
         val timerState = PlayerManager.sleepTimerManager.timerState.value
         val contentText = if (timerState.isActive) {
@@ -1383,7 +1387,7 @@ class AudioPlayerService : Service() {
         currentNotificationLargeIcon?.let { builder.setLargeIcon(it) }
 
         return builder.build().apply {
-            if (statusBarLyricsEnable) {
+            if (currentStatusBarLyricState.hasTicker) {
                 val FLAG_ALWAYS_SHOW_TICKER = 0x01000000
                 val FLAG_ONLY_UPDATE_TICKER = 0x02000000
                 // 魅族状态栏歌词依赖这两个私有通知标记
@@ -1391,7 +1395,7 @@ class AudioPlayerService : Service() {
                 flags = flags.or(FLAG_ONLY_UPDATE_TICKER)
                 // ticker_icon: 状态栏歌词前的小图标
                 extras.putInt("ticker_icon", R.drawable.ic_notification_small)
-                // ticker_icon_switch: false 表示不显示图标，仅显示文字
+                // false 表示沿用缓存图标，图标资源变化时才需要切换
                 extras.putBoolean("ticker_icon_switch", false)
             }
         }
@@ -1486,12 +1490,7 @@ class AudioPlayerService : Service() {
         } else {
             song?.displayArtist() ?: ""
         }
-        val currentStatusBarLyricLine = if (statusBarLyricsEnable) {
-            PlayerManager.externalBluetoothLyricLineFlow.value
-                ?.takeIf { it.isNotBlank() && it != "null" }
-        } else {
-            null
-        }
+        val currentStatusBarLyricState = statusBarLyricState
         return PlaybackNotificationSnapshot(
             songKey = song?.stableKey(),
             title = song?.displayName() ?: "NeriPlayer",
@@ -1502,7 +1501,7 @@ class AudioPlayerService : Service() {
             requiresInteractiveFavoriteConfirmation = requiresInteractiveFavoriteConfirmation(song),
             largeIconReady = currentNotificationLargeIcon != null,
             coverSource = currentCoverSource,
-            statusBarLyricLine = currentStatusBarLyricLine,
+            statusBarLyricState = currentStatusBarLyricState,
         )
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
@@ -1389,6 +1389,10 @@ class AudioPlayerService : Service() {
                 // 魅族状态栏歌词依赖这两个私有通知标记
                 flags = flags.or(FLAG_ALWAYS_SHOW_TICKER)
                 flags = flags.or(FLAG_ONLY_UPDATE_TICKER)
+                // ticker_icon: 状态栏歌词前的小图标
+                extras.putInt("ticker_icon", R.drawable.ic_notification_small)
+                // ticker_icon_switch: false 表示不显示图标，仅显示文字
+                extras.putBoolean("ticker_icon_switch", false)
             }
         }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/service/StatusBarLyricNotificationState.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/service/StatusBarLyricNotificationState.kt
@@ -1,0 +1,32 @@
+package moe.ouom.neriplayer.core.player.service
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+internal data class StatusBarLyricNotificationState(
+    val enabled: Boolean,
+    val line: String?,
+) {
+    val hasTicker: Boolean
+        get() = enabled && line != null
+}
+
+internal fun resolveStatusBarLyricNotificationState(
+    enabled: Boolean,
+    line: String?,
+): StatusBarLyricNotificationState {
+    val normalizedLine = line?.takeIf { it.isNotBlank() && it != "null" }
+    return StatusBarLyricNotificationState(
+        enabled = enabled,
+        line = normalizedLine.takeIf { enabled },
+    )
+}
+
+internal fun statusBarLyricNotificationStateFlow(
+    enabledFlow: Flow<Boolean>,
+    lineFlow: Flow<String?>,
+): Flow<StatusBarLyricNotificationState> {
+    return combine(enabledFlow, lineFlow, ::resolveStatusBarLyricNotificationState)
+        .distinctUntilChanged()
+}

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/service/StatusBarLyricNotificationStateTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/service/StatusBarLyricNotificationStateTest.kt
@@ -1,0 +1,87 @@
+package moe.ouom.neriplayer.core.player.service
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StatusBarLyricNotificationStateTest {
+
+    @Test
+    fun `setting and lyric changes produce distinct notification states`() = runTest {
+        val enabledFlow = MutableStateFlow(false)
+        val lineFlow = MutableStateFlow<String?>("line A")
+        val states = mutableListOf<StatusBarLyricNotificationState>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            statusBarLyricNotificationStateFlow(enabledFlow, lineFlow).collect { state ->
+                states += state
+            }
+        }
+
+        assertEquals(
+            listOf(resolveStatusBarLyricNotificationState(false, null)),
+            states,
+        )
+
+        enabledFlow.value = true
+        lineFlow.value = "line B"
+        enabledFlow.value = false
+        val stateCountAfterDisable = states.size
+        lineFlow.value = "line C"
+        assertEquals(stateCountAfterDisable, states.size)
+        enabledFlow.value = true
+
+        assertEquals(
+            listOf(
+                resolveStatusBarLyricNotificationState(false, null),
+                resolveStatusBarLyricNotificationState(true, "line A"),
+                resolveStatusBarLyricNotificationState(true, "line B"),
+                resolveStatusBarLyricNotificationState(false, null),
+                resolveStatusBarLyricNotificationState(true, "line C"),
+            ),
+            states,
+        )
+    }
+
+    @Test
+    fun `setting changes are emitted even without a lyric line`() = runTest {
+        val enabledFlow = MutableStateFlow(false)
+        val lineFlow = MutableStateFlow<String?>(null)
+        val states = mutableListOf<StatusBarLyricNotificationState>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            statusBarLyricNotificationStateFlow(enabledFlow, lineFlow).collect { state ->
+                states += state
+            }
+        }
+
+        enabledFlow.value = true
+        enabledFlow.value = false
+
+        assertEquals(
+            listOf(
+                resolveStatusBarLyricNotificationState(false, null),
+                resolveStatusBarLyricNotificationState(true, null),
+                resolveStatusBarLyricNotificationState(false, null),
+            ),
+            states,
+        )
+    }
+
+    @Test
+    fun `invalid lyric lines never create a ticker`() {
+        listOf(null, "", "   ", "null").forEach { line ->
+            val state = resolveStatusBarLyricNotificationState(enabled = true, line = line)
+
+            assertTrue(state.enabled)
+            assertNull(state.line)
+            assertFalse(state.hasTicker)
+        }
+    }
+}


### PR DESCRIPTION
fix: 修复魅族状态栏歌词不跟随进度更新、补充 Flyme ticker_icon 支持
## 修复内容

在魅族 21 Pro 上测试并修复了状态栏歌词的两个问题：

### 1. 歌词卡住不更新
`PlaybackNotificationSnapshot` 缺少歌词行字段，导致歌词变化时通知去重机制误判为"无变化"，通知不被重建，ticker 停留在上一句。

### 2. 部分设备完全不显示
根据 Flyme 状态栏歌词适配文档，补充了 `ticker_icon` 和 `ticker_icon_switch` 两个 extras，同时新增了状态栏小图标。

## 测试设备

- 魅族 21 Pro (Flyme12.0.00A)
- 状态栏歌词正常滚动更新，图标正常显示
- 本人小白，所有修改由deepseek进行
- 参考资料：https://juejin.cn/post/7097415319643226125
