### PR TITLE
feat: add dynamic island lyrics support and allow forced bluetooth metadata updates

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -421,6 +421,7 @@ object PlayerManager {
     internal var statusBarLyricsEnable = false
     internal var externalBluetoothLyricsEnabled = false
     internal var externalBluetoothTranslationEnabled = false
+    internal var dynamicIslandLyricsEnabled = false
     internal var floatingLyricsEnabled = false
     internal var floatingLyricsShowTranslation = true
     internal var cloudMusicLyricDefaultOffsetMs = DEFAULT_CLOUD_MUSIC_LYRIC_OFFSET_MS

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
@@ -225,6 +225,7 @@ internal fun PlayerManager.initializeImpl(
             initialPlaybackPreferences.qqMusicLyricDefaultOffsetMs
         externalBluetoothLyricsEnabled = false
         externalBluetoothTranslationEnabled = false
+        dynamicIslandLyricsEnabled = false
         amllLyricsEnabled = initialPlaybackPreferences.amllLyricsEnabled
         lyriconEnabled = initialPlaybackPreferences.lyriconEnabled
         LyriconManager.setEnabled(lyriconEnabled)
@@ -758,6 +759,12 @@ internal fun PlayerManager.initializeImpl(
             settingsRepo.externalBluetoothTranslationEnabledFlow.collect { enabled ->
                 externalBluetoothTranslationEnabled = enabled
                 syncExternalTranslatedLyrics(_currentSongFlow.value)
+            }
+        }
+        ioScope.launch {
+            settingsRepo.dynamicIslandLyricsEnabledFlow.collect { enabled ->
+                dynamicIslandLyricsEnabled = enabled
+                syncExternalBluetoothLyrics(_currentSongFlow.value)
             }
         }
         ioScope.launch {
@@ -3572,6 +3579,7 @@ internal fun PlayerManager.releaseImpl() {
         externalBluetoothLyricsSongKey = null
         externalBluetoothLyricsEnabled = false
         externalBluetoothTranslationEnabled = false
+        dynamicIslandLyricsEnabled = false
         floatingLyricsEnabled = false
         floatingLyricsShowTranslation = true
         statusBarLyricsEnable = false

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lyrics/FloatingLyricsOverlayManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lyrics/FloatingLyricsOverlayManager.kt
@@ -89,6 +89,7 @@ object FloatingLyricsOverlayManager {
                 syncOverlay()
             }
 
+            @Deprecated("kept for ActivityLifecycleCallbacks compatibility")
             override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
             override fun onActivityResumed(activity: Activity) = syncOverlay()
             override fun onActivityPaused(activity: Activity) = Unit
@@ -105,6 +106,7 @@ object FloatingLyricsOverlayManager {
                 }
             }
 
+            @Deprecated("kept for ComponentCallbacks compatibility")
             override fun onLowMemory() = Unit
         }
         configurationCallbacks = appConfigurationCallbacks

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lyrics/PlayerManagerExternalBluetoothLyrics.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lyrics/PlayerManagerExternalBluetoothLyrics.kt
@@ -171,8 +171,9 @@ internal fun PlayerManager.updateExternalBluetoothLyricLine(positionMs: Long) {
         _floatingTranslatedLyricLineFlow.value = translatedLine
     }
     val payload = resolveExternalBluetoothLyricPayload(
-        lyricEnabled = externalBluetoothLyricsEnabled,
-        translationEnabled = externalBluetoothTranslationEnabled,
+        lyricEnabled = externalBluetoothLyricsEnabled || dynamicIslandLyricsEnabled,
+        translationEnabled = externalBluetoothTranslationEnabled ||
+            dynamicIslandLyricsEnabled,
         lyricLine = line,
         translationLine = translatedLine
     )
@@ -202,18 +203,35 @@ private fun PlayerManager.clearFloatingTranslatedLyricLine() {
 private fun PlayerManager.shouldProvideExternalLyricLine(): Boolean {
     return externalBluetoothLyricsEnabled ||
         externalBluetoothTranslationEnabled ||
+        dynamicIslandLyricsEnabled ||
         statusBarLyricsEnable ||
         floatingLyricsEnabled
 }
 
 private fun PlayerManager.shouldProvideExternalTranslatedLyricLine(): Boolean {
+    return shouldProvideExternalTranslatedLyricLine(
+        externalBluetoothTranslationEnabled = externalBluetoothTranslationEnabled,
+        floatingLyricsEnabled = floatingLyricsEnabled,
+        floatingLyricsShowTranslation = floatingLyricsShowTranslation,
+        dynamicIslandLyricsEnabled = dynamicIslandLyricsEnabled
+    )
+}
+
+internal fun shouldProvideExternalTranslatedLyricLine(
+    externalBluetoothTranslationEnabled: Boolean,
+    floatingLyricsEnabled: Boolean,
+    floatingLyricsShowTranslation: Boolean,
+    dynamicIslandLyricsEnabled: Boolean
+): Boolean {
     return externalBluetoothTranslationEnabled ||
+        dynamicIslandLyricsEnabled ||
         (floatingLyricsEnabled && floatingLyricsShowTranslation)
 }
 
 internal fun PlayerManager.isExternalBluetoothLyricCadenceActive(): Boolean {
-    val deviceType = _currentAudioDevice.value?.type ?: return false
-    return isBluetoothOutputType(deviceType) &&
-        (externalBluetoothLyricsEnabled || externalBluetoothTranslationEnabled) &&
+    val deviceType = _currentAudioDevice.value?.type
+    val hasBluetoothOutput = deviceType != null && isBluetoothOutputType(deviceType)
+    return (dynamicIslandLyricsEnabled || hasBluetoothOutput) &&
+        (externalBluetoothLyricsEnabled || externalBluetoothTranslationEnabled || dynamicIslandLyricsEnabled) &&
         externalBluetoothLyrics.isNotEmpty()
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/metadata/ExternalBluetoothLyrics.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/metadata/ExternalBluetoothLyrics.kt
@@ -45,9 +45,7 @@ internal fun findFloatingTranslatedLyricLine(
     if (lyrics.isEmpty() || translations.isEmpty()) return null
     val targetTimeMs = (positionMs + lyricOffsetMs).coerceAtLeast(0L)
     val lyricIndex = findCurrentExternalBluetoothLyricIndex(lyrics, targetTimeMs)
-    val lyric = lyrics.getOrNull(lyricIndex)
-        ?.takeIf { it.text.isNotBlank() }
-        ?: return null
+    if (lyrics.getOrNull(lyricIndex)?.text.isNullOrBlank()) return null
     val matches = translationMatchesByIndex ?: matchTranslationsToLineIndices(
         lines = lyrics,
         translations = translations.filter { it.text.isNotBlank() }
@@ -79,11 +77,12 @@ internal fun resolveExternalBluetoothLyricPayload(
 
 internal fun shouldUseExternalBluetoothLyrics(
     audioDeviceType: Int?,
-    payload: ExternalBluetoothLyricPayload
+    payload: ExternalBluetoothLyricPayload,
+    forceSendLyrics: Boolean = false
 ): Boolean {
-    return audioDeviceType != null &&
-        isBluetoothOutputType(audioDeviceType) &&
-        (!payload.lyric.isNullOrBlank() || !payload.translation.isNullOrBlank())
+    val hasLyricPayload = !payload.lyric.isNullOrBlank() || !payload.translation.isNullOrBlank()
+    return hasLyricPayload &&
+        (forceSendLyrics || (audioDeviceType != null && isBluetoothOutputType(audioDeviceType)))
 }
 
 internal fun resolveExternalBluetoothMetadataText(

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
@@ -2251,7 +2251,8 @@ class AudioPlayerService : Service() {
         val lyricPayload = PlayerManager.externalBluetoothLyricPayloadFlow.value
         val useBluetoothLyrics = shouldUseExternalBluetoothLyrics(
             audioDeviceType = PlayerManager.currentAudioDeviceFlow.value?.type,
-            payload = lyricPayload
+            payload = lyricPayload,
+            forceSendLyrics = PlayerManager.dynamicIslandLyricsEnabled
         )
         val metadataText = resolveExternalBluetoothMetadataText(
             normalTitle = normalTitle,

--- a/app/src/main/java/moe/ouom/neriplayer/data/settings/AutoSettingsSchema.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/settings/AutoSettingsSchema.kt
@@ -210,6 +210,7 @@ object AutoSettingsSchema {
             descriptionRes = R.string.settings_bili_skip_segment_prompt_desc,
             icon = AutoSettingIcon.Info
         )
+
     }
 
     /*
@@ -1189,7 +1190,7 @@ object AutoSettingsSchema {
         @AutoSetting(
             key = "external_bluetooth_lyrics_enabled",
             type = SettingValueType.Boolean,
-            defaultBoolean = false,
+            defaultBoolean = true,
             order = 26,
             ui = SettingUiType.Switch
         )
@@ -1202,7 +1203,7 @@ object AutoSettingsSchema {
         @AutoSetting(
             key = "external_bluetooth_translation_enabled",
             type = SettingValueType.Boolean,
-            defaultBoolean = false,
+            defaultBoolean = true,
             order = 27,
             ui = SettingUiType.Switch
         )
@@ -1210,6 +1211,21 @@ object AutoSettingsSchema {
             titleRes = R.string.settings_external_bluetooth_translation_enabled,
             descriptionRes = R.string.settings_external_bluetooth_translation_enabled_desc,
             icon = AutoSettingIcon.Translate
+        )
+
+        @AutoSetting(
+            key = "dynamic_island_lyrics_enabled",
+            type = SettingValueType.Boolean,
+            defaultBoolean = true,
+            order = 28,
+            ui = SettingUiType.Custom
+        )
+        val dynamicIslandLyricsEnabled = autoSwitchSetting(
+            key = "dynamic_island_lyrics_enabled",
+            defaultValue = true,
+            titleRes = R.string.settings_dynamic_island_lyrics_enabled,
+            descriptionRes = R.string.settings_dynamic_island_lyrics_enabled_desc,
+            icon = AutoSettingIcon.Subtitles
         )
 
         @AutoSetting(

--- a/app/src/main/java/moe/ouom/neriplayer/data/settings/AutoSettingsSchema.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/settings/AutoSettingsSchema.kt
@@ -1225,7 +1225,7 @@ object AutoSettingsSchema {
             defaultValue = true,
             titleRes = R.string.settings_dynamic_island_lyrics_enabled,
             descriptionRes = R.string.settings_dynamic_island_lyrics_enabled_desc,
-            icon = AutoSettingIcon.Subtitles
+            icon = AutoSettingIcon.AutoAwesome
         )
 
         @AutoSetting(

--- a/app/src/main/java/moe/ouom/neriplayer/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/settings/SettingsRepository.kt
@@ -262,6 +262,9 @@ class SettingsRepository(private val context: Context) {
     val externalBluetoothTranslationEnabledFlow: Flow<Boolean> =
         autoSettingsRepository.externalBluetoothTranslationEnabledFlow
 
+    val dynamicIslandLyricsEnabledFlow: Flow<Boolean> =
+        settingFlow(AutoSettingsSchema.lyrics.dynamicIslandLyricsEnabled)
+
     val floatingLyricsPreferencesFlow: Flow<FloatingLyricsPreferences> =
         dataStoreSettingFlow { prefs ->
             val outlineWidthDp = prefs[SettingsKeys.FLOATING_LYRICS_OUTLINE_WIDTH_DP] ?: 1.6f
@@ -831,6 +834,14 @@ class SettingsRepository(private val context: Context) {
 
     suspend fun setExternalBluetoothTranslationEnabled(enabled: Boolean) {
         autoSettingsRepository.setExternalBluetoothTranslationEnabled(enabled)
+    }
+
+    suspend fun setDynamicIslandLyricsEnabled(enabled: Boolean) {
+        if (enabled) {
+            setExternalBluetoothLyricsEnabled(true)
+            setExternalBluetoothTranslationEnabled(true)
+        }
+        setSetting(AutoSettingsSchema.lyrics.dynamicIslandLyricsEnabled, enabled)
     }
 
     suspend fun setFloatingLyricsPreferences(preferences: FloatingLyricsPreferences) {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/SettingsScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/SettingsScreen.kt
@@ -1612,6 +1612,7 @@ fun SettingsScreen(
                                 onExpandedChange = {},
                                 showHeader = false,
                                 autoSettingsRepository = autoSettingsRepository,
+                                settingsRepository = AppContainer.settingsRepo,
                                 scope = scope,
                                 floatingLyricsPreferences = floatingLyricsPreferences,
                                 onFloatingLyricsPreferencesChange = onFloatingLyricsPreferencesChange,

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/DynamicIslandLyricsSetting.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/DynamicIslandLyricsSetting.kt
@@ -1,0 +1,92 @@
+package moe.ouom.neriplayer.ui.screen.tab.settings.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.res.stringResource
+import kotlinx.coroutines.launch
+import moe.ouom.neriplayer.R
+import moe.ouom.neriplayer.data.settings.AutoSettingsSchema
+import moe.ouom.neriplayer.data.settings.SettingsRepository
+import moe.ouom.neriplayer.ui.screen.tab.settings.miuix.MiuixSettingsDialog
+import moe.ouom.neriplayer.ui.screen.tab.settings.miuix.MiuixSettingsSwitch
+import moe.ouom.neriplayer.ui.screen.tab.settings.miuix.MiuixSettingsTextButton
+
+@Composable
+internal fun DynamicIslandLyricsSetting(
+    repository: SettingsRepository,
+    highlightTargetId: String? = null,
+    highlightPulse: Int = 0,
+    onHighlightFinished: (() -> Unit)? = null
+) {
+    val scope = rememberCoroutineScope()
+    val setting = AutoSettingsSchema.lyrics.dynamicIslandLyricsEnabled
+    val enabled by repository.dynamicIslandLyricsEnabledFlow.collectAsState(
+        initial = setting.defaultValue
+    )
+    val bluetoothLyricsEnabled by repository.externalBluetoothLyricsEnabledFlow.collectAsState(
+        initial = true
+    )
+    val showDependencyDialog = remember { mutableStateOf(false) }
+
+    fun requestEnabledState(nextEnabled: Boolean) {
+        if (!nextEnabled) {
+            scope.launch { repository.setDynamicIslandLyricsEnabled(false) }
+            return
+        }
+        if (bluetoothLyricsEnabled) {
+            scope.launch { repository.setDynamicIslandLyricsEnabled(true) }
+            return
+        }
+        showDependencyDialog.value = true
+    }
+
+    AutoSettingSpecListItem(
+        setting = setting,
+        trailingContent = {
+            MiuixSettingsSwitch(
+                checked = enabled,
+                onCheckedChange = { requestEnabledState(it) }
+            )
+        },
+        highlightTargetId = highlightTargetId,
+        highlightPulse = highlightPulse,
+        onHighlightFinished = onHighlightFinished,
+        onClick = { requestEnabledState(!enabled) }
+    )
+
+    if (!showDependencyDialog.value) {
+        return
+    }
+
+    MiuixSettingsDialog(
+        onDismissRequest = { showDependencyDialog.value = false },
+        title = { Text(stringResource(R.string.settings_dynamic_island_lyrics_dependency_title)) },
+        text = {
+            Text(stringResource(R.string.settings_dynamic_island_lyrics_dependency_message))
+        },
+        confirmButton = {
+            MiuixSettingsTextButton(
+                onClick = {
+                    scope.launch {
+                        repository.setDynamicIslandLyricsEnabled(true)
+                    }
+                    showDependencyDialog.value = false
+                }
+            ) {
+                Text(stringResource(R.string.action_confirm))
+            }
+        },
+        dismissButton = {
+            MiuixSettingsTextButton(
+                onClick = { showDependencyDialog.value = false }
+            ) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        }
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/SettingsLyricsOffsetSection.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/SettingsLyricsOffsetSection.kt
@@ -50,6 +50,7 @@ import moe.ouom.neriplayer.data.settings.FloatingLyricsPreferences
 import moe.ouom.neriplayer.data.settings.LYRIC_DEFAULT_OFFSET_STEP_MS
 import moe.ouom.neriplayer.data.settings.MAX_LYRIC_DEFAULT_OFFSET_MS
 import moe.ouom.neriplayer.data.settings.MIN_LYRIC_DEFAULT_OFFSET_MS
+import moe.ouom.neriplayer.data.settings.SettingsRepository
 import moe.ouom.neriplayer.data.settings.generated.AutoSettingsRepository
 import moe.ouom.neriplayer.data.settings.generated.AutoSettingsScopes
 import moe.ouom.neriplayer.data.settings.generated.AutoSettingsSwitchItems
@@ -71,6 +72,7 @@ internal fun SettingsLyricsSection(
     onExpandedChange: (Boolean) -> Unit,
     showHeader: Boolean = true,
     autoSettingsRepository: AutoSettingsRepository,
+    settingsRepository: SettingsRepository,
     scope: CoroutineScope,
     floatingLyricsPreferences: FloatingLyricsPreferences,
     onFloatingLyricsPreferencesChange: (FloatingLyricsPreferences) -> Unit,
@@ -109,9 +111,7 @@ internal fun SettingsLyricsSection(
         ) {
             if (shouldShowCard(0)) LyricsDetailCard(
                 showCard = !showHeader,
-                highlighted = false,
                 highlightPulse = highlightPulse,
-                onHighlightFinished = onHighlightFinished
             ) {
                 MiuixSettingsSectionIntro(
                     title = stringResource(R.string.settings_lyrics_floating_section),
@@ -128,9 +128,7 @@ internal fun SettingsLyricsSection(
             if (cardIndex == null) LyricsDetailGap(showHeader)
             if (shouldShowCard(1)) LyricsDetailCard(
                 showCard = !showHeader,
-                highlighted = false,
                 highlightPulse = highlightPulse,
-                onHighlightFinished = onHighlightFinished
             ) {
                 MiuixSettingsSectionIntro(
                     title = stringResource(R.string.settings_lyrics_source_section),
@@ -144,13 +142,17 @@ internal fun SettingsLyricsSection(
                     highlightPulse = highlightPulse,
                     onHighlightFinished = onHighlightFinished
                 )
+                DynamicIslandLyricsSetting(
+                    repository = settingsRepository,
+                    highlightTargetId = highlightTargetId,
+                    highlightPulse = highlightPulse,
+                    onHighlightFinished = onHighlightFinished
+                )
             }
             if (cardIndex == null) LyricsDetailGap(showHeader)
             if (shouldShowCard(2)) LyricsDetailCard(
                 showCard = !showHeader,
-                highlighted = false,
                 highlightPulse = highlightPulse,
-                onHighlightFinished = onHighlightFinished
             ) {
                 MiuixSettingsSectionIntro(
                     title = stringResource(R.string.settings_lyrics_offset_section),
@@ -185,16 +187,14 @@ internal fun SettingsLyricsSection(
 @Composable
 private fun LyricsDetailCard(
     showCard: Boolean,
-    highlighted: Boolean = false,
     highlightPulse: Int = 0,
-    onHighlightFinished: (() -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
     if (showCard) {
         MiuixSettingsSectionCard(
-            highlighted = highlighted,
+            highlighted = false,
             highlightPulse = highlightPulse,
-            onHighlightFinished = if (highlighted) onHighlightFinished else null,
+            onHighlightFinished = null,
             content = content
         )
     } else {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/page/SettingsSearchIndex.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/page/SettingsSearchIndex.kt
@@ -414,7 +414,7 @@ internal fun manualSettingsSearchEntries(context: Context): List<SettingsSearchE
                 "english",
                 "chinese"
             ),
-            order = SettingsPage.General.ordinal * 100 + 4
+            order = 4
         ),
         entry(
             page = SettingsPage.General,
@@ -432,7 +432,7 @@ internal fun manualSettingsSearchEntries(context: Context): List<SettingsSearchE
                 "gjh",
                 "qiehuanpingtai"
             ),
-            order = SettingsPage.General.ordinal * 100 + 90
+            order = 90
         ),
         entry(
             page = SettingsPage.Accounts,
@@ -842,6 +842,13 @@ private val SettingSearchAliases = mapOf(
     "status_bar_lyrics_enabled" to listOf("status bar", "zhuangtailan", "lyric"),
     "floating_lyrics_enabled" to listOf("floating", "desktop lyrics", "xuanfu"),
     "external_bluetooth_lyrics_enabled" to listOf("bluetooth", "car", "lyric", "lanyageci", "bt"),
+    "dynamic_island_lyrics_enabled" to listOf(
+        "灵动岛",
+        "dynamic island",
+        "live activity",
+        "always send",
+        "bluetooth lyrics"
+    ),
     "cloud_music_lyric_default_offset_ms" to listOf("netease lyrics offset", "wy geci pianyi"),
     "qq_music_lyric_default_offset_ms" to listOf("qq lyrics offset", "qq geci pianyi"),
     "bypass_proxy" to listOf("proxy", "vpn", "direct", "daili"),

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1513,6 +1513,10 @@
     <string name="settings_external_bluetooth_lyrics_enabled_desc">When a Bluetooth device is connected, send the current original lyric to its title field</string>
     <string name="settings_external_bluetooth_translation_enabled">Bluetooth Translated Lyrics</string>
     <string name="settings_external_bluetooth_translation_enabled_desc">Send the current translation independently; with original lyrics enabled, title and artist fields carry separate lines</string>
+    <string name="settings_dynamic_island_lyrics_enabled">Dynamic Island Lyrics</string>
+    <string name="settings_dynamic_island_lyrics_enabled_desc">When enabled, Bluetooth lyric metadata is uploaded even without a connected Bluetooth device</string>
+    <string name="settings_dynamic_island_lyrics_dependency_title">Bluetooth lyrics required</string>
+    <string name="settings_dynamic_island_lyrics_dependency_message">Dynamic Island Lyrics requires Bluetooth original lyrics. Turn them on automatically?</string>
     <string name="settings_lyrics_offset">Lyrics Settings</string>
     <string name="settings_lyrics_offset_expand">External lyrics, Lyricon integration, and default offsets</string>
     <string name="settings_lyrics_offset_cloud_music">Cloud Music default offset</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1513,6 +1513,10 @@
     <string name="settings_external_bluetooth_lyrics_enabled_desc">连接蓝牙设备时，将当前原文歌词发送到外接设备的标题区域</string>
     <string name="settings_external_bluetooth_translation_enabled">蓝牙外接设备翻译歌词</string>
     <string name="settings_external_bluetooth_translation_enabled_desc">独立发送当前翻译歌词；与原文同时开启时分别显示在标题和艺术家区域</string>
+    <string name="settings_dynamic_island_lyrics_enabled">灵动岛歌词</string>
+    <string name="settings_dynamic_island_lyrics_enabled_desc">开启后即使没有连接蓝牙设备，也会上传蓝牙歌词元数据</string>
+    <string name="settings_dynamic_island_lyrics_dependency_title">需要开启蓝牙歌词</string>
+    <string name="settings_dynamic_island_lyrics_dependency_message">开启灵动岛歌词需要先打开蓝牙外接设备原文歌词，是否自动开启？</string>
     <string name="settings_lyrics_offset">歌词设置</string>
     <string name="settings_lyrics_offset_expand">外接歌词、词幕适配与默认偏移</string>
     <string name="settings_lyrics_offset_cloud_music">网易云默认歌词偏移</string>

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/lyrics/PlayerManagerExternalBluetoothLyricsTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/lyrics/PlayerManagerExternalBluetoothLyricsTest.kt
@@ -1,0 +1,55 @@
+package moe.ouom.neriplayer.core.player.lyrics
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlayerManagerExternalBluetoothLyricsTest {
+    @Test
+    fun dynamicIslandForcesExternalTranslatedLyrics() {
+        assertTrue(
+            shouldProvideExternalTranslatedLyricLine(
+                externalBluetoothTranslationEnabled = false,
+                floatingLyricsEnabled = false,
+                floatingLyricsShowTranslation = false,
+                dynamicIslandLyricsEnabled = true
+            )
+        )
+    }
+
+    @Test
+    fun externalTranslatedLyricsStillFollowNormalAndFloatingRules() {
+        assertTrue(
+            shouldProvideExternalTranslatedLyricLine(
+                externalBluetoothTranslationEnabled = true,
+                floatingLyricsEnabled = false,
+                floatingLyricsShowTranslation = false,
+                dynamicIslandLyricsEnabled = false
+            )
+        )
+        assertTrue(
+            shouldProvideExternalTranslatedLyricLine(
+                externalBluetoothTranslationEnabled = false,
+                floatingLyricsEnabled = true,
+                floatingLyricsShowTranslation = true,
+                dynamicIslandLyricsEnabled = false
+            )
+        )
+        assertFalse(
+            shouldProvideExternalTranslatedLyricLine(
+                externalBluetoothTranslationEnabled = false,
+                floatingLyricsEnabled = true,
+                floatingLyricsShowTranslation = false,
+                dynamicIslandLyricsEnabled = false
+            )
+        )
+        assertFalse(
+            shouldProvideExternalTranslatedLyricLine(
+                externalBluetoothTranslationEnabled = false,
+                floatingLyricsEnabled = false,
+                floatingLyricsShowTranslation = false,
+                dynamicIslandLyricsEnabled = false
+            )
+        )
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/metadata/ExternalBluetoothLyricsTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/metadata/ExternalBluetoothLyricsTest.kt
@@ -205,11 +205,30 @@ class ExternalBluetoothLyricsTest {
     }
 
     @Test
-    fun `shouldUseExternalBluetoothLyrics requires bluetooth device and lyric payload`() {
+    fun `shouldUseExternalBluetoothLyrics requires bluetooth output unless forced`() {
         assertTrue(
             shouldUseExternalBluetoothLyrics(
                 audioDeviceType = AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
                 payload = ExternalBluetoothLyricPayload(lyric = "current line")
+            )
+        )
+        assertFalse(
+            shouldUseExternalBluetoothLyrics(
+                audioDeviceType = AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
+                payload = ExternalBluetoothLyricPayload(lyric = "current line")
+            )
+        )
+        assertFalse(
+            shouldUseExternalBluetoothLyrics(
+                audioDeviceType = null,
+                payload = ExternalBluetoothLyricPayload(translation = "translated line")
+            )
+        )
+        assertTrue(
+            shouldUseExternalBluetoothLyrics(
+                audioDeviceType = null,
+                payload = ExternalBluetoothLyricPayload(lyric = "current line"),
+                forceSendLyrics = true
             )
         )
         assertFalse(
@@ -220,14 +239,9 @@ class ExternalBluetoothLyricsTest {
         )
         assertFalse(
             shouldUseExternalBluetoothLyrics(
-                audioDeviceType = AudioDeviceInfo.TYPE_BUILTIN_SPEAKER,
-                payload = ExternalBluetoothLyricPayload(translation = "translated line")
-            )
-        )
-        assertFalse(
-            shouldUseExternalBluetoothLyrics(
                 audioDeviceType = null,
-                payload = ExternalBluetoothLyricPayload(lyric = "current line")
+                payload = ExternalBluetoothLyricPayload(),
+                forceSendLyrics = true
             )
         )
     }

--- a/app/src/test/java/moe/ouom/neriplayer/data/settings/AutoSettingsGeneratedTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/settings/AutoSettingsGeneratedTest.kt
@@ -1,8 +1,12 @@
 package moe.ouom.neriplayer.data.settings
 
+import android.content.Context
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import moe.ouom.neriplayer.R
 import moe.ouom.neriplayer.data.settings.generated.AutoSettingsBackupKeys
 import moe.ouom.neriplayer.data.settings.generated.AutoSettingsMetadata
+import moe.ouom.neriplayer.data.settings.generated.AutoSettingsRepository
 import moe.ouom.neriplayer.data.settings.generated.AutoSettingsScopes
 import moe.ouom.neriplayer.data.settings.generated.AutoSettingsSections
 import moe.ouom.neriplayer.ksp.annotations.AutoSettingIcon
@@ -12,6 +16,9 @@ import moe.ouom.neriplayer.ksp.annotations.SettingValueType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 class AutoSettingsGeneratedTest {
     @Test
@@ -157,6 +164,10 @@ class AutoSettingsGeneratedTest {
         assertTrue(
             "external bluetooth translation switch should be exportable",
             "external_bluetooth_translation_enabled" in booleanKeyNames
+        )
+        assertTrue(
+            "dynamic island lyrics switch should be exportable",
+            "dynamic_island_lyrics_enabled" in booleanKeyNames
         )
     }
 
@@ -309,6 +320,13 @@ class AutoSettingsGeneratedTest {
             }
         )
         assertTrue(
+            "lyrics metadata should include dynamic island lyrics switch",
+            lyricsSettings.any {
+                it.keyName == "dynamic_island_lyrics_enabled" &&
+                    it.ui == SettingUiType.Custom
+            }
+        )
+        assertTrue(
             "lyrics metadata should include source offset sliders",
             lyricsSettings.any { it.keyName == "cloud_music_lyric_default_offset_ms" && it.ui == SettingUiType.Custom }
         )
@@ -377,6 +395,19 @@ class AutoSettingsGeneratedTest {
         assertEquals(SettingUiType.Switch, metadata?.ui)
         assertEquals(AutoSettingsSections.general, metadata?.section)
         assertEquals(AutoSettingIcon.AutoAwesome, metadata?.icon)
+    }
+
+    @Test
+    fun dynamicIslandLyricsDefaultsToEnabledInLyricsSettings() {
+        val setting = AutoSettingsSchema.lyrics.dynamicIslandLyricsEnabled
+        val metadata = AutoSettingsMetadata.setting("dynamic_island_lyrics_enabled")
+
+        assertEquals("dynamic_island_lyrics_enabled", setting.preferencesKey.name)
+        assertEquals(true, setting.defaultValue)
+        assertEquals(SettingValueType.Boolean, metadata?.valueType)
+        assertEquals(SettingUiType.Custom, metadata?.ui)
+        assertEquals(AutoSettingsSections.lyrics, metadata?.section)
+        assertEquals(AutoSettingIcon.Subtitles, metadata?.icon)
     }
 
     @Test
@@ -576,6 +607,10 @@ class AutoSettingsGeneratedTest {
             AutoSettingsSchema.lyrics.externalBluetoothTranslationEnabled.icon
         )
         assertEquals(
+            AutoSettingIcon.Subtitles,
+            AutoSettingsSchema.lyrics.dynamicIslandLyricsEnabled.icon
+        )
+        assertEquals(
             AutoSettingIcon.Error,
             AutoSettingsSchema.backup.silentGitHubSyncFailure.icon
         )
@@ -599,5 +634,39 @@ class AutoSettingsGeneratedTest {
 
         assertEquals("youtube_enabled", setting.key)
         assertEquals(true, setting.defaultValue)
+    }
+
+    @Test
+    fun externalBluetoothLyricsSwitchesDefaultToEnabled() {
+        val filesDir = File.createTempFile("neriplayer-settings", "").apply {
+            delete()
+            mkdirs()
+            deleteOnExit()
+        }
+        val context = mock(Context::class.java)
+        `when`(context.filesDir).thenReturn(filesDir)
+        `when`(context.applicationContext).thenReturn(context)
+        val repository = AutoSettingsRepository(context)
+
+        runBlocking {
+            assertTrue(repository.externalBluetoothLyricsEnabledFlow.first())
+            assertTrue(repository.externalBluetoothTranslationEnabledFlow.first())
+        }
+        assertEquals(
+            SettingUiType.Switch,
+            AutoSettingsMetadata.setting("external_bluetooth_lyrics_enabled")?.ui
+        )
+        assertEquals(
+            SettingUiType.Switch,
+            AutoSettingsMetadata.setting("external_bluetooth_translation_enabled")?.ui
+        )
+        assertEquals(
+            AutoSettingsSections.lyrics,
+            AutoSettingsMetadata.setting("external_bluetooth_lyrics_enabled")?.section
+        )
+        assertEquals(
+            AutoSettingsSections.lyrics,
+            AutoSettingsMetadata.setting("external_bluetooth_translation_enabled")?.section
+        )
     }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/data/settings/AutoSettingsGeneratedTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/settings/AutoSettingsGeneratedTest.kt
@@ -14,6 +14,7 @@ import moe.ouom.neriplayer.ksp.annotations.SettingAccessMode
 import moe.ouom.neriplayer.ksp.annotations.SettingUiType
 import moe.ouom.neriplayer.ksp.annotations.SettingValueType
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -407,7 +408,11 @@ class AutoSettingsGeneratedTest {
         assertEquals(SettingValueType.Boolean, metadata?.valueType)
         assertEquals(SettingUiType.Custom, metadata?.ui)
         assertEquals(AutoSettingsSections.lyrics, metadata?.section)
-        assertEquals(AutoSettingIcon.Subtitles, metadata?.icon)
+        assertEquals(AutoSettingIcon.AutoAwesome, metadata?.icon)
+        assertNotEquals(
+            AutoSettingsSchema.lyrics.amllLyricsEnabled.icon,
+            metadata?.icon
+        )
     }
 
     @Test
@@ -607,7 +612,7 @@ class AutoSettingsGeneratedTest {
             AutoSettingsSchema.lyrics.externalBluetoothTranslationEnabled.icon
         )
         assertEquals(
-            AutoSettingIcon.Subtitles,
+            AutoSettingIcon.AutoAwesome,
             AutoSettingsSchema.lyrics.dynamicIslandLyricsEnabled.icon
         )
         assertEquals(

--- a/app/src/test/java/moe/ouom/neriplayer/data/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/settings/SettingsRepositoryTest.kt
@@ -1,0 +1,35 @@
+package moe.ouom.neriplayer.data.settings
+
+import android.content.Context
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.io.File
+
+class SettingsRepositoryTest {
+    @Test
+    fun enablingDynamicIslandLyricsTurnsOnBluetoothLyricsAndTranslation() {
+        val filesDir = File.createTempFile("neriplayer-settings", "").apply {
+            delete()
+            mkdirs()
+            deleteOnExit()
+        }
+        val context = mock(Context::class.java)
+        `when`(context.filesDir).thenReturn(filesDir)
+        `when`(context.applicationContext).thenReturn(context)
+        val repository = SettingsRepository(context)
+
+        runBlocking {
+            repository.setExternalBluetoothLyricsEnabled(false)
+            repository.setExternalBluetoothTranslationEnabled(false)
+            repository.setDynamicIslandLyricsEnabled(true)
+
+            assertTrue(repository.externalBluetoothLyricsEnabledFlow.first())
+            assertTrue(repository.externalBluetoothTranslationEnabledFlow.first())
+            assertTrue(repository.dynamicIslandLyricsEnabledFlow.first())
+        }
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/ui/screen/tab/settings/page/SettingsPageTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/screen/tab/settings/page/SettingsPageTest.kt
@@ -9,6 +9,7 @@ import moe.ouom.neriplayer.util.search.SearchTextMatcher
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito
 import org.mockito.stubbing.Answer
@@ -94,6 +95,17 @@ class SettingsPageTest {
         assertEquals(AutoSettingsSections.theme, dynamicColor.section)
         assertEquals(SettingsPage.Theme, dynamicColor.settingsPage())
         assertEquals("setting:dynamic_color", dynamicColor.searchTargetId())
+    }
+
+    @Test
+    fun dynamicIslandLyricsSettingOpensLyricsPage() {
+        val dynamicIslandLyrics = AutoSettingsMetadata.settings.first {
+            it.keyName == "dynamic_island_lyrics_enabled"
+        }
+
+        assertEquals(AutoSettingsSections.lyrics, dynamicIslandLyrics.section)
+        assertEquals(SettingsPage.Lyrics, dynamicIslandLyrics.settingsPage())
+        assertEquals("setting:dynamic_island_lyrics_enabled", dynamicIslandLyrics.searchTargetId())
     }
 
     @Test
@@ -466,6 +478,17 @@ class SettingsPageTest {
     }
 
     @Test
+    fun dynamicIslandLyricsSettingIsSearchable() {
+        val entries = buildSettingsSearchEntries(settingsStringContext())
+
+        assertTrue(
+            searchSettingsEntries(entries, "dynamic island").any {
+                it.targetId == "setting:dynamic_island_lyrics_enabled"
+            }
+        )
+    }
+
+    @Test
     fun dependentSettingsHighlightTheirPrimaryControls() {
         fun targetId(keyName: String): String {
             return AutoSettingsMetadata.settings.first { it.keyName == keyName }.searchTargetId()
@@ -680,7 +703,9 @@ class SettingsPageTest {
             R.string.settings_export_config to "导出配置文件",
             R.string.settings_import_config to "导入配置文件",
             R.string.settings_export_config_desc to "导出设置、登录信息和同步配置",
-            R.string.settings_import_config_desc to "从配置文件恢复设置、登录信息和同步配置"
+            R.string.settings_import_config_desc to "从配置文件恢复设置、登录信息和同步配置",
+            R.string.settings_dynamic_island_lyrics_enabled to "灵动岛歌词",
+            R.string.settings_dynamic_island_lyrics_enabled_desc to "即使没有连接蓝牙设备，也会上传蓝牙歌词元数据"
         )
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 用户可见变化

- 新增“灵动岛歌词”设置，默认启用。
- 启用“灵动岛歌词”时，应用会强制发送外部蓝牙歌词和翻译。
- 启用“灵动岛歌词”前，应用会检查外部蓝牙歌词依赖。依赖未启用时，应用会请求确认，并在确认后自动启用依赖。
- 外部蓝牙歌词和翻译默认启用。
- 设置搜索支持通过“灵动岛歌词”、Live Activity、“始终发送”和蓝牙歌词等关键词查找该设置。

## 兼容性影响

- 启用“灵动岛歌词”时，即使没有蓝牙设备，应用也会发送外部蓝牙歌词数据。
- 未启用“灵动岛歌词”时，现有蓝牙歌词发送规则保持不变。

## 测试

- 新增“灵动岛歌词”强制发送外部翻译歌词的测试。
- 更新外部蓝牙歌词发送条件测试。
- 新增设置默认值、依赖联动、持久化、元数据和搜索映射测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->