### PR TITLE
fix: 完善魅族状态栏歌词通知刷新

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
@@ -80,7 +80,6 @@ import moe.ouom.neriplayer.core.di.AppContainer
 import moe.ouom.neriplayer.core.download.GlobalDownloadManager
 import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.core.player.PlayerManager.externalBluetoothLyricLineFlow
-import moe.ouom.neriplayer.core.player.PlayerManager.statusBarLyricsEnable
 import moe.ouom.neriplayer.core.player.audio.focus.StartupAudioFocusController
 import moe.ouom.neriplayer.core.player.lifecycle.recoverUsbExclusivePlaybackIfUnhealthy
 import moe.ouom.neriplayer.core.player.persistence.preloadRestoredStateSnapshot
@@ -149,6 +148,7 @@ private data class PlaybackNotificationSnapshot(
     val requiresInteractiveFavoriteConfirmation: Boolean,
     val largeIconReady: Boolean,
     val coverSource: String?,
+    val statusBarLyricState: StatusBarLyricNotificationState,
 )
 
 private data class PlaybackMetadataSnapshot(
@@ -494,6 +494,10 @@ class AudioPlayerService : Service() {
     private var isForegroundStarted = false
     private var lastNotificationSnapshot: PlaybackNotificationSnapshot? = null
     private var lastMetadataSnapshot: PlaybackMetadataSnapshot? = null
+    private var statusBarLyricState = resolveStatusBarLyricNotificationState(
+        enabled = false,
+        line = null,
+    )
     private var usbExclusiveKeepAliveJob: Job? = null
     private var usbExclusiveKeepAliveTick: Long = 0L
     private var lastUsbExclusiveKeepAliveAtMs: Long = 0L
@@ -1063,8 +1067,12 @@ class AudioPlayerService : Service() {
         }
 
         serviceScope.launch {
-            externalBluetoothLyricLineFlow.collectSafely("statusBarLyricLineFlow") {
-                if (statusBarLyricsEnable) {
+            statusBarLyricNotificationStateFlow(
+                enabledFlow = AppContainer.settingsRepo.statusBarLyricsEnabledFlow,
+                lineFlow = externalBluetoothLyricLineFlow,
+            ).collectSafely("statusBarLyricNotificationStateFlow") { state ->
+                if (statusBarLyricState != state) {
+                    statusBarLyricState = state
                     updateNotification()
                 }
             }
@@ -1354,11 +1362,8 @@ class AudioPlayerService : Service() {
         builder.addAction(R.drawable.round_skip_next_24, getString(R.string.player_next), nextIntent)
 
         builder.setContentTitle(song?.displayName() ?: "NeriPlayer")
-        val statusBarLyricLine = externalBluetoothLyricLineFlow.value
-            ?.takeIf { it.isNotBlank() && it != "null" }
-        if (statusBarLyricsEnable && statusBarLyricLine != null) {
-            builder.setTicker(statusBarLyricLine)
-        }
+        val currentStatusBarLyricState = statusBarLyricState
+        currentStatusBarLyricState.line?.let(builder::setTicker)
 
         val timerState = PlayerManager.sleepTimerManager.timerState.value
         val contentText = if (timerState.isActive) {
@@ -1382,12 +1387,16 @@ class AudioPlayerService : Service() {
         currentNotificationLargeIcon?.let { builder.setLargeIcon(it) }
 
         return builder.build().apply {
-            if (statusBarLyricsEnable) {
+            if (currentStatusBarLyricState.hasTicker) {
                 val FLAG_ALWAYS_SHOW_TICKER = 0x01000000
                 val FLAG_ONLY_UPDATE_TICKER = 0x02000000
                 // 魅族状态栏歌词依赖这两个私有通知标记
                 flags = flags.or(FLAG_ALWAYS_SHOW_TICKER)
                 flags = flags.or(FLAG_ONLY_UPDATE_TICKER)
+                // ticker_icon: 状态栏歌词前的小图标
+                extras.putInt("ticker_icon", R.drawable.ic_notification_small)
+                // false 表示沿用缓存图标，图标资源变化时才需要切换
+                extras.putBoolean("ticker_icon_switch", false)
             }
         }
 
@@ -1481,6 +1490,7 @@ class AudioPlayerService : Service() {
         } else {
             song?.displayArtist() ?: ""
         }
+        val currentStatusBarLyricState = statusBarLyricState
         return PlaybackNotificationSnapshot(
             songKey = song?.stableKey(),
             title = song?.displayName() ?: "NeriPlayer",
@@ -1491,6 +1501,7 @@ class AudioPlayerService : Service() {
             requiresInteractiveFavoriteConfirmation = requiresInteractiveFavoriteConfirmation(song),
             largeIconReady = currentNotificationLargeIcon != null,
             coverSource = currentCoverSource,
+            statusBarLyricState = currentStatusBarLyricState,
         )
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/service/StatusBarLyricNotificationState.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/service/StatusBarLyricNotificationState.kt
@@ -1,0 +1,32 @@
+package moe.ouom.neriplayer.core.player.service
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+internal data class StatusBarLyricNotificationState(
+    val enabled: Boolean,
+    val line: String?,
+) {
+    val hasTicker: Boolean
+        get() = enabled && line != null
+}
+
+internal fun resolveStatusBarLyricNotificationState(
+    enabled: Boolean,
+    line: String?,
+): StatusBarLyricNotificationState {
+    val normalizedLine = line?.takeIf { it.isNotBlank() && it != "null" }
+    return StatusBarLyricNotificationState(
+        enabled = enabled,
+        line = normalizedLine.takeIf { enabled },
+    )
+}
+
+internal fun statusBarLyricNotificationStateFlow(
+    enabledFlow: Flow<Boolean>,
+    lineFlow: Flow<String?>,
+): Flow<StatusBarLyricNotificationState> {
+    return combine(enabledFlow, lineFlow, ::resolveStatusBarLyricNotificationState)
+        .distinctUntilChanged()
+}

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/service/StatusBarLyricNotificationStateTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/service/StatusBarLyricNotificationStateTest.kt
@@ -1,0 +1,87 @@
+package moe.ouom.neriplayer.core.player.service
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StatusBarLyricNotificationStateTest {
+
+    @Test
+    fun `setting and lyric changes produce distinct notification states`() = runTest {
+        val enabledFlow = MutableStateFlow(false)
+        val lineFlow = MutableStateFlow<String?>("line A")
+        val states = mutableListOf<StatusBarLyricNotificationState>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            statusBarLyricNotificationStateFlow(enabledFlow, lineFlow).collect { state ->
+                states += state
+            }
+        }
+
+        assertEquals(
+            listOf(resolveStatusBarLyricNotificationState(false, null)),
+            states,
+        )
+
+        enabledFlow.value = true
+        lineFlow.value = "line B"
+        enabledFlow.value = false
+        val stateCountAfterDisable = states.size
+        lineFlow.value = "line C"
+        assertEquals(stateCountAfterDisable, states.size)
+        enabledFlow.value = true
+
+        assertEquals(
+            listOf(
+                resolveStatusBarLyricNotificationState(false, null),
+                resolveStatusBarLyricNotificationState(true, "line A"),
+                resolveStatusBarLyricNotificationState(true, "line B"),
+                resolveStatusBarLyricNotificationState(false, null),
+                resolveStatusBarLyricNotificationState(true, "line C"),
+            ),
+            states,
+        )
+    }
+
+    @Test
+    fun `setting changes are emitted even without a lyric line`() = runTest {
+        val enabledFlow = MutableStateFlow(false)
+        val lineFlow = MutableStateFlow<String?>(null)
+        val states = mutableListOf<StatusBarLyricNotificationState>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            statusBarLyricNotificationStateFlow(enabledFlow, lineFlow).collect { state ->
+                states += state
+            }
+        }
+
+        enabledFlow.value = true
+        enabledFlow.value = false
+
+        assertEquals(
+            listOf(
+                resolveStatusBarLyricNotificationState(false, null),
+                resolveStatusBarLyricNotificationState(true, null),
+                resolveStatusBarLyricNotificationState(false, null),
+            ),
+            states,
+        )
+    }
+
+    @Test
+    fun `invalid lyric lines never create a ticker`() {
+        listOf(null, "", "   ", "null").forEach { line ->
+            val state = resolveStatusBarLyricNotificationState(enabled = true, line = line)
+
+            assertTrue(state.enabled)
+            assertNull(state.line)
+            assertFalse(state.hasTicker)
+        }
+    }
+}


### PR DESCRIPTION
替代 #239 的可合并版本。

- 将状态栏歌词开关与当前歌词行组合为单一通知状态
- 歌词行或开关变化时可靠刷新通知快照
- 关闭开关后立即移除 Flyme ticker flags/extras
- 仅在存在有效歌词时附加 Flyme 私有标记
- 修正 ticker_icon_switch 注释并补充状态流单元测试
- 不包含任何 CI workflow 变更

验证：`./gradlew :app:testDebugUnitTest`