### PR TITLE
feat(storage): complete Room-backed user data migration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -216,6 +216,10 @@ tasks.withType<Test>().configureEach {
     )
 }
 
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+}
+
 androidComponents {
     onVariants(selector().all()) { variant ->
         if (variant.buildType == "debug") return@onVariants
@@ -270,9 +274,13 @@ dependencies {
     androidTestImplementation(libs.compose.ui.test.junit4)
     androidTestImplementation(libs.kotlinx.coroutines.android)
     androidTestImplementation(libs.kotlinx.coroutines.test)
+    androidTestImplementation(libs.androidx.room.testing)
     implementation(libs.androidx.animation)
     implementation(libs.accompanist.navigation.animation)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
 
     implementation(libs.dec)
     implementation(libs.newpipe.extractor)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -123,6 +123,12 @@ android {
         unitTests.isReturnDefaultValues = true
     }
 
+    sourceSets {
+        getByName("androidTest") {
+            assets.directories.add("schemas")
+        }
+    }
+
     packaging {
         dex {
             // minSdk 28 后 AGP 默认会把 dex 直接存储，恢复 legacy packaging 可显著降低 APK 体积

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/1.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/1.json
@@ -1,0 +1,617 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "6d1a4b4b2388f9ce13f4454de3b354f9",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6d1a4b4b2388f9ce13f4454de3b354f9')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/10.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/10.json
@@ -1,0 +1,2556 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "624136f2acf2bcac334814a4887decbd",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          },
+          {
+            "name": "index_playback_stat_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`day_start_at`, `identity_key`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC, `identity_key` ASC)"
+          },
+          {
+            "name": "index_playback_stat_bucket_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_counter_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_counter_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_daily_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`, `identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`day_start_at`, `identity_key`) REFERENCES `playback_stat_bucket`(`day_start_at`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_daily_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_daily_counter_scope` ON `${TABLE_NAME}` (`day_start_at`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat_bucket",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "day_start_at",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `track_count` INTEGER NOT NULL, `browse_id` TEXT, `remote_playlist_id` TEXT, `subtitle` TEXT, `added_time` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `source`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remotePlaylistId",
+            "columnName": "remote_playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedTime",
+            "columnName": "added_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_sort",
+            "unique": false,
+            "columnNames": [
+              "sort_order",
+              "modified_at"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_sort` ON `${TABLE_NAME}` (`sort_order` DESC, `modified_at` DESC)"
+          },
+          {
+            "name": "index_favorite_playlist_visibility",
+            "unique": false,
+            "columnNames": [
+              "is_deleted",
+              "sort_order"
+            ],
+            "orders": [
+              "ASC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_visibility` ON `${TABLE_NAME}` (`is_deleted` ASC, `sort_order` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `song_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `source`, `display_position`), FOREIGN KEY(`playlist_id`, `source`) REFERENCES `favorite_playlist`(`playlist_id`, `source`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songPayloadJson",
+            "columnName": "song_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source",
+            "display_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_song_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_song_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `source` ASC, `display_position` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "favorite_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "source"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "source"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "traffic_stats_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `wifi_bytes` INTEGER NOT NULL, `mobile_bytes` INTEGER NOT NULL, `roaming_bytes` INTEGER NOT NULL, `playback_network_bytes` INTEGER NOT NULL, `download_network_bytes` INTEGER NOT NULL, `cache_hit_bytes` INTEGER NOT NULL, `request_count` INTEGER NOT NULL, `cache_hit_count` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`))",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wifiBytes",
+            "columnName": "wifi_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mobileBytes",
+            "columnName": "mobile_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roamingBytes",
+            "columnName": "roaming_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackNetworkBytes",
+            "columnName": "playback_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadNetworkBytes",
+            "columnName": "download_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitBytes",
+            "columnName": "cache_hit_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestCount",
+            "columnName": "request_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitCount",
+            "columnName": "cache_hit_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traffic_stats_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traffic_stats_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `current_index` INTEGER NOT NULL, `media_url` TEXT, `position_ms` INTEGER NOT NULL, `should_resume_playback` INTEGER NOT NULL, `repeat_mode` INTEGER, `shuffle_enabled` INTEGER, `shuffle_restore_index` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "current_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUrl",
+            "columnName": "media_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldResumePlayback",
+            "columnName": "should_resume_playback",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeat_mode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffle_enabled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleRestoreIndex",
+            "columnName": "shuffle_restore_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_queue_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`queue_id` TEXT NOT NULL, `position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `stream_url` TEXT, PRIMARY KEY(`queue_id`, `position`))",
+        "fields": [
+          {
+            "fieldPath": "queueId",
+            "columnName": "queue_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "queue_id",
+            "position"
+          ]
+        }
+      },
+      {
+        "tableName": "bili_video_skip_rule",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`))",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bili_video_skip_rule_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bili_video_skip_rule_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_interval",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `position` INTEGER NOT NULL, `start_ms` INTEGER NOT NULL, `end_ms` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`, `position`), FOREIGN KEY(`bvid`, `cid`) REFERENCES `bili_video_skip_rule`(`bvid`, `cid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startMs",
+            "columnName": "start_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endMs",
+            "columnName": "end_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid",
+            "position"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "bili_video_skip_rule",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bvid",
+              "cid"
+            ],
+            "referencedColumns": [
+              "bvid",
+              "cid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_draft",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`target_key` TEXT NOT NULL, `bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `start_text` TEXT NOT NULL, `end_text` TEXT NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`target_key`))",
+        "fields": [
+          {
+            "fieldPath": "targetKey",
+            "columnName": "target_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startText",
+            "columnName": "start_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endText",
+            "columnName": "end_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "target_key"
+          ]
+        }
+      },
+      {
+        "tableName": "download_pending_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `queue_order` INTEGER NOT NULL, `queued_at_ms` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `source_stable_key` TEXT, `stream_url` TEXT, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queueOrder",
+            "columnName": "queue_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAtMs",
+            "columnName": "queued_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_pending_queue_order",
+            "unique": false,
+            "columnNames": [
+              "queue_order"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_pending_queue_order` ON `${TABLE_NAME}` (`queue_order` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_cancelled_key",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `cancelled_at_ms` INTEGER NOT NULL, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cancelledAtMs",
+            "columnName": "cancelled_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '624136f2acf2bcac334814a4887decbd')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/11.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/11.json
@@ -1,0 +1,2792 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "9aa0543b6c84f08259772ceb86761d8f",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          },
+          {
+            "name": "index_playback_stat_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`day_start_at`, `identity_key`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC, `identity_key` ASC)"
+          },
+          {
+            "name": "index_playback_stat_bucket_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_counter_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_counter_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_daily_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`, `identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`day_start_at`, `identity_key`) REFERENCES `playback_stat_bucket`(`day_start_at`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_daily_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_daily_counter_scope` ON `${TABLE_NAME}` (`day_start_at`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat_bucket",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "day_start_at",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `track_count` INTEGER NOT NULL, `browse_id` TEXT, `remote_playlist_id` TEXT, `subtitle` TEXT, `added_time` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `source`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remotePlaylistId",
+            "columnName": "remote_playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedTime",
+            "columnName": "added_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_sort",
+            "unique": false,
+            "columnNames": [
+              "sort_order",
+              "modified_at"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_sort` ON `${TABLE_NAME}` (`sort_order` DESC, `modified_at` DESC)"
+          },
+          {
+            "name": "index_favorite_playlist_visibility",
+            "unique": false,
+            "columnNames": [
+              "is_deleted",
+              "sort_order"
+            ],
+            "orders": [
+              "ASC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_visibility` ON `${TABLE_NAME}` (`is_deleted` ASC, `sort_order` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `song_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `source`, `display_position`), FOREIGN KEY(`playlist_id`, `source`) REFERENCES `favorite_playlist`(`playlist_id`, `source`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songPayloadJson",
+            "columnName": "song_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source",
+            "display_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_song_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_song_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `source` ASC, `display_position` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "favorite_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "source"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "source"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "traffic_stats_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `wifi_bytes` INTEGER NOT NULL, `mobile_bytes` INTEGER NOT NULL, `roaming_bytes` INTEGER NOT NULL, `playback_network_bytes` INTEGER NOT NULL, `download_network_bytes` INTEGER NOT NULL, `cache_hit_bytes` INTEGER NOT NULL, `request_count` INTEGER NOT NULL, `cache_hit_count` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`))",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wifiBytes",
+            "columnName": "wifi_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mobileBytes",
+            "columnName": "mobile_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roamingBytes",
+            "columnName": "roaming_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackNetworkBytes",
+            "columnName": "playback_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadNetworkBytes",
+            "columnName": "download_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitBytes",
+            "columnName": "cache_hit_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestCount",
+            "columnName": "request_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitCount",
+            "columnName": "cache_hit_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traffic_stats_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traffic_stats_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `current_index` INTEGER NOT NULL, `media_url` TEXT, `position_ms` INTEGER NOT NULL, `should_resume_playback` INTEGER NOT NULL, `repeat_mode` INTEGER, `shuffle_enabled` INTEGER, `shuffle_restore_index` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "current_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUrl",
+            "columnName": "media_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldResumePlayback",
+            "columnName": "should_resume_playback",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeat_mode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffle_enabled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleRestoreIndex",
+            "columnName": "shuffle_restore_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_queue_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`queue_id` TEXT NOT NULL, `position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `stream_url` TEXT, PRIMARY KEY(`queue_id`, `position`))",
+        "fields": [
+          {
+            "fieldPath": "queueId",
+            "columnName": "queue_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "queue_id",
+            "position"
+          ]
+        }
+      },
+      {
+        "tableName": "bili_video_skip_rule",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`))",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bili_video_skip_rule_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bili_video_skip_rule_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_interval",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `position` INTEGER NOT NULL, `start_ms` INTEGER NOT NULL, `end_ms` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`, `position`), FOREIGN KEY(`bvid`, `cid`) REFERENCES `bili_video_skip_rule`(`bvid`, `cid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startMs",
+            "columnName": "start_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endMs",
+            "columnName": "end_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid",
+            "position"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "bili_video_skip_rule",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bvid",
+              "cid"
+            ],
+            "referencedColumns": [
+              "bvid",
+              "cid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_draft",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`target_key` TEXT NOT NULL, `bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `start_text` TEXT NOT NULL, `end_text` TEXT NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`target_key`))",
+        "fields": [
+          {
+            "fieldPath": "targetKey",
+            "columnName": "target_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startText",
+            "columnName": "start_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endText",
+            "columnName": "end_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "target_key"
+          ]
+        }
+      },
+      {
+        "tableName": "download_pending_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `queue_order` INTEGER NOT NULL, `queued_at_ms` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `source_stable_key` TEXT, `stream_url` TEXT, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queueOrder",
+            "columnName": "queue_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAtMs",
+            "columnName": "queued_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_pending_queue_order",
+            "unique": false,
+            "columnNames": [
+              "queue_order"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_pending_queue_order` ON `${TABLE_NAME}` (`queue_order` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_cancelled_key",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `cancelled_at_ms` INTEGER NOT NULL, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cancelledAtMs",
+            "columnName": "cancelled_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        }
+      },
+      {
+        "tableName": "downloaded_song_catalog",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`catalog_key` TEXT NOT NULL, `root_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `file_path` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `download_time` INTEGER NOT NULL, `cover_path` TEXT, `cover_url` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `media_uri` TEXT, `duration_ms` INTEGER NOT NULL, `stable_key` TEXT, `source_identity_album` TEXT, `source_media_uri` TEXT, `source_channel_id` TEXT, `source_audio_id` TEXT, `source_sub_audio_id` TEXT, `source_playlist_context_id` TEXT, PRIMARY KEY(`catalog_key`))",
+        "fields": [
+          {
+            "fieldPath": "catalogKey",
+            "columnName": "catalog_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceIdentityAlbum",
+            "columnName": "source_identity_album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceMediaUri",
+            "columnName": "source_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceChannelId",
+            "columnName": "source_channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceAudioId",
+            "columnName": "source_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceSubAudioId",
+            "columnName": "source_sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcePlaylistContextId",
+            "columnName": "source_playlist_context_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "catalog_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloaded_song_catalog_root_position",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_root_position` ON `${TABLE_NAME}` (`root_key` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_file_path",
+            "unique": false,
+            "columnNames": [
+              "file_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_file_path` ON `${TABLE_NAME}` (`file_path`)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_stable_key",
+            "unique": false,
+            "columnNames": [
+              "stable_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_stable_key` ON `${TABLE_NAME}` (`stable_key`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '9aa0543b6c84f08259772ceb86761d8f')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/12.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/12.json
@@ -1,0 +1,2835 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "c58f330baa0813870f17ced0de9551da",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          },
+          {
+            "name": "index_playback_stat_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`day_start_at`, `identity_key`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC, `identity_key` ASC)"
+          },
+          {
+            "name": "index_playback_stat_bucket_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_counter_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_counter_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_daily_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`, `identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`day_start_at`, `identity_key`) REFERENCES `playback_stat_bucket`(`day_start_at`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_daily_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_daily_counter_scope` ON `${TABLE_NAME}` (`day_start_at`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat_bucket",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "day_start_at",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `track_count` INTEGER NOT NULL, `browse_id` TEXT, `remote_playlist_id` TEXT, `subtitle` TEXT, `added_time` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `source`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remotePlaylistId",
+            "columnName": "remote_playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedTime",
+            "columnName": "added_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_sort",
+            "unique": false,
+            "columnNames": [
+              "sort_order",
+              "modified_at"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_sort` ON `${TABLE_NAME}` (`sort_order` DESC, `modified_at` DESC)"
+          },
+          {
+            "name": "index_favorite_playlist_visibility",
+            "unique": false,
+            "columnNames": [
+              "is_deleted",
+              "sort_order"
+            ],
+            "orders": [
+              "ASC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_visibility` ON `${TABLE_NAME}` (`is_deleted` ASC, `sort_order` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `song_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `source`, `display_position`), FOREIGN KEY(`playlist_id`, `source`) REFERENCES `favorite_playlist`(`playlist_id`, `source`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songPayloadJson",
+            "columnName": "song_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source",
+            "display_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_song_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_song_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `source` ASC, `display_position` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "favorite_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "source"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "source"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "traffic_stats_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `wifi_bytes` INTEGER NOT NULL, `mobile_bytes` INTEGER NOT NULL, `roaming_bytes` INTEGER NOT NULL, `playback_network_bytes` INTEGER NOT NULL, `download_network_bytes` INTEGER NOT NULL, `cache_hit_bytes` INTEGER NOT NULL, `request_count` INTEGER NOT NULL, `cache_hit_count` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`))",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wifiBytes",
+            "columnName": "wifi_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mobileBytes",
+            "columnName": "mobile_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roamingBytes",
+            "columnName": "roaming_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackNetworkBytes",
+            "columnName": "playback_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadNetworkBytes",
+            "columnName": "download_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitBytes",
+            "columnName": "cache_hit_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestCount",
+            "columnName": "request_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitCount",
+            "columnName": "cache_hit_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traffic_stats_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traffic_stats_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `current_index` INTEGER NOT NULL, `media_url` TEXT, `position_ms` INTEGER NOT NULL, `should_resume_playback` INTEGER NOT NULL, `repeat_mode` INTEGER, `shuffle_enabled` INTEGER, `shuffle_restore_index` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "current_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUrl",
+            "columnName": "media_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldResumePlayback",
+            "columnName": "should_resume_playback",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeat_mode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffle_enabled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleRestoreIndex",
+            "columnName": "shuffle_restore_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_queue_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`queue_id` TEXT NOT NULL, `position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `stream_url` TEXT, PRIMARY KEY(`queue_id`, `position`))",
+        "fields": [
+          {
+            "fieldPath": "queueId",
+            "columnName": "queue_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "queue_id",
+            "position"
+          ]
+        }
+      },
+      {
+        "tableName": "bili_video_skip_rule",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`))",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bili_video_skip_rule_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bili_video_skip_rule_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_interval",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `position` INTEGER NOT NULL, `start_ms` INTEGER NOT NULL, `end_ms` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`, `position`), FOREIGN KEY(`bvid`, `cid`) REFERENCES `bili_video_skip_rule`(`bvid`, `cid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startMs",
+            "columnName": "start_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endMs",
+            "columnName": "end_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid",
+            "position"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "bili_video_skip_rule",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bvid",
+              "cid"
+            ],
+            "referencedColumns": [
+              "bvid",
+              "cid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_draft",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`target_key` TEXT NOT NULL, `bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `start_text` TEXT NOT NULL, `end_text` TEXT NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`target_key`))",
+        "fields": [
+          {
+            "fieldPath": "targetKey",
+            "columnName": "target_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startText",
+            "columnName": "start_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endText",
+            "columnName": "end_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "target_key"
+          ]
+        }
+      },
+      {
+        "tableName": "download_pending_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `queue_order` INTEGER NOT NULL, `queued_at_ms` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `source_stable_key` TEXT, `stream_url` TEXT, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queueOrder",
+            "columnName": "queue_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAtMs",
+            "columnName": "queued_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_pending_queue_order",
+            "unique": false,
+            "columnNames": [
+              "queue_order"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_pending_queue_order` ON `${TABLE_NAME}` (`queue_order` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_cancelled_key",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `cancelled_at_ms` INTEGER NOT NULL, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cancelledAtMs",
+            "columnName": "cancelled_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        }
+      },
+      {
+        "tableName": "downloaded_song_catalog",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`catalog_key` TEXT NOT NULL, `root_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `file_path` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `download_time` INTEGER NOT NULL, `cover_path` TEXT, `cover_url` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `media_uri` TEXT, `duration_ms` INTEGER NOT NULL, `stable_key` TEXT, `source_identity_album` TEXT, `source_media_uri` TEXT, `source_channel_id` TEXT, `source_audio_id` TEXT, `source_sub_audio_id` TEXT, `source_playlist_context_id` TEXT, PRIMARY KEY(`catalog_key`))",
+        "fields": [
+          {
+            "fieldPath": "catalogKey",
+            "columnName": "catalog_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceIdentityAlbum",
+            "columnName": "source_identity_album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceMediaUri",
+            "columnName": "source_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceChannelId",
+            "columnName": "source_channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceAudioId",
+            "columnName": "source_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceSubAudioId",
+            "columnName": "source_sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcePlaylistContextId",
+            "columnName": "source_playlist_context_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "catalog_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloaded_song_catalog_root_position",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_root_position` ON `${TABLE_NAME}` (`root_key` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_file_path",
+            "unique": false,
+            "columnNames": [
+              "file_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_file_path` ON `${TABLE_NAME}` (`file_path`)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_stable_key",
+            "unique": false,
+            "columnNames": [
+              "stable_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_stable_key` ON `${TABLE_NAME}` (`stable_key`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cover_url_mapping",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`local_url` TEXT NOT NULL, `network_url` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`local_url`))",
+        "fields": [
+          {
+            "fieldPath": "localUrl",
+            "columnName": "local_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkUrl",
+            "columnName": "network_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "local_url"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cover_url_mapping_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cover_url_mapping_updated_at` ON `${TABLE_NAME}` (`updated_at` DESC)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c58f330baa0813870f17ced0de9551da')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/13.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/13.json
@@ -1,0 +1,3168 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 13,
+    "identityHash": "95f1c359ed994a50b649473dc880f5a7",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          },
+          {
+            "name": "index_playback_stat_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`day_start_at`, `identity_key`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC, `identity_key` ASC)"
+          },
+          {
+            "name": "index_playback_stat_bucket_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_counter_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_counter_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_daily_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`, `identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`day_start_at`, `identity_key`) REFERENCES `playback_stat_bucket`(`day_start_at`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_daily_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_daily_counter_scope` ON `${TABLE_NAME}` (`day_start_at`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat_bucket",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "day_start_at",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `track_count` INTEGER NOT NULL, `browse_id` TEXT, `remote_playlist_id` TEXT, `subtitle` TEXT, `added_time` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `source`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remotePlaylistId",
+            "columnName": "remote_playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedTime",
+            "columnName": "added_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_sort",
+            "unique": false,
+            "columnNames": [
+              "sort_order",
+              "modified_at"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_sort` ON `${TABLE_NAME}` (`sort_order` DESC, `modified_at` DESC)"
+          },
+          {
+            "name": "index_favorite_playlist_visibility",
+            "unique": false,
+            "columnNames": [
+              "is_deleted",
+              "sort_order"
+            ],
+            "orders": [
+              "ASC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_visibility` ON `${TABLE_NAME}` (`is_deleted` ASC, `sort_order` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `song_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `source`, `display_position`), FOREIGN KEY(`playlist_id`, `source`) REFERENCES `favorite_playlist`(`playlist_id`, `source`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songPayloadJson",
+            "columnName": "song_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source",
+            "display_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_song_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_song_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `source` ASC, `display_position` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "favorite_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "source"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "source"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "traffic_stats_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `wifi_bytes` INTEGER NOT NULL, `mobile_bytes` INTEGER NOT NULL, `roaming_bytes` INTEGER NOT NULL, `playback_network_bytes` INTEGER NOT NULL, `download_network_bytes` INTEGER NOT NULL, `cache_hit_bytes` INTEGER NOT NULL, `request_count` INTEGER NOT NULL, `cache_hit_count` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`))",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wifiBytes",
+            "columnName": "wifi_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mobileBytes",
+            "columnName": "mobile_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roamingBytes",
+            "columnName": "roaming_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackNetworkBytes",
+            "columnName": "playback_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadNetworkBytes",
+            "columnName": "download_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitBytes",
+            "columnName": "cache_hit_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestCount",
+            "columnName": "request_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitCount",
+            "columnName": "cache_hit_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traffic_stats_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traffic_stats_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `current_index` INTEGER NOT NULL, `media_url` TEXT, `position_ms` INTEGER NOT NULL, `should_resume_playback` INTEGER NOT NULL, `repeat_mode` INTEGER, `shuffle_enabled` INTEGER, `shuffle_restore_index` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "current_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUrl",
+            "columnName": "media_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldResumePlayback",
+            "columnName": "should_resume_playback",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeat_mode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffle_enabled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleRestoreIndex",
+            "columnName": "shuffle_restore_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_queue_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`queue_id` TEXT NOT NULL, `position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `stream_url` TEXT, PRIMARY KEY(`queue_id`, `position`))",
+        "fields": [
+          {
+            "fieldPath": "queueId",
+            "columnName": "queue_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "queue_id",
+            "position"
+          ]
+        }
+      },
+      {
+        "tableName": "bili_video_skip_rule",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`))",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bili_video_skip_rule_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bili_video_skip_rule_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_interval",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `position` INTEGER NOT NULL, `start_ms` INTEGER NOT NULL, `end_ms` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`, `position`), FOREIGN KEY(`bvid`, `cid`) REFERENCES `bili_video_skip_rule`(`bvid`, `cid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startMs",
+            "columnName": "start_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endMs",
+            "columnName": "end_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid",
+            "position"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "bili_video_skip_rule",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bvid",
+              "cid"
+            ],
+            "referencedColumns": [
+              "bvid",
+              "cid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_draft",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`target_key` TEXT NOT NULL, `bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `start_text` TEXT NOT NULL, `end_text` TEXT NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`target_key`))",
+        "fields": [
+          {
+            "fieldPath": "targetKey",
+            "columnName": "target_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startText",
+            "columnName": "start_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endText",
+            "columnName": "end_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "target_key"
+          ]
+        }
+      },
+      {
+        "tableName": "download_pending_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `queue_order` INTEGER NOT NULL, `queued_at_ms` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `source_stable_key` TEXT, `stream_url` TEXT, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queueOrder",
+            "columnName": "queue_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAtMs",
+            "columnName": "queued_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_pending_queue_order",
+            "unique": false,
+            "columnNames": [
+              "queue_order"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_pending_queue_order` ON `${TABLE_NAME}` (`queue_order` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_cancelled_key",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `cancelled_at_ms` INTEGER NOT NULL, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cancelledAtMs",
+            "columnName": "cancelled_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        }
+      },
+      {
+        "tableName": "downloaded_song_catalog",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`catalog_key` TEXT NOT NULL, `root_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `file_path` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `download_time` INTEGER NOT NULL, `cover_path` TEXT, `cover_url` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `media_uri` TEXT, `duration_ms` INTEGER NOT NULL, `stable_key` TEXT, `source_identity_album` TEXT, `source_media_uri` TEXT, `source_channel_id` TEXT, `source_audio_id` TEXT, `source_sub_audio_id` TEXT, `source_playlist_context_id` TEXT, PRIMARY KEY(`catalog_key`))",
+        "fields": [
+          {
+            "fieldPath": "catalogKey",
+            "columnName": "catalog_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceIdentityAlbum",
+            "columnName": "source_identity_album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceMediaUri",
+            "columnName": "source_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceChannelId",
+            "columnName": "source_channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceAudioId",
+            "columnName": "source_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceSubAudioId",
+            "columnName": "source_sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcePlaylistContextId",
+            "columnName": "source_playlist_context_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "catalog_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloaded_song_catalog_root_position",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_root_position` ON `${TABLE_NAME}` (`root_key` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_file_path",
+            "unique": false,
+            "columnNames": [
+              "file_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_file_path` ON `${TABLE_NAME}` (`file_path`)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_stable_key",
+            "unique": false,
+            "columnNames": [
+              "stable_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_stable_key` ON `${TABLE_NAME}` (`stable_key`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cover_url_mapping",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`local_url` TEXT NOT NULL, `network_url` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`local_url`))",
+        "fields": [
+          {
+            "fieldPath": "localUrl",
+            "columnName": "local_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkUrl",
+            "columnName": "network_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "local_url"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cover_url_mapping_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cover_url_mapping_updated_at` ON `${TABLE_NAME}` (`updated_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_snapshot_entry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`root_key` TEXT NOT NULL, `bucket` TEXT NOT NULL, `entry_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `name` TEXT NOT NULL, `reference` TEXT NOT NULL, `media_uri` TEXT NOT NULL, `local_file_path` TEXT, `size_bytes` INTEGER NOT NULL, `last_modified_ms` INTEGER NOT NULL, `is_directory` INTEGER NOT NULL, PRIMARY KEY(`root_key`, `bucket`, `entry_key`))",
+        "fields": [
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bucket",
+            "columnName": "bucket",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryKey",
+            "columnName": "entry_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedMs",
+            "columnName": "last_modified_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDirectory",
+            "columnName": "is_directory",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "root_key",
+            "bucket",
+            "entry_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_snapshot_entry_root_bucket_position",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "bucket",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_entry_root_bucket_position` ON `${TABLE_NAME}` (`root_key` ASC, `bucket` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_download_snapshot_entry_root_bucket_name",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "bucket",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_entry_root_bucket_name` ON `${TABLE_NAME}` (`root_key`, `bucket`, `name`)"
+          },
+          {
+            "name": "index_download_snapshot_entry_root_reference",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "reference"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_entry_root_reference` ON `${TABLE_NAME}` (`root_key`, `reference`)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_snapshot_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`root_key` TEXT NOT NULL, `audio_name` TEXT NOT NULL, `stable_key` TEXT, `song_id` INTEGER, `identity_album` TEXT, `name` TEXT, `artist` TEXT, `cover_url` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `cover_path` TEXT, `lyric_path` TEXT, `translated_lyric_path` TEXT, `duration_ms` INTEGER NOT NULL, `download_finalized` INTEGER, PRIMARY KEY(`root_key`, `audio_name`))",
+        "fields": [
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioName",
+            "columnName": "audio_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lyricPath",
+            "columnName": "lyric_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "translatedLyricPath",
+            "columnName": "translated_lyric_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadFinalized",
+            "columnName": "download_finalized",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "root_key",
+            "audio_name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_snapshot_metadata_root_stable_key",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "stable_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_stable_key` ON `${TABLE_NAME}` (`root_key`, `stable_key`)"
+          },
+          {
+            "name": "index_download_snapshot_metadata_root_song_id",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "song_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_song_id` ON `${TABLE_NAME}` (`root_key`, `song_id`)"
+          },
+          {
+            "name": "index_download_snapshot_metadata_root_media_uri",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_media_uri` ON `${TABLE_NAME}` (`root_key`, `media_uri`)"
+          },
+          {
+            "name": "index_download_snapshot_metadata_root_remote_track",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "channel_id",
+              "audio_id",
+              "sub_audio_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_remote_track` ON `${TABLE_NAME}` (`root_key`, `channel_id`, `audio_id`, `sub_audio_id`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '95f1c359ed994a50b649473dc880f5a7')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/14.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/14.json
@@ -1,0 +1,3500 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 14,
+    "identityHash": "c62e6938e5e0895f567c1c407d8d5336",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          },
+          {
+            "name": "index_playback_stat_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`day_start_at`, `identity_key`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC, `identity_key` ASC)"
+          },
+          {
+            "name": "index_playback_stat_bucket_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_counter_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_counter_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_daily_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`, `identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`day_start_at`, `identity_key`) REFERENCES `playback_stat_bucket`(`day_start_at`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_daily_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_daily_counter_scope` ON `${TABLE_NAME}` (`day_start_at`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat_bucket",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "day_start_at",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `track_count` INTEGER NOT NULL, `browse_id` TEXT, `remote_playlist_id` TEXT, `subtitle` TEXT, `added_time` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `source`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remotePlaylistId",
+            "columnName": "remote_playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedTime",
+            "columnName": "added_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_sort",
+            "unique": false,
+            "columnNames": [
+              "sort_order",
+              "modified_at"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_sort` ON `${TABLE_NAME}` (`sort_order` DESC, `modified_at` DESC)"
+          },
+          {
+            "name": "index_favorite_playlist_visibility",
+            "unique": false,
+            "columnNames": [
+              "is_deleted",
+              "sort_order"
+            ],
+            "orders": [
+              "ASC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_visibility` ON `${TABLE_NAME}` (`is_deleted` ASC, `sort_order` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `song_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `source`, `display_position`), FOREIGN KEY(`playlist_id`, `source`) REFERENCES `favorite_playlist`(`playlist_id`, `source`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songPayloadJson",
+            "columnName": "song_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source",
+            "display_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_song_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_song_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `source` ASC, `display_position` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "favorite_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "source"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "source"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "traffic_stats_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `wifi_bytes` INTEGER NOT NULL, `mobile_bytes` INTEGER NOT NULL, `roaming_bytes` INTEGER NOT NULL, `playback_network_bytes` INTEGER NOT NULL, `download_network_bytes` INTEGER NOT NULL, `cache_hit_bytes` INTEGER NOT NULL, `request_count` INTEGER NOT NULL, `cache_hit_count` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`))",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wifiBytes",
+            "columnName": "wifi_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mobileBytes",
+            "columnName": "mobile_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roamingBytes",
+            "columnName": "roaming_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackNetworkBytes",
+            "columnName": "playback_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadNetworkBytes",
+            "columnName": "download_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitBytes",
+            "columnName": "cache_hit_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestCount",
+            "columnName": "request_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitCount",
+            "columnName": "cache_hit_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traffic_stats_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traffic_stats_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `current_index` INTEGER NOT NULL, `media_url` TEXT, `position_ms` INTEGER NOT NULL, `should_resume_playback` INTEGER NOT NULL, `repeat_mode` INTEGER, `shuffle_enabled` INTEGER, `shuffle_restore_index` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "current_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUrl",
+            "columnName": "media_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldResumePlayback",
+            "columnName": "should_resume_playback",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeat_mode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffle_enabled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleRestoreIndex",
+            "columnName": "shuffle_restore_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_queue_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`queue_id` TEXT NOT NULL, `position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `stream_url` TEXT, PRIMARY KEY(`queue_id`, `position`))",
+        "fields": [
+          {
+            "fieldPath": "queueId",
+            "columnName": "queue_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "queue_id",
+            "position"
+          ]
+        }
+      },
+      {
+        "tableName": "bili_video_skip_rule",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`))",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bili_video_skip_rule_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bili_video_skip_rule_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_interval",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `position` INTEGER NOT NULL, `start_ms` INTEGER NOT NULL, `end_ms` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`, `position`), FOREIGN KEY(`bvid`, `cid`) REFERENCES `bili_video_skip_rule`(`bvid`, `cid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startMs",
+            "columnName": "start_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endMs",
+            "columnName": "end_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid",
+            "position"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "bili_video_skip_rule",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bvid",
+              "cid"
+            ],
+            "referencedColumns": [
+              "bvid",
+              "cid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_draft",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`target_key` TEXT NOT NULL, `bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `start_text` TEXT NOT NULL, `end_text` TEXT NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`target_key`))",
+        "fields": [
+          {
+            "fieldPath": "targetKey",
+            "columnName": "target_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startText",
+            "columnName": "start_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endText",
+            "columnName": "end_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "target_key"
+          ]
+        }
+      },
+      {
+        "tableName": "download_pending_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `queue_order` INTEGER NOT NULL, `queued_at_ms` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `source_stable_key` TEXT, `stream_url` TEXT, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queueOrder",
+            "columnName": "queue_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAtMs",
+            "columnName": "queued_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_pending_queue_order",
+            "unique": false,
+            "columnNames": [
+              "queue_order"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_pending_queue_order` ON `${TABLE_NAME}` (`queue_order` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_cancelled_key",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `cancelled_at_ms` INTEGER NOT NULL, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cancelledAtMs",
+            "columnName": "cancelled_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        }
+      },
+      {
+        "tableName": "downloaded_song_catalog",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`catalog_key` TEXT NOT NULL, `root_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `file_path` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `download_time` INTEGER NOT NULL, `cover_path` TEXT, `cover_url` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `media_uri` TEXT, `duration_ms` INTEGER NOT NULL, `stable_key` TEXT, `source_identity_album` TEXT, `source_media_uri` TEXT, `source_channel_id` TEXT, `source_audio_id` TEXT, `source_sub_audio_id` TEXT, `source_playlist_context_id` TEXT, PRIMARY KEY(`catalog_key`))",
+        "fields": [
+          {
+            "fieldPath": "catalogKey",
+            "columnName": "catalog_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceIdentityAlbum",
+            "columnName": "source_identity_album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceMediaUri",
+            "columnName": "source_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceChannelId",
+            "columnName": "source_channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceAudioId",
+            "columnName": "source_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceSubAudioId",
+            "columnName": "source_sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcePlaylistContextId",
+            "columnName": "source_playlist_context_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "catalog_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloaded_song_catalog_root_position",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_root_position` ON `${TABLE_NAME}` (`root_key` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_file_path",
+            "unique": false,
+            "columnNames": [
+              "file_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_file_path` ON `${TABLE_NAME}` (`file_path`)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_stable_key",
+            "unique": false,
+            "columnNames": [
+              "stable_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_stable_key` ON `${TABLE_NAME}` (`stable_key`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cover_url_mapping",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`local_url` TEXT NOT NULL, `network_url` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`local_url`))",
+        "fields": [
+          {
+            "fieldPath": "localUrl",
+            "columnName": "local_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkUrl",
+            "columnName": "network_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "local_url"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cover_url_mapping_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cover_url_mapping_updated_at` ON `${TABLE_NAME}` (`updated_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_snapshot_entry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`root_key` TEXT NOT NULL, `bucket` TEXT NOT NULL, `entry_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `name` TEXT NOT NULL, `reference` TEXT NOT NULL, `media_uri` TEXT NOT NULL, `local_file_path` TEXT, `size_bytes` INTEGER NOT NULL, `last_modified_ms` INTEGER NOT NULL, `is_directory` INTEGER NOT NULL, PRIMARY KEY(`root_key`, `bucket`, `entry_key`))",
+        "fields": [
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bucket",
+            "columnName": "bucket",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryKey",
+            "columnName": "entry_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedMs",
+            "columnName": "last_modified_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDirectory",
+            "columnName": "is_directory",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "root_key",
+            "bucket",
+            "entry_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_snapshot_entry_root_bucket_position",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "bucket",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_entry_root_bucket_position` ON `${TABLE_NAME}` (`root_key` ASC, `bucket` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_download_snapshot_entry_root_bucket_name",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "bucket",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_entry_root_bucket_name` ON `${TABLE_NAME}` (`root_key`, `bucket`, `name`)"
+          },
+          {
+            "name": "index_download_snapshot_entry_root_reference",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "reference"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_entry_root_reference` ON `${TABLE_NAME}` (`root_key`, `reference`)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_snapshot_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`root_key` TEXT NOT NULL, `audio_name` TEXT NOT NULL, `stable_key` TEXT, `song_id` INTEGER, `identity_album` TEXT, `name` TEXT, `artist` TEXT, `cover_url` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `cover_path` TEXT, `lyric_path` TEXT, `translated_lyric_path` TEXT, `duration_ms` INTEGER NOT NULL, `download_finalized` INTEGER, PRIMARY KEY(`root_key`, `audio_name`))",
+        "fields": [
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioName",
+            "columnName": "audio_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lyricPath",
+            "columnName": "lyric_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "translatedLyricPath",
+            "columnName": "translated_lyric_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadFinalized",
+            "columnName": "download_finalized",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "root_key",
+            "audio_name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_snapshot_metadata_root_stable_key",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "stable_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_stable_key` ON `${TABLE_NAME}` (`root_key`, `stable_key`)"
+          },
+          {
+            "name": "index_download_snapshot_metadata_root_song_id",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "song_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_song_id` ON `${TABLE_NAME}` (`root_key`, `song_id`)"
+          },
+          {
+            "name": "index_download_snapshot_metadata_root_media_uri",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_media_uri` ON `${TABLE_NAME}` (`root_key`, `media_uri`)"
+          },
+          {
+            "name": "index_download_snapshot_metadata_root_remote_track",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "channel_id",
+              "audio_id",
+              "sub_audio_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_remote_track` ON `${TABLE_NAME}` (`root_key`, `channel_id`, `audio_id`, `sub_audio_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "platform_playlist_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platform` TEXT NOT NULL, `cache_key` TEXT NOT NULL, `source_id` INTEGER, `alternate_key` TEXT, `kind` TEXT, `title` TEXT, `subtitle` TEXT, `creator_name` TEXT, `cover_url` TEXT, `play_count` INTEGER, `track_count` INTEGER NOT NULL, `total_count` INTEGER NOT NULL, `signature_primary` TEXT, `signature_secondary` TEXT, `has_more` INTEGER, `saved_at_ms` INTEGER NOT NULL, PRIMARY KEY(`platform`, `cache_key`))",
+        "fields": [
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alternateKey",
+            "columnName": "alternate_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creator_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalCount",
+            "columnName": "total_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "signaturePrimary",
+            "columnName": "signature_primary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "signatureSecondary",
+            "columnName": "signature_secondary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hasMore",
+            "columnName": "has_more",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "savedAtMs",
+            "columnName": "saved_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platform",
+            "cache_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_platform_playlist_cache_source_id",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "source_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_source_id` ON `${TABLE_NAME}` (`platform`, `source_id`)"
+          },
+          {
+            "name": "index_platform_playlist_cache_saved_at",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "saved_at_ms"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_saved_at` ON `${TABLE_NAME}` (`platform`, `saved_at_ms`)"
+          }
+        ]
+      },
+      {
+        "tableName": "platform_playlist_cache_track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platform` TEXT NOT NULL, `cache_key` TEXT NOT NULL, `position` INTEGER NOT NULL, `item_id` INTEGER, `item_key` TEXT, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `audio_id` TEXT, `uploader_mid` INTEGER, `added_at` INTEGER NOT NULL, PRIMARY KEY(`platform`, `cache_key`, `position`), FOREIGN KEY(`platform`, `cache_key`) REFERENCES `platform_playlist_cache`(`platform`, `cache_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "itemKey",
+            "columnName": "item_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uploaderMid",
+            "columnName": "uploader_mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platform",
+            "cache_key",
+            "position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_platform_playlist_cache_track_item_id",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "cache_key",
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_track_item_id` ON `${TABLE_NAME}` (`platform`, `cache_key`, `item_id`)"
+          },
+          {
+            "name": "index_platform_playlist_cache_track_item_key",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "cache_key",
+              "item_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_track_item_key` ON `${TABLE_NAME}` (`platform`, `cache_key`, `item_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "platform_playlist_cache",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "platform",
+              "cache_key"
+            ],
+            "referencedColumns": [
+              "platform",
+              "cache_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "platform_playlist_cache_track_artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platform` TEXT NOT NULL, `cache_key` TEXT NOT NULL, `track_position` INTEGER NOT NULL, `artist_position` INTEGER NOT NULL, `artist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`platform`, `cache_key`, `track_position`, `artist_position`), FOREIGN KEY(`platform`, `cache_key`, `track_position`) REFERENCES `platform_playlist_cache_track`(`platform`, `cache_key`, `position`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackPosition",
+            "columnName": "track_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistPosition",
+            "columnName": "artist_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platform",
+            "cache_key",
+            "track_position",
+            "artist_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_platform_playlist_cache_artist_track",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "cache_key",
+              "track_position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_artist_track` ON `${TABLE_NAME}` (`platform`, `cache_key`, `track_position`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "platform_playlist_cache_track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "platform",
+              "cache_key",
+              "track_position"
+            ],
+            "referencedColumns": [
+              "platform",
+              "cache_key",
+              "position"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c62e6938e5e0895f567c1c407d8d5336')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/15.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/15.json
@@ -1,0 +1,4001 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 15,
+    "identityHash": "8f0b3d8e2fe98ed9847615f22ac97207",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `structured_schema_version` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "structuredSchemaVersion",
+            "columnName": "structured_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `structured_schema_version` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "structuredSchemaVersion",
+            "columnName": "structured_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_netease_artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `artist_position` INTEGER NOT NULL, `artist_id` INTEGER NOT NULL, `artist_name` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `artist_position`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistPosition",
+            "columnName": "artist_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "artist_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_artist_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_artist_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          },
+          {
+            "name": "index_playback_stat_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`day_start_at`, `identity_key`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC, `identity_key` ASC)"
+          },
+          {
+            "name": "index_playback_stat_bucket_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_counter_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_counter_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_daily_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`, `identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`day_start_at`, `identity_key`) REFERENCES `playback_stat_bucket`(`day_start_at`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_daily_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_daily_counter_scope` ON `${TABLE_NAME}` (`day_start_at`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat_bucket",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "day_start_at",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `track_count` INTEGER NOT NULL, `browse_id` TEXT, `remote_playlist_id` TEXT, `subtitle` TEXT, `added_time` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `source`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remotePlaylistId",
+            "columnName": "remote_playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedTime",
+            "columnName": "added_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_sort",
+            "unique": false,
+            "columnNames": [
+              "sort_order",
+              "modified_at"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_sort` ON `${TABLE_NAME}` (`sort_order` DESC, `modified_at` DESC)"
+          },
+          {
+            "name": "index_favorite_playlist_visibility",
+            "unique": false,
+            "columnNames": [
+              "is_deleted",
+              "sort_order"
+            ],
+            "orders": [
+              "ASC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_visibility` ON `${TABLE_NAME}` (`is_deleted` ASC, `sort_order` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `source_stable_key` TEXT, `added_at` INTEGER NOT NULL, `structured_schema_version` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `source`, `display_position`), FOREIGN KEY(`playlist_id`, `source`) REFERENCES `favorite_playlist`(`playlist_id`, `source`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "structuredSchemaVersion",
+            "columnName": "structured_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source",
+            "display_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_song_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_song_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `source` ASC, `display_position` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "favorite_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "source"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "source"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist_song_netease_artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `artist_position` INTEGER NOT NULL, `artist_id` INTEGER NOT NULL, `artist_name` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `source`, `display_position`, `artist_position`), FOREIGN KEY(`playlist_id`, `source`, `display_position`) REFERENCES `favorite_playlist_song`(`playlist_id`, `source`, `display_position`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistPosition",
+            "columnName": "artist_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistName",
+            "columnName": "artist_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source",
+            "display_position",
+            "artist_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_song_artist_song",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_song_artist_song` ON `${TABLE_NAME}` (`playlist_id`, `source`, `display_position`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "favorite_playlist_song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "traffic_stats_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `wifi_bytes` INTEGER NOT NULL, `mobile_bytes` INTEGER NOT NULL, `roaming_bytes` INTEGER NOT NULL, `playback_network_bytes` INTEGER NOT NULL, `download_network_bytes` INTEGER NOT NULL, `cache_hit_bytes` INTEGER NOT NULL, `request_count` INTEGER NOT NULL, `cache_hit_count` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`))",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wifiBytes",
+            "columnName": "wifi_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mobileBytes",
+            "columnName": "mobile_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roamingBytes",
+            "columnName": "roaming_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackNetworkBytes",
+            "columnName": "playback_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadNetworkBytes",
+            "columnName": "download_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitBytes",
+            "columnName": "cache_hit_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestCount",
+            "columnName": "request_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitCount",
+            "columnName": "cache_hit_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traffic_stats_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traffic_stats_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `current_index` INTEGER NOT NULL, `media_url` TEXT, `position_ms` INTEGER NOT NULL, `should_resume_playback` INTEGER NOT NULL, `repeat_mode` INTEGER, `shuffle_enabled` INTEGER, `shuffle_restore_index` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "current_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUrl",
+            "columnName": "media_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldResumePlayback",
+            "columnName": "should_resume_playback",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeat_mode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffle_enabled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleRestoreIndex",
+            "columnName": "shuffle_restore_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_queue_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`queue_id` TEXT NOT NULL, `position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `stream_url` TEXT, PRIMARY KEY(`queue_id`, `position`))",
+        "fields": [
+          {
+            "fieldPath": "queueId",
+            "columnName": "queue_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "queue_id",
+            "position"
+          ]
+        }
+      },
+      {
+        "tableName": "bili_video_skip_rule",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`))",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bili_video_skip_rule_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bili_video_skip_rule_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_interval",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `position` INTEGER NOT NULL, `start_ms` INTEGER NOT NULL, `end_ms` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`, `position`), FOREIGN KEY(`bvid`, `cid`) REFERENCES `bili_video_skip_rule`(`bvid`, `cid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startMs",
+            "columnName": "start_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endMs",
+            "columnName": "end_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid",
+            "position"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "bili_video_skip_rule",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bvid",
+              "cid"
+            ],
+            "referencedColumns": [
+              "bvid",
+              "cid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_draft",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`target_key` TEXT NOT NULL, `bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `start_text` TEXT NOT NULL, `end_text` TEXT NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`target_key`))",
+        "fields": [
+          {
+            "fieldPath": "targetKey",
+            "columnName": "target_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startText",
+            "columnName": "start_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endText",
+            "columnName": "end_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "target_key"
+          ]
+        }
+      },
+      {
+        "tableName": "download_pending_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `queue_order` INTEGER NOT NULL, `queued_at_ms` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `source_stable_key` TEXT, `stream_url` TEXT, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queueOrder",
+            "columnName": "queue_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAtMs",
+            "columnName": "queued_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_pending_queue_order",
+            "unique": false,
+            "columnNames": [
+              "queue_order"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_pending_queue_order` ON `${TABLE_NAME}` (`queue_order` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_cancelled_key",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `cancelled_at_ms` INTEGER NOT NULL, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cancelledAtMs",
+            "columnName": "cancelled_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        }
+      },
+      {
+        "tableName": "downloaded_song_catalog",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`catalog_key` TEXT NOT NULL, `root_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `file_path` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `download_time` INTEGER NOT NULL, `cover_path` TEXT, `cover_url` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `media_uri` TEXT, `duration_ms` INTEGER NOT NULL, `stable_key` TEXT, `source_identity_album` TEXT, `source_media_uri` TEXT, `source_channel_id` TEXT, `source_audio_id` TEXT, `source_sub_audio_id` TEXT, `source_playlist_context_id` TEXT, PRIMARY KEY(`catalog_key`))",
+        "fields": [
+          {
+            "fieldPath": "catalogKey",
+            "columnName": "catalog_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceIdentityAlbum",
+            "columnName": "source_identity_album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceMediaUri",
+            "columnName": "source_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceChannelId",
+            "columnName": "source_channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceAudioId",
+            "columnName": "source_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceSubAudioId",
+            "columnName": "source_sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcePlaylistContextId",
+            "columnName": "source_playlist_context_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "catalog_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloaded_song_catalog_root_position",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_root_position` ON `${TABLE_NAME}` (`root_key` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_file_path",
+            "unique": false,
+            "columnNames": [
+              "file_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_file_path` ON `${TABLE_NAME}` (`file_path`)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_stable_key",
+            "unique": false,
+            "columnNames": [
+              "stable_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_stable_key` ON `${TABLE_NAME}` (`stable_key`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cover_url_mapping",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`local_url` TEXT NOT NULL, `network_url` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`local_url`))",
+        "fields": [
+          {
+            "fieldPath": "localUrl",
+            "columnName": "local_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkUrl",
+            "columnName": "network_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "local_url"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cover_url_mapping_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cover_url_mapping_updated_at` ON `${TABLE_NAME}` (`updated_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_snapshot_entry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`root_key` TEXT NOT NULL, `bucket` TEXT NOT NULL, `entry_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `name` TEXT NOT NULL, `reference` TEXT NOT NULL, `media_uri` TEXT NOT NULL, `local_file_path` TEXT, `size_bytes` INTEGER NOT NULL, `last_modified_ms` INTEGER NOT NULL, `is_directory` INTEGER NOT NULL, PRIMARY KEY(`root_key`, `bucket`, `entry_key`))",
+        "fields": [
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bucket",
+            "columnName": "bucket",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryKey",
+            "columnName": "entry_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedMs",
+            "columnName": "last_modified_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDirectory",
+            "columnName": "is_directory",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "root_key",
+            "bucket",
+            "entry_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_snapshot_entry_root_bucket_position",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "bucket",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_entry_root_bucket_position` ON `${TABLE_NAME}` (`root_key` ASC, `bucket` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_download_snapshot_entry_root_bucket_name",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "bucket",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_entry_root_bucket_name` ON `${TABLE_NAME}` (`root_key`, `bucket`, `name`)"
+          },
+          {
+            "name": "index_download_snapshot_entry_root_reference",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "reference"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_entry_root_reference` ON `${TABLE_NAME}` (`root_key`, `reference`)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_snapshot_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`root_key` TEXT NOT NULL, `audio_name` TEXT NOT NULL, `stable_key` TEXT, `song_id` INTEGER, `identity_album` TEXT, `name` TEXT, `artist` TEXT, `cover_url` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `cover_path` TEXT, `lyric_path` TEXT, `translated_lyric_path` TEXT, `duration_ms` INTEGER NOT NULL, `download_finalized` INTEGER, PRIMARY KEY(`root_key`, `audio_name`))",
+        "fields": [
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioName",
+            "columnName": "audio_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lyricPath",
+            "columnName": "lyric_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "translatedLyricPath",
+            "columnName": "translated_lyric_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadFinalized",
+            "columnName": "download_finalized",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "root_key",
+            "audio_name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_snapshot_metadata_root_stable_key",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "stable_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_stable_key` ON `${TABLE_NAME}` (`root_key`, `stable_key`)"
+          },
+          {
+            "name": "index_download_snapshot_metadata_root_song_id",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "song_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_song_id` ON `${TABLE_NAME}` (`root_key`, `song_id`)"
+          },
+          {
+            "name": "index_download_snapshot_metadata_root_media_uri",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_media_uri` ON `${TABLE_NAME}` (`root_key`, `media_uri`)"
+          },
+          {
+            "name": "index_download_snapshot_metadata_root_remote_track",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "channel_id",
+              "audio_id",
+              "sub_audio_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_remote_track` ON `${TABLE_NAME}` (`root_key`, `channel_id`, `audio_id`, `sub_audio_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "platform_playlist_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platform` TEXT NOT NULL, `cache_key` TEXT NOT NULL, `source_id` INTEGER, `alternate_key` TEXT, `kind` TEXT, `title` TEXT, `subtitle` TEXT, `creator_name` TEXT, `cover_url` TEXT, `play_count` INTEGER, `track_count` INTEGER NOT NULL, `total_count` INTEGER NOT NULL, `signature_primary` TEXT, `signature_secondary` TEXT, `has_more` INTEGER, `saved_at_ms` INTEGER NOT NULL, PRIMARY KEY(`platform`, `cache_key`))",
+        "fields": [
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alternateKey",
+            "columnName": "alternate_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creator_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalCount",
+            "columnName": "total_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "signaturePrimary",
+            "columnName": "signature_primary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "signatureSecondary",
+            "columnName": "signature_secondary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hasMore",
+            "columnName": "has_more",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "savedAtMs",
+            "columnName": "saved_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platform",
+            "cache_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_platform_playlist_cache_source_id",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "source_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_source_id` ON `${TABLE_NAME}` (`platform`, `source_id`)"
+          },
+          {
+            "name": "index_platform_playlist_cache_saved_at",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "saved_at_ms"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_saved_at` ON `${TABLE_NAME}` (`platform`, `saved_at_ms`)"
+          }
+        ]
+      },
+      {
+        "tableName": "platform_playlist_cache_track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platform` TEXT NOT NULL, `cache_key` TEXT NOT NULL, `position` INTEGER NOT NULL, `item_id` INTEGER, `item_key` TEXT, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `audio_id` TEXT, `uploader_mid` INTEGER, `added_at` INTEGER NOT NULL, PRIMARY KEY(`platform`, `cache_key`, `position`), FOREIGN KEY(`platform`, `cache_key`) REFERENCES `platform_playlist_cache`(`platform`, `cache_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "itemKey",
+            "columnName": "item_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uploaderMid",
+            "columnName": "uploader_mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platform",
+            "cache_key",
+            "position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_platform_playlist_cache_track_item_id",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "cache_key",
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_track_item_id` ON `${TABLE_NAME}` (`platform`, `cache_key`, `item_id`)"
+          },
+          {
+            "name": "index_platform_playlist_cache_track_item_key",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "cache_key",
+              "item_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_track_item_key` ON `${TABLE_NAME}` (`platform`, `cache_key`, `item_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "platform_playlist_cache",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "platform",
+              "cache_key"
+            ],
+            "referencedColumns": [
+              "platform",
+              "cache_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "platform_playlist_cache_track_artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platform` TEXT NOT NULL, `cache_key` TEXT NOT NULL, `track_position` INTEGER NOT NULL, `artist_position` INTEGER NOT NULL, `artist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`platform`, `cache_key`, `track_position`, `artist_position`), FOREIGN KEY(`platform`, `cache_key`, `track_position`) REFERENCES `platform_playlist_cache_track`(`platform`, `cache_key`, `position`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackPosition",
+            "columnName": "track_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistPosition",
+            "columnName": "artist_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platform",
+            "cache_key",
+            "track_position",
+            "artist_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_platform_playlist_cache_artist_track",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "cache_key",
+              "track_position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_artist_track` ON `${TABLE_NAME}` (`platform`, `cache_key`, `track_position`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "platform_playlist_cache_track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "platform",
+              "cache_key",
+              "track_position"
+            ],
+            "referencedColumns": [
+              "platform",
+              "cache_key",
+              "position"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8f0b3d8e2fe98ed9847615f22ac97207')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/2.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/2.json
@@ -1,0 +1,814 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "22482cc7cdc6a254216f18ed1ca56255",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '22482cc7cdc6a254216f18ed1ca56255')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/3.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/3.json
@@ -1,0 +1,1012 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "e46680b831698557ceedad04e4c940f4",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e46680b831698557ceedad04e4c940f4')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/4.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/4.json
@@ -1,0 +1,1226 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "0ef4ce2b70651c6041fea6a12ca3d083",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0ef4ce2b70651c6041fea6a12ca3d083')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/5.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/5.json
@@ -1,0 +1,1688 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "d48f08a0c60dc45a955d1f8d2f8eadb6",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          },
+          {
+            "name": "index_playback_stat_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`day_start_at`, `identity_key`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC, `identity_key` ASC)"
+          },
+          {
+            "name": "index_playback_stat_bucket_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_counter_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_counter_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_daily_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`, `identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`day_start_at`, `identity_key`) REFERENCES `playback_stat_bucket`(`day_start_at`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_daily_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_daily_counter_scope` ON `${TABLE_NAME}` (`day_start_at`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat_bucket",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "day_start_at",
+              "identity_key"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd48f08a0c60dc45a955d1f8d2f8eadb6')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/6.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/6.json
@@ -1,0 +1,1867 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "e9fc72e44b2c077070c814efe54d0504",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          },
+          {
+            "name": "index_playback_stat_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`day_start_at`, `identity_key`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC, `identity_key` ASC)"
+          },
+          {
+            "name": "index_playback_stat_bucket_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_counter_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_counter_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_daily_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`, `identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`day_start_at`, `identity_key`) REFERENCES `playback_stat_bucket`(`day_start_at`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_daily_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_daily_counter_scope` ON `${TABLE_NAME}` (`day_start_at`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat_bucket",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "day_start_at",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `track_count` INTEGER NOT NULL, `browse_id` TEXT, `remote_playlist_id` TEXT, `subtitle` TEXT, `added_time` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `source`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remotePlaylistId",
+            "columnName": "remote_playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedTime",
+            "columnName": "added_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_sort",
+            "unique": false,
+            "columnNames": [
+              "sort_order",
+              "modified_at"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_sort` ON `${TABLE_NAME}` (`sort_order` DESC, `modified_at` DESC)"
+          },
+          {
+            "name": "index_favorite_playlist_visibility",
+            "unique": false,
+            "columnNames": [
+              "is_deleted",
+              "sort_order"
+            ],
+            "orders": [
+              "ASC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_visibility` ON `${TABLE_NAME}` (`is_deleted` ASC, `sort_order` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `song_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `source`, `display_position`), FOREIGN KEY(`playlist_id`, `source`) REFERENCES `favorite_playlist`(`playlist_id`, `source`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songPayloadJson",
+            "columnName": "song_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source",
+            "display_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_song_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_song_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `source` ASC, `display_position` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "favorite_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "source"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "source"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e9fc72e44b2c077070c814efe54d0504')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/7.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/7.json
@@ -1,0 +1,1946 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "7be667e92f3030ed10270467692dc9bc",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          },
+          {
+            "name": "index_playback_stat_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`day_start_at`, `identity_key`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC, `identity_key` ASC)"
+          },
+          {
+            "name": "index_playback_stat_bucket_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_counter_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_counter_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_daily_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`, `identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`day_start_at`, `identity_key`) REFERENCES `playback_stat_bucket`(`day_start_at`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_daily_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_daily_counter_scope` ON `${TABLE_NAME}` (`day_start_at`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat_bucket",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "day_start_at",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `track_count` INTEGER NOT NULL, `browse_id` TEXT, `remote_playlist_id` TEXT, `subtitle` TEXT, `added_time` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `source`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remotePlaylistId",
+            "columnName": "remote_playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedTime",
+            "columnName": "added_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_sort",
+            "unique": false,
+            "columnNames": [
+              "sort_order",
+              "modified_at"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_sort` ON `${TABLE_NAME}` (`sort_order` DESC, `modified_at` DESC)"
+          },
+          {
+            "name": "index_favorite_playlist_visibility",
+            "unique": false,
+            "columnNames": [
+              "is_deleted",
+              "sort_order"
+            ],
+            "orders": [
+              "ASC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_visibility` ON `${TABLE_NAME}` (`is_deleted` ASC, `sort_order` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `song_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `source`, `display_position`), FOREIGN KEY(`playlist_id`, `source`) REFERENCES `favorite_playlist`(`playlist_id`, `source`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songPayloadJson",
+            "columnName": "song_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source",
+            "display_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_song_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_song_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `source` ASC, `display_position` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "favorite_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "source"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "source"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "traffic_stats_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `wifi_bytes` INTEGER NOT NULL, `mobile_bytes` INTEGER NOT NULL, `roaming_bytes` INTEGER NOT NULL, `playback_network_bytes` INTEGER NOT NULL, `download_network_bytes` INTEGER NOT NULL, `cache_hit_bytes` INTEGER NOT NULL, `request_count` INTEGER NOT NULL, `cache_hit_count` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`))",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wifiBytes",
+            "columnName": "wifi_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mobileBytes",
+            "columnName": "mobile_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roamingBytes",
+            "columnName": "roaming_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackNetworkBytes",
+            "columnName": "playback_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadNetworkBytes",
+            "columnName": "download_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitBytes",
+            "columnName": "cache_hit_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestCount",
+            "columnName": "request_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitCount",
+            "columnName": "cache_hit_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traffic_stats_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traffic_stats_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7be667e92f3030ed10270467692dc9bc')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/8.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/8.json
@@ -1,0 +1,2180 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "bc6d390b365e1b5a9849a4f144343d0c",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          },
+          {
+            "name": "index_playback_stat_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`day_start_at`, `identity_key`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC, `identity_key` ASC)"
+          },
+          {
+            "name": "index_playback_stat_bucket_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_counter_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_counter_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_daily_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`, `identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`day_start_at`, `identity_key`) REFERENCES `playback_stat_bucket`(`day_start_at`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_daily_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_daily_counter_scope` ON `${TABLE_NAME}` (`day_start_at`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat_bucket",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "day_start_at",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `track_count` INTEGER NOT NULL, `browse_id` TEXT, `remote_playlist_id` TEXT, `subtitle` TEXT, `added_time` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `source`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remotePlaylistId",
+            "columnName": "remote_playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedTime",
+            "columnName": "added_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_sort",
+            "unique": false,
+            "columnNames": [
+              "sort_order",
+              "modified_at"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_sort` ON `${TABLE_NAME}` (`sort_order` DESC, `modified_at` DESC)"
+          },
+          {
+            "name": "index_favorite_playlist_visibility",
+            "unique": false,
+            "columnNames": [
+              "is_deleted",
+              "sort_order"
+            ],
+            "orders": [
+              "ASC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_visibility` ON `${TABLE_NAME}` (`is_deleted` ASC, `sort_order` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `song_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `source`, `display_position`), FOREIGN KEY(`playlist_id`, `source`) REFERENCES `favorite_playlist`(`playlist_id`, `source`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songPayloadJson",
+            "columnName": "song_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source",
+            "display_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_song_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_song_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `source` ASC, `display_position` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "favorite_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "source"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "source"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "traffic_stats_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `wifi_bytes` INTEGER NOT NULL, `mobile_bytes` INTEGER NOT NULL, `roaming_bytes` INTEGER NOT NULL, `playback_network_bytes` INTEGER NOT NULL, `download_network_bytes` INTEGER NOT NULL, `cache_hit_bytes` INTEGER NOT NULL, `request_count` INTEGER NOT NULL, `cache_hit_count` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`))",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wifiBytes",
+            "columnName": "wifi_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mobileBytes",
+            "columnName": "mobile_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roamingBytes",
+            "columnName": "roaming_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackNetworkBytes",
+            "columnName": "playback_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadNetworkBytes",
+            "columnName": "download_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitBytes",
+            "columnName": "cache_hit_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestCount",
+            "columnName": "request_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitCount",
+            "columnName": "cache_hit_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traffic_stats_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traffic_stats_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `current_index` INTEGER NOT NULL, `media_url` TEXT, `position_ms` INTEGER NOT NULL, `should_resume_playback` INTEGER NOT NULL, `repeat_mode` INTEGER, `shuffle_enabled` INTEGER, `shuffle_restore_index` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "current_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUrl",
+            "columnName": "media_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldResumePlayback",
+            "columnName": "should_resume_playback",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeat_mode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffle_enabled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleRestoreIndex",
+            "columnName": "shuffle_restore_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_queue_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`queue_id` TEXT NOT NULL, `position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `stream_url` TEXT, PRIMARY KEY(`queue_id`, `position`))",
+        "fields": [
+          {
+            "fieldPath": "queueId",
+            "columnName": "queue_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "queue_id",
+            "position"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bc6d390b365e1b5a9849a4f144343d0c')"
+    ]
+  }
+}

--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/9.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/9.json
@@ -1,0 +1,2337 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "a81aec5900f30fb6324fc2782f28658d",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          },
+          {
+            "name": "index_playback_stat_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`day_start_at`, `identity_key`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC, `identity_key` ASC)"
+          },
+          {
+            "name": "index_playback_stat_bucket_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_counter_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_counter_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_daily_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`, `identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`day_start_at`, `identity_key`) REFERENCES `playback_stat_bucket`(`day_start_at`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_daily_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_daily_counter_scope` ON `${TABLE_NAME}` (`day_start_at`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat_bucket",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "day_start_at",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `track_count` INTEGER NOT NULL, `browse_id` TEXT, `remote_playlist_id` TEXT, `subtitle` TEXT, `added_time` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `source`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remotePlaylistId",
+            "columnName": "remote_playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedTime",
+            "columnName": "added_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_sort",
+            "unique": false,
+            "columnNames": [
+              "sort_order",
+              "modified_at"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_sort` ON `${TABLE_NAME}` (`sort_order` DESC, `modified_at` DESC)"
+          },
+          {
+            "name": "index_favorite_playlist_visibility",
+            "unique": false,
+            "columnNames": [
+              "is_deleted",
+              "sort_order"
+            ],
+            "orders": [
+              "ASC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_visibility` ON `${TABLE_NAME}` (`is_deleted` ASC, `sort_order` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `song_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `source`, `display_position`), FOREIGN KEY(`playlist_id`, `source`) REFERENCES `favorite_playlist`(`playlist_id`, `source`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songPayloadJson",
+            "columnName": "song_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source",
+            "display_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_song_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_song_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `source` ASC, `display_position` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "favorite_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "source"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "source"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "traffic_stats_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `wifi_bytes` INTEGER NOT NULL, `mobile_bytes` INTEGER NOT NULL, `roaming_bytes` INTEGER NOT NULL, `playback_network_bytes` INTEGER NOT NULL, `download_network_bytes` INTEGER NOT NULL, `cache_hit_bytes` INTEGER NOT NULL, `request_count` INTEGER NOT NULL, `cache_hit_count` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`))",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wifiBytes",
+            "columnName": "wifi_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mobileBytes",
+            "columnName": "mobile_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roamingBytes",
+            "columnName": "roaming_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackNetworkBytes",
+            "columnName": "playback_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadNetworkBytes",
+            "columnName": "download_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitBytes",
+            "columnName": "cache_hit_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestCount",
+            "columnName": "request_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitCount",
+            "columnName": "cache_hit_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traffic_stats_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traffic_stats_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `current_index` INTEGER NOT NULL, `media_url` TEXT, `position_ms` INTEGER NOT NULL, `should_resume_playback` INTEGER NOT NULL, `repeat_mode` INTEGER, `shuffle_enabled` INTEGER, `shuffle_restore_index` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "current_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUrl",
+            "columnName": "media_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldResumePlayback",
+            "columnName": "should_resume_playback",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeat_mode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffle_enabled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleRestoreIndex",
+            "columnName": "shuffle_restore_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_queue_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`queue_id` TEXT NOT NULL, `position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `stream_url` TEXT, PRIMARY KEY(`queue_id`, `position`))",
+        "fields": [
+          {
+            "fieldPath": "queueId",
+            "columnName": "queue_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "queue_id",
+            "position"
+          ]
+        }
+      },
+      {
+        "tableName": "bili_video_skip_rule",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`))",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bili_video_skip_rule_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bili_video_skip_rule_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_interval",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `position` INTEGER NOT NULL, `start_ms` INTEGER NOT NULL, `end_ms` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`, `position`), FOREIGN KEY(`bvid`, `cid`) REFERENCES `bili_video_skip_rule`(`bvid`, `cid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startMs",
+            "columnName": "start_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endMs",
+            "columnName": "end_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid",
+            "position"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "bili_video_skip_rule",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bvid",
+              "cid"
+            ],
+            "referencedColumns": [
+              "bvid",
+              "cid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_draft",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`target_key` TEXT NOT NULL, `bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `start_text` TEXT NOT NULL, `end_text` TEXT NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`target_key`))",
+        "fields": [
+          {
+            "fieldPath": "targetKey",
+            "columnName": "target_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startText",
+            "columnName": "start_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endText",
+            "columnName": "end_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "target_key"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a81aec5900f30fb6324fc2782f28658d')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogRoomStoreTest.kt
@@ -1,0 +1,114 @@
+package moe.ouom.neriplayer.core.download.catalog
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.io.File
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.core.download.DownloadedSong
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DownloadedSongCatalogRoomStoreTest {
+    @Test
+    fun persistAndRestoreKeepsMetadataAndRootIsolation() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        try {
+            var rootKey = "root-a"
+            val store = DownloadedSongCatalogRoomStore(
+                context = context,
+                database = database,
+                cacheFileName = "unused-catalog.json",
+                snapshotCacheKeyProvider = { rootKey },
+                loggerTag = "DownloadedSongCatalogRoomStoreTest"
+            )
+            val song = song("first", "/music/first.mp3")
+
+            store.persist(listOf(song))
+
+            assertEquals(listOf(song), store.restore())
+            rootKey = "root-b"
+            assertNull(store.restore())
+            assertTrue(
+                database.syncMetadataDao()
+                    .getMigrationMetadata(
+                        DownloadedSongCatalogRoomStore.CUTOVER_STATE_METADATA_KEY
+                    )
+                    ?.value == DownloadedSongCatalogRoomStore.ROOM_PRIMARY_STATE
+            )
+        } finally {
+            database.close()
+        }
+    }
+
+    @Test
+    fun importsLegacyCatalogBeforePromotingRoom() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        val cacheFileName = "downloaded-song-catalog-room-test.json"
+        val cacheFile = File(context.filesDir, cacheFileName)
+        val song = song("legacy", "/music/legacy.mp3")
+        cacheFile.writeText(
+            serializeDownloadedSongsCatalog(
+                cacheKey = "root-a",
+                songs = listOf(song)
+            )
+        )
+
+        try {
+            val store = DownloadedSongCatalogRoomStore(
+                context = context,
+                database = database,
+                cacheFileName = cacheFileName,
+                snapshotCacheKeyProvider = { "root-a" },
+                loggerTag = "DownloadedSongCatalogRoomStoreTest"
+            )
+
+            assertEquals(
+                listOf(song.copy(matchedLyric = null, matchedTranslatedLyric = null)),
+                store.restore()
+            )
+            assertTrue(cacheFile.exists())
+            assertEquals(
+                DownloadedSongCatalogRoomStore.ROOM_PRIMARY_STATE,
+                database.syncMetadataDao()
+                    .getMigrationMetadata(
+                        DownloadedSongCatalogRoomStore.CUTOVER_STATE_METADATA_KEY
+                    )
+                    ?.value
+            )
+        } finally {
+            cacheFile.delete()
+            database.close()
+        }
+    }
+
+    private fun song(name: String, filePath: String): DownloadedSong {
+        return DownloadedSong(
+            id = 1L,
+            name = name,
+            artist = "artist",
+            album = "album",
+            filePath = filePath,
+            fileSize = 100L,
+            downloadTime = 20L,
+            matchedLyric = "lyric",
+            matchedTranslatedLyric = "translation",
+            durationMs = 180_000L,
+            stableKey = "1|netease|"
+        )
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/download/storage/queue/DownloadRecoveryRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/download/storage/queue/DownloadRecoveryRoomStoreTest.kt
@@ -1,0 +1,164 @@
+package moe.ouom.neriplayer.core.download.storage.queue
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.io.File
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
+import moe.ouom.neriplayer.core.download.storage.CANCELLED_DOWNLOAD_KEYS_FILE_NAME
+import moe.ouom.neriplayer.core.download.storage.ManagedDownloadStorageJsonCodec
+import moe.ouom.neriplayer.core.download.storage.PENDING_DOWNLOAD_QUEUE_FILE_NAME
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.model.stableKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DownloadRecoveryRoomStoreTest {
+    @Test
+    fun queueAndCancellationRoundTripWithoutRewritingLegacyFiles() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        val queueFile = File(context.filesDir, PENDING_DOWNLOAD_QUEUE_FILE_NAME)
+        val cancelledFile = File(context.filesDir, CANCELLED_DOWNLOAD_KEYS_FILE_NAME)
+        queueFile.delete()
+        cancelledFile.delete()
+
+        try {
+            val first = song(1L, "first")
+            val second = song(2L, "second")
+            val store = DownloadRecoveryRoomStore(context, database)
+
+            store.upsertPendingDownloadQueue(listOf(first, second), nowMs = 10L)
+            store.upsertPendingDownloadQueue(listOf(first.copy(name = "updated")), nowMs = 20L)
+            store.markCancelledDownloadKeys(listOf(second.stableKey()), nowMs = 30L)
+
+            val queued = store.listPendingQueuedDownloads()
+            assertEquals(listOf("first", "second"), queued.map { it.song.name })
+            assertEquals(10L, queued.first().queuedAtMs)
+            assertEquals("updated", queued.first().song.name)
+            assertEquals(setOf(second.stableKey()), store.listCancelledDownloadKeys())
+            assertTrue(!queueFile.exists())
+            assertTrue(!cancelledFile.exists())
+
+            store.removePendingDownloadQueueEntries(listOf(first.stableKey()))
+            store.removeCancelledDownloadKeys(listOf(second.stableKey()))
+            assertEquals(listOf("second"), store.listPendingQueuedDownloads().map { it.song.name })
+            assertTrue(store.listCancelledDownloadKeys().isEmpty())
+        } finally {
+            queueFile.delete()
+            cancelledFile.delete()
+            database.close()
+        }
+    }
+
+    @Test
+    fun importsLegacyFilesBeforePromotingRoom() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        val queueFile = File(context.filesDir, PENDING_DOWNLOAD_QUEUE_FILE_NAME)
+        val cancelledFile = File(context.filesDir, CANCELLED_DOWNLOAD_KEYS_FILE_NAME)
+        val first = song(3L, "legacy")
+        queueFile.writeText(
+            ManagedDownloadStorageJsonCodec.serializePendingDownloadQueuePayload(
+                entries = listOf(
+                    ManagedDownloadStorage.PendingDownloadQueueEntry(
+                        stableKey = first.stableKey(),
+                        song = first,
+                        order = 0,
+                        queuedAtMs = 40L
+                    )
+                ),
+                updatedAtMs = 40L
+            )
+        )
+        cancelledFile.writeText(
+            ManagedDownloadStorageJsonCodec.serializeCancelledDownloadKeysPayload(
+                songKeys = setOf(first.stableKey()),
+                updatedAtMs = 40L
+            )
+        )
+
+        try {
+            val store = DownloadRecoveryRoomStore(context, database)
+
+            assertEquals(listOf("legacy"), store.listPendingQueuedDownloads().map { it.song.name })
+            assertEquals(setOf(first.stableKey()), store.listCancelledDownloadKeys())
+            assertEquals(
+                DownloadRecoveryRoomStore.ROOM_PRIMARY_STATE,
+                database.syncMetadataDao()
+                    .getMigrationMetadata(
+                        DownloadRecoveryRoomStore.PENDING_QUEUE_CUTOVER_STATE_KEY
+                    )
+                    ?.value
+            )
+            assertEquals(
+                DownloadRecoveryRoomStore.ROOM_PRIMARY_STATE,
+                database.syncMetadataDao()
+                    .getMigrationMetadata(
+                        DownloadRecoveryRoomStore.CANCELLED_KEYS_CUTOVER_STATE_KEY
+                    )
+                    ?.value
+            )
+            assertTrue(queueFile.exists())
+            assertTrue(cancelledFile.exists())
+        } finally {
+            queueFile.delete()
+            cancelledFile.delete()
+            database.close()
+        }
+    }
+
+    @Test
+    fun malformedLegacyFileDoesNotPromoteRoom() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        val queueFile = File(context.filesDir, PENDING_DOWNLOAD_QUEUE_FILE_NAME)
+        queueFile.writeText("{malformed")
+
+        try {
+            val store = DownloadRecoveryRoomStore(context, database)
+
+            assertTrue(store.listPendingQueuedDownloads().isEmpty())
+            assertEquals(
+                null,
+                database.syncMetadataDao()
+                    .getMigrationMetadata(
+                        DownloadRecoveryRoomStore.PENDING_QUEUE_CUTOVER_STATE_KEY
+                    )
+            )
+            assertTrue(queueFile.exists())
+        } finally {
+            queueFile.delete()
+            database.close()
+        }
+    }
+
+    private fun song(id: Long, name: String): SongItem {
+        return SongItem(
+            id = id,
+            name = name,
+            artist = "artist",
+            album = "album",
+            albumId = 10L,
+            durationMs = 180_000L,
+            coverUrl = null,
+            channelId = "netease",
+            audioId = id.toString()
+        )
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/download/storage/queue/DownloadRecoveryRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/download/storage/queue/DownloadRecoveryRoomStoreTest.kt
@@ -42,7 +42,7 @@ class DownloadRecoveryRoomStoreTest {
             store.markCancelledDownloadKeys(listOf(second.stableKey()), nowMs = 30L)
 
             val queued = store.listPendingQueuedDownloads()
-            assertEquals(listOf("first", "second"), queued.map { it.song.name })
+            assertEquals(listOf("updated", "second"), queued.map { it.song.name })
             assertEquals(10L, queued.first().queuedAtMs)
             assertEquals("updated", queued.first().song.name)
             assertEquals(setOf(second.stableKey()), store.listCancelledDownloadKeys())

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomStoreTest.kt
@@ -83,6 +83,73 @@ class ManagedDownloadSnapshotRoomStoreTest {
         }
     }
 
+    @Test
+    fun clearDeletesLegacyCacheAndLeavesRoomAsEmptyPrimary() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        val cacheFile = ManagedDownloadSnapshotDiskCache.cacheFile(context)
+        cacheFile.delete()
+        cacheFile.writeText(
+            ManagedDownloadSnapshotIndex.serializePayload(
+                cacheKey = "root-a",
+                snapshot = snapshot()
+            ),
+            Charsets.UTF_8
+        )
+
+        try {
+            val store = ManagedDownloadSnapshotRoomStore(context, database)
+
+            assertTrue(store.clear())
+            assertFalse(cacheFile.exists())
+            assertNull(store.restore(expectedKey = "root-a"))
+            assertEquals(
+                ManagedDownloadSnapshotRoomStore.ROOM_PRIMARY_STATE,
+                database.syncMetadataDao()
+                    .getMigrationMetadata(
+                        ManagedDownloadSnapshotRoomStore.CUTOVER_STATE_METADATA_KEY
+                    )
+                    ?.value
+            )
+        } finally {
+            cacheFile.delete()
+            database.close()
+        }
+    }
+
+    @Test
+    fun clearKeepsLegacyCacheWhenRoomClearFails() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        val cacheFile = ManagedDownloadSnapshotDiskCache.cacheFile(context)
+        cacheFile.delete()
+        cacheFile.writeText(
+            ManagedDownloadSnapshotIndex.serializePayload(
+                cacheKey = "root-a",
+                snapshot = snapshot()
+            ),
+            Charsets.UTF_8
+        )
+        val store = ManagedDownloadSnapshotRoomStore(context, database)
+        database.openHelper.writableDatabase.execSQL(
+            "DROP TABLE download_snapshot_entry"
+        )
+
+        try {
+            assertFalse(store.clear())
+            assertTrue(cacheFile.exists())
+        } finally {
+            cacheFile.delete()
+            database.close()
+        }
+    }
+
     private fun snapshot(): ManagedDownloadStorage.DownloadLibrarySnapshot {
         val audioEntry = ManagedDownloadStorage.StoredEntry(
             name = "Artist - Snapshot Song.flac",

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomStoreTest.kt
@@ -1,0 +1,123 @@
+package moe.ouom.neriplayer.core.download.storage.snapshot
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ManagedDownloadSnapshotRoomStoreTest {
+    @Test
+    fun persistAndRestoreKeepsSnapshotIndexesAndRootIsolation() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        try {
+            val store = ManagedDownloadSnapshotRoomStore(context, database)
+            val snapshot = snapshot()
+
+            assertTrue(store.persist("root-a", snapshot))
+
+            val restored = store.restore(expectedKey = "root-a")
+            assertEquals("root-a", restored?.first)
+            assertEquals(snapshot.audioEntries, restored?.second?.audioEntries)
+            assertEquals(
+                snapshot.metadataByAudioName,
+                restored?.second?.metadataByAudioName
+            )
+            assertEquals(
+                snapshot.audioEntriesByRemoteTrackKey,
+                restored?.second?.audioEntriesByRemoteTrackKey
+            )
+            assertNull(store.restore(expectedKey = "root-b"))
+        } finally {
+            database.close()
+        }
+    }
+
+    @Test
+    fun importsLegacyDiskCacheAndDeletesJsonAfterRoomPromotion() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        val cacheFile = ManagedDownloadSnapshotDiskCache.cacheFile(context)
+        cacheFile.delete()
+        cacheFile.writeText(
+            ManagedDownloadSnapshotIndex.serializePayload(
+                cacheKey = "root-a",
+                snapshot = snapshot()
+            ),
+            Charsets.UTF_8
+        )
+
+        try {
+            val store = ManagedDownloadSnapshotRoomStore(context, database)
+            val restored = store.restore(expectedKey = "root-a")
+
+            assertEquals("root-a", restored?.first)
+            assertFalse(cacheFile.exists())
+            assertEquals(
+                ManagedDownloadSnapshotRoomStore.ROOM_PRIMARY_STATE,
+                database.syncMetadataDao()
+                    .getMigrationMetadata(
+                        ManagedDownloadSnapshotRoomStore.CUTOVER_STATE_METADATA_KEY
+                    )
+                    ?.value
+            )
+        } finally {
+            cacheFile.delete()
+            database.close()
+        }
+    }
+
+    private fun snapshot(): ManagedDownloadStorage.DownloadLibrarySnapshot {
+        val audioEntry = ManagedDownloadStorage.StoredEntry(
+            name = "Artist - Snapshot Song.flac",
+            reference = "/music/Artist - Snapshot Song.flac",
+            mediaUri = "file:///music/Artist%20-%20Snapshot%20Song.flac",
+            localFilePath = "/music/Artist - Snapshot Song.flac",
+            sizeBytes = 4096L,
+            lastModifiedMs = 100L
+        )
+        val metadataEntry = ManagedDownloadStorage.StoredEntry(
+            name = "Artist - Snapshot Song.flac.npmeta.json",
+            reference = "/music/Artist - Snapshot Song.flac.npmeta.json",
+            mediaUri = "file:///music/Artist%20-%20Snapshot%20Song.flac.npmeta.json",
+            localFilePath = "/music/Artist - Snapshot Song.flac.npmeta.json",
+            sizeBytes = 256L,
+            lastModifiedMs = 101L
+        )
+        val metadata = ManagedDownloadStorage.DownloadedAudioMetadata(
+            stableKey = "snapshot-stable",
+            songId = 55L,
+            identityAlbum = "NeteaseAlbum",
+            name = "Snapshot Song",
+            artist = "Artist",
+            mediaUri = "https://example.com/snapshot.flac",
+            channelId = "netease",
+            audioId = "55",
+            durationMs = 180_000L,
+            downloadFinalized = true
+        )
+        return ManagedDownloadSnapshotIndex.compose(
+            audioEntries = listOf(audioEntry),
+            metadataEntries = listOf(metadataEntry),
+            metadataByAudioName = mapOf(audioEntry.name to metadata),
+            coverEntries = emptyList(),
+            lyricEntries = emptyList()
+        )
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/player/lyrics/FloatingLyricsLongPressDragControllerTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/player/lyrics/FloatingLyricsLongPressDragControllerTest.kt
@@ -24,8 +24,8 @@ class FloatingLyricsLongPressDragControllerTest {
             touchSlopPx = 12f,
             initialPositionProvider = { Point(0, 0) },
             onDragStarted = { dragStartCount += 1 },
-            onDragPositionChanged = { _, _ -> Unit },
-            onDragEnded = { _, _ -> Unit }
+            onDragPositionChanged = { _, _ -> },
+            onDragEnded = { _, _ -> }
         )
         val down = MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_DOWN, 16f, 24f, 0)
         val up = MotionEvent.obtain(0L, 8L, MotionEvent.ACTION_UP, 16f, 24f, 0)

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStoreTest.kt
@@ -11,6 +11,7 @@ import moe.ouom.neriplayer.core.player.model.PersistedSongItem
 import moe.ouom.neriplayer.core.player.model.PersistedState
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -38,7 +39,8 @@ class PlaybackQueueRoomStoreTest {
                 repeatMode = 2,
                 shuffleEnabled = true,
                 shuffleRestorePlaylist = listOf(second, first),
-                shuffleRestoreIndex = 0
+                shuffleRestoreIndex = 0,
+                sourceRoute = "local_playlist_detail/42"
             )
             val store = PlaybackQueueRoomStore(database)
 
@@ -108,12 +110,114 @@ class PlaybackQueueRoomStoreTest {
             store.clear()
 
             assertNull(database.playbackQueueDao().getState())
+            assertNull(
+                database.syncMetadataDao().getMigrationMetadata(
+                    PlaybackQueueRoomStore.SOURCE_ROUTE_METADATA_KEY
+                )
+            )
             assertTrue(
                 database.syncMetadataDao().getMigrationMetadata(
                     PlaybackQueueRoomStore.CUTOVER_STATE_METADATA_KEY
                 )?.value == PlaybackQueueRoomStore.ROOM_PRIMARY_STATE
             )
             assertNull(store.readIfRoomPrimary())
+        } finally {
+            database.close()
+        }
+    }
+
+    @Test
+    fun sourceRouteSurvivesDatabaseReopen() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val databaseName = "playback_queue_room_store_${System.nanoTime()}.db"
+        val firstDatabase = Room.databaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java,
+            databaseName
+        ).allowMainThreadQueries().build()
+
+        try {
+            PlaybackQueueRoomStore(firstDatabase).replaceSnapshot(
+                PersistedState(
+                    playlist = listOf(song(1L, "first")),
+                    index = 0,
+                    sourceRoute = "local_playlist_detail/42"
+                ),
+                now = 10L
+            )
+        } finally {
+            firstDatabase.close()
+        }
+
+        val reopenedDatabase = Room.databaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java,
+            databaseName
+        ).allowMainThreadQueries().build()
+        try {
+            assertEquals(
+                "local_playlist_detail/42",
+                PlaybackQueueRoomStore(reopenedDatabase)
+                    .readIfRoomPrimary()
+                    ?.sourceRoute
+            )
+        } finally {
+            reopenedDatabase.close()
+            context.deleteDatabase(databaseName)
+        }
+    }
+
+    @Test
+    fun oversizedSourceRouteClearsPreviousValue() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val store = PlaybackQueueRoomStore(database)
+            store.replaceSnapshot(
+                PersistedState(
+                    playlist = listOf(song(1L, "first")),
+                    index = 0,
+                    sourceRoute = "local_playlist_detail/42"
+                ),
+                now = 10L
+            )
+            store.updateSourceRoute("x".repeat(16 * 1024 + 1), now = 20L)
+
+            assertNull(store.readIfRoomPrimary()?.sourceRoute)
+            assertNull(
+                database.syncMetadataDao().getMigrationMetadata(
+                    PlaybackQueueRoomStore.SOURCE_ROUTE_METADATA_KEY
+                )
+            )
+        } finally {
+            database.close()
+        }
+    }
+
+    @Test
+    fun routeOnlyUpdateDoesNotPromoteRoomBeforeQueueCutover() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val store = PlaybackQueueRoomStore(database)
+            store.updateSourceRoute("local_playlist_detail/42", now = 10L)
+
+            assertFalse(store.isRoomPrimary())
+            assertNull(store.readIfRoomPrimary())
+            assertEquals(
+                "local_playlist_detail/42",
+                database.syncMetadataDao().getMigrationMetadata(
+                    PlaybackQueueRoomStore.SOURCE_ROUTE_METADATA_KEY
+                )?.value
+            )
         } finally {
             database.close()
         }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStoreTest.kt
@@ -1,0 +1,132 @@
+package moe.ouom.neriplayer.core.player.persistence
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.core.api.search.MusicPlatform
+import moe.ouom.neriplayer.core.player.model.PersistedPlaybackState
+import moe.ouom.neriplayer.core.player.model.PersistedSongItem
+import moe.ouom.neriplayer.core.player.model.PersistedState
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PlaybackQueueRoomStoreTest {
+    @Test
+    fun snapshotRoundTripKeepsQueueOrderAndPlaybackFields() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val first = song(1L, "first")
+            val second = song(2L, "second")
+            val state = PersistedState(
+                playlist = listOf(first, second),
+                index = 1,
+                mediaUrl = "https://example.test/stream",
+                positionMs = 4_200L,
+                shouldResumePlayback = true,
+                repeatMode = 2,
+                shuffleEnabled = true,
+                shuffleRestorePlaylist = listOf(second, first),
+                shuffleRestoreIndex = 0
+            )
+            val store = PlaybackQueueRoomStore(database)
+
+            store.replaceSnapshot(state, now = 10L)
+
+            assertEquals(state, store.readIfRoomPrimary())
+        } finally {
+            database.close()
+        }
+    }
+
+    @Test
+    fun playbackOnlyUpdatePreservesShuffleRestoreIndex() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val store = PlaybackQueueRoomStore(database)
+            store.replaceSnapshot(
+                PersistedState(
+                    playlist = listOf(song(1L, "first")),
+                    index = 0,
+                    shuffleEnabled = true,
+                    shuffleRestorePlaylist = listOf(song(1L, "first")),
+                    shuffleRestoreIndex = 3
+                ),
+                now = 10L
+            )
+
+            store.updatePlaybackState(
+                PersistedPlaybackState(
+                    index = 0,
+                    positionMs = 7_000L,
+                    shouldResumePlayback = true,
+                    shuffleEnabled = true
+                ),
+                now = 20L
+            )
+
+            assertEquals(3, database.playbackQueueDao().getState()?.shuffleRestoreIndex)
+            assertEquals(7_000L, store.readIfRoomPrimary()?.positionMs)
+        } finally {
+            database.close()
+        }
+    }
+
+    @Test
+    fun clearRemovesStateButKeepsRoomPrimaryMarker() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val store = PlaybackQueueRoomStore(database)
+            store.replaceSnapshot(
+                PersistedState(playlist = listOf(song(1L, "first")), index = 0)
+            )
+            store.clear()
+
+            assertNull(database.playbackQueueDao().getState())
+            assertTrue(
+                database.syncMetadataDao().getMigrationMetadata(
+                    PlaybackQueueRoomStore.CUTOVER_STATE_METADATA_KEY
+                )?.value == PlaybackQueueRoomStore.ROOM_PRIMARY_STATE
+            )
+            assertNull(store.readIfRoomPrimary())
+        } finally {
+            database.close()
+        }
+    }
+
+    private fun song(id: Long, name: String): PersistedSongItem {
+        return PersistedSongItem(
+            id = id,
+            name = name,
+            artist = "artist",
+            album = "album",
+            albumId = 10L,
+            durationMs = 180_000L,
+            coverUrl = null,
+            matchedLyricSource = MusicPlatform.CLOUD_MUSIC,
+            channelId = "netease",
+            audioId = id.toString()
+        )
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStoreTest.kt
@@ -43,6 +43,10 @@ class PlaybackQueueRoomStoreTest {
             val store = PlaybackQueueRoomStore(database)
 
             store.replaceSnapshot(state, now = 10L)
+            store.importLegacyAndPromote(
+                PersistedState(playlist = emptyList(), index = 0),
+                now = 20L
+            )
 
             assertEquals(state, store.readIfRoomPrimary())
         } finally {

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -19,12 +19,12 @@ class NeriUserDataDatabaseMigrationTest {
     )
 
     @Test
-    fun migrateFromVersion1ToVersion8() {
+    fun migrateFromVersion1ToVersion9() {
         helper.createDatabase(TEST_DATABASE_NAME, 1).close()
 
         helper.runMigrationsAndValidate(
             TEST_DATABASE_NAME,
-            8,
+            9,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
             NeriUserDataDatabase.MIGRATION_2_3,
@@ -32,7 +32,8 @@ class NeriUserDataDatabaseMigrationTest {
             NeriUserDataDatabase.MIGRATION_4_5,
             NeriUserDataDatabase.MIGRATION_5_6,
             NeriUserDataDatabase.MIGRATION_6_7,
-            NeriUserDataDatabase.MIGRATION_7_8
+            NeriUserDataDatabase.MIGRATION_7_8,
+            NeriUserDataDatabase.MIGRATION_8_9
         ).close()
     }
 

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -19,18 +19,19 @@ class NeriUserDataDatabaseMigrationTest {
     )
 
     @Test
-    fun migrateFromVersion1ToVersion6() {
+    fun migrateFromVersion1ToVersion7() {
         helper.createDatabase(TEST_DATABASE_NAME, 1).close()
 
         helper.runMigrationsAndValidate(
             TEST_DATABASE_NAME,
-            6,
+            7,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
             NeriUserDataDatabase.MIGRATION_2_3,
             NeriUserDataDatabase.MIGRATION_3_4,
             NeriUserDataDatabase.MIGRATION_4_5,
-            NeriUserDataDatabase.MIGRATION_5_6
+            NeriUserDataDatabase.MIGRATION_5_6,
+            NeriUserDataDatabase.MIGRATION_6_7
         ).close()
     }
 

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -19,12 +19,12 @@ class NeriUserDataDatabaseMigrationTest {
     )
 
     @Test
-    fun migrateFromVersion1ToVersion13() {
+    fun migrateFromVersion1ToVersion14() {
         helper.createDatabase(TEST_DATABASE_NAME, 1).close()
 
         helper.runMigrationsAndValidate(
             TEST_DATABASE_NAME,
-            13,
+            14,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
             NeriUserDataDatabase.MIGRATION_2_3,
@@ -37,7 +37,8 @@ class NeriUserDataDatabaseMigrationTest {
             NeriUserDataDatabase.MIGRATION_9_10,
             NeriUserDataDatabase.MIGRATION_10_11,
             NeriUserDataDatabase.MIGRATION_11_12,
-            NeriUserDataDatabase.MIGRATION_12_13
+            NeriUserDataDatabase.MIGRATION_12_13,
+            NeriUserDataDatabase.MIGRATION_13_14
         ).close()
     }
 

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -19,19 +19,20 @@ class NeriUserDataDatabaseMigrationTest {
     )
 
     @Test
-    fun migrateFromVersion1ToVersion7() {
+    fun migrateFromVersion1ToVersion8() {
         helper.createDatabase(TEST_DATABASE_NAME, 1).close()
 
         helper.runMigrationsAndValidate(
             TEST_DATABASE_NAME,
-            7,
+            8,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
             NeriUserDataDatabase.MIGRATION_2_3,
             NeriUserDataDatabase.MIGRATION_3_4,
             NeriUserDataDatabase.MIGRATION_4_5,
             NeriUserDataDatabase.MIGRATION_5_6,
-            NeriUserDataDatabase.MIGRATION_6_7
+            NeriUserDataDatabase.MIGRATION_6_7,
+            NeriUserDataDatabase.MIGRATION_7_8
         ).close()
     }
 

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -19,12 +19,12 @@ class NeriUserDataDatabaseMigrationTest {
     )
 
     @Test
-    fun migrateFromVersion1ToVersion10() {
+    fun migrateFromVersion1ToVersion11() {
         helper.createDatabase(TEST_DATABASE_NAME, 1).close()
 
         helper.runMigrationsAndValidate(
             TEST_DATABASE_NAME,
-            10,
+            11,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
             NeriUserDataDatabase.MIGRATION_2_3,
@@ -34,7 +34,8 @@ class NeriUserDataDatabaseMigrationTest {
             NeriUserDataDatabase.MIGRATION_6_7,
             NeriUserDataDatabase.MIGRATION_7_8,
             NeriUserDataDatabase.MIGRATION_8_9,
-            NeriUserDataDatabase.MIGRATION_9_10
+            NeriUserDataDatabase.MIGRATION_9_10,
+            NeriUserDataDatabase.MIGRATION_10_11
         ).close()
     }
 

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -19,12 +19,12 @@ class NeriUserDataDatabaseMigrationTest {
     )
 
     @Test
-    fun migrateFromVersion1ToVersion11() {
+    fun migrateFromVersion1ToVersion13() {
         helper.createDatabase(TEST_DATABASE_NAME, 1).close()
 
         helper.runMigrationsAndValidate(
             TEST_DATABASE_NAME,
-            11,
+            13,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
             NeriUserDataDatabase.MIGRATION_2_3,
@@ -35,7 +35,9 @@ class NeriUserDataDatabaseMigrationTest {
             NeriUserDataDatabase.MIGRATION_7_8,
             NeriUserDataDatabase.MIGRATION_8_9,
             NeriUserDataDatabase.MIGRATION_9_10,
-            NeriUserDataDatabase.MIGRATION_10_11
+            NeriUserDataDatabase.MIGRATION_10_11,
+            NeriUserDataDatabase.MIGRATION_11_12,
+            NeriUserDataDatabase.MIGRATION_12_13
         ).close()
     }
 

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -19,12 +19,12 @@ class NeriUserDataDatabaseMigrationTest {
     )
 
     @Test
-    fun migrateFromVersion1ToVersion9() {
+    fun migrateFromVersion1ToVersion10() {
         helper.createDatabase(TEST_DATABASE_NAME, 1).close()
 
         helper.runMigrationsAndValidate(
             TEST_DATABASE_NAME,
-            9,
+            10,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
             NeriUserDataDatabase.MIGRATION_2_3,
@@ -33,7 +33,8 @@ class NeriUserDataDatabaseMigrationTest {
             NeriUserDataDatabase.MIGRATION_5_6,
             NeriUserDataDatabase.MIGRATION_6_7,
             NeriUserDataDatabase.MIGRATION_7_8,
-            NeriUserDataDatabase.MIGRATION_8_9
+            NeriUserDataDatabase.MIGRATION_8_9,
+            NeriUserDataDatabase.MIGRATION_9_10
         ).close()
     }
 

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -19,15 +19,16 @@ class NeriUserDataDatabaseMigrationTest {
     )
 
     @Test
-    fun migrateFromVersion1ToVersion3() {
+    fun migrateFromVersion1ToVersion4() {
         helper.createDatabase(TEST_DATABASE_NAME, 1).close()
 
         helper.runMigrationsAndValidate(
             TEST_DATABASE_NAME,
-            3,
+            4,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
-            NeriUserDataDatabase.MIGRATION_2_3
+            NeriUserDataDatabase.MIGRATION_2_3,
+            NeriUserDataDatabase.MIGRATION_3_4
         ).close()
     }
 

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -1,0 +1,37 @@
+package moe.ouom.neriplayer.data.local.database
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NeriUserDataDatabaseMigrationTest {
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        NeriUserDataDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory()
+    )
+
+    @Test
+    fun migrateFromVersion1ToVersion3() {
+        helper.createDatabase(TEST_DATABASE_NAME, 1).close()
+
+        helper.runMigrationsAndValidate(
+            TEST_DATABASE_NAME,
+            3,
+            true,
+            NeriUserDataDatabase.MIGRATION_1_2,
+            NeriUserDataDatabase.MIGRATION_2_3
+        ).close()
+    }
+
+    private companion object {
+        const val TEST_DATABASE_NAME = "neri-user-data-migration-test"
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -19,16 +19,17 @@ class NeriUserDataDatabaseMigrationTest {
     )
 
     @Test
-    fun migrateFromVersion1ToVersion4() {
+    fun migrateFromVersion1ToVersion5() {
         helper.createDatabase(TEST_DATABASE_NAME, 1).close()
 
         helper.runMigrationsAndValidate(
             TEST_DATABASE_NAME,
-            4,
+            5,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
             NeriUserDataDatabase.MIGRATION_2_3,
-            NeriUserDataDatabase.MIGRATION_3_4
+            NeriUserDataDatabase.MIGRATION_3_4,
+            NeriUserDataDatabase.MIGRATION_4_5
         ).close()
     }
 

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Rule
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,14 +23,14 @@ class NeriUserDataDatabaseMigrationTest {
     )
 
     @Test
-    fun migrateFromVersion1ToVersion14() {
+    fun migrateFromVersion1ToVersion15() {
         helper.createDatabase(EMPTY_SCHEMA_DATABASE_NAME, 1).close()
 
         migrateToCurrent(EMPTY_SCHEMA_DATABASE_NAME).close()
     }
 
     @Test
-    fun migrateFromVersion1ToVersion14PreservesLocalPlaylistAndSyncRecords() {
+    fun migrateFromVersion1ToVersion15PreservesLocalPlaylistAndSyncRecords() {
         helper.createDatabase(DATA_PRESERVATION_DATABASE_NAME, 1).use { database ->
             insertVersion1Records(database)
         }
@@ -45,17 +46,80 @@ class NeriUserDataDatabaseMigrationTest {
             }
             assertRowCount(database, "track", 1)
             assertRowCount(database, "playlist_member", 1)
+            assertRowCount(database, "playlist_member_netease_artist", 0)
             assertRowCount(database, "playlist_member_token", 1)
             assertRowCount(database, "sync_outbox", 1)
             assertRowCount(database, "sync_replica_checkpoint", 1)
             assertRowCount(database, "migration_metadata", 1)
+            assertFalse(hasColumn(database, "track", "durable_payload_json"))
+            assertFalse(hasColumn(database, "playlist_member", "member_payload_json"))
+            database.query(
+                "SELECT `name`, `song_id` FROM `playlist_member` " +
+                    "WHERE `playlist_id` = 42"
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("Migration track", cursor.getString(0))
+                assertEquals(42L, cursor.getLong(1))
+            }
+        }
+    }
+
+    @Test
+    fun migrateFromVersion14StructuresFavoriteSongsAndToleratesBadPayload() {
+        helper.createDatabase(FAVORITE_MIGRATION_DATABASE_NAME, 14).use { database ->
+            database.execSQL(
+                """
+                INSERT INTO favorite_playlist (
+                    playlist_id, source, name, cover_url, track_count, browse_id,
+                    remote_playlist_id, subtitle, added_time, sort_order, modified_at,
+                    is_deleted
+                ) VALUES (99, 'netease', 'Migrated favorites', NULL, 2, NULL, NULL,
+                    NULL, 1, 2, 3, 0)
+                """.trimIndent()
+            )
+            database.execSQL(
+                """
+                INSERT INTO favorite_playlist_song (
+                    playlist_id, source, display_position, song_payload_json
+                ) VALUES (99, 'netease', 0,
+                    '{"id":7,"name":"Structured","artist":"Artist",
+                    "album":"Album","albumId":8,"durationMs":9000,
+                    "neteaseArtists":[{"id":11,"name":"Artist"}]}')
+                """.trimIndent()
+            )
+            database.execSQL(
+                """
+                INSERT INTO favorite_playlist_song (
+                    playlist_id, source, display_position, song_payload_json
+                ) VALUES (99, 'netease', 1, '{bad-json')
+                """.trimIndent()
+            )
+        }
+
+        helper.runMigrationsAndValidate(
+            FAVORITE_MIGRATION_DATABASE_NAME,
+            15,
+            true,
+            NeriUserDataDatabase.MIGRATION_14_15
+        ).use { database ->
+            assertFalse(hasColumn(database, "favorite_playlist_song", "song_payload_json"))
+            assertRowCount(database, "favorite_playlist_song", 2)
+            assertRowCount(database, "favorite_playlist_song_netease_artist", 1)
+            database.query(
+                "SELECT `name`, `id` FROM favorite_playlist_song " +
+                    "WHERE playlist_id = 99 AND display_position = 0"
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("Structured", cursor.getString(0))
+                assertEquals(7L, cursor.getLong(1))
+            }
         }
     }
 
     private fun migrateToCurrent(databaseName: String): SupportSQLiteDatabase {
         return helper.runMigrationsAndValidate(
             databaseName,
-            14,
+            15,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
             NeriUserDataDatabase.MIGRATION_2_3,
@@ -69,7 +133,8 @@ class NeriUserDataDatabaseMigrationTest {
             NeriUserDataDatabase.MIGRATION_10_11,
             NeriUserDataDatabase.MIGRATION_11_12,
             NeriUserDataDatabase.MIGRATION_12_13,
-            NeriUserDataDatabase.MIGRATION_13_14
+            NeriUserDataDatabase.MIGRATION_13_14,
+            NeriUserDataDatabase.MIGRATION_14_15
         )
     }
 
@@ -144,8 +209,23 @@ class NeriUserDataDatabaseMigrationTest {
         }
     }
 
+    private fun hasColumn(
+        database: SupportSQLiteDatabase,
+        tableName: String,
+        columnName: String
+    ): Boolean {
+        database.query("PRAGMA table_info(`$tableName`)").use { cursor ->
+            val nameIndex = cursor.getColumnIndexOrThrow("name")
+            while (cursor.moveToNext()) {
+                if (cursor.getString(nameIndex) == columnName) return true
+            }
+        }
+        return false
+    }
+
     private companion object {
         const val EMPTY_SCHEMA_DATABASE_NAME = "neri-user-data-migration-empty-test"
         const val DATA_PRESERVATION_DATABASE_NAME = "neri-user-data-migration-data-test"
+        const val FAVORITE_MIGRATION_DATABASE_NAME = "neri-user-data-migration-favorite-test"
     }
 }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -19,17 +19,18 @@ class NeriUserDataDatabaseMigrationTest {
     )
 
     @Test
-    fun migrateFromVersion1ToVersion5() {
+    fun migrateFromVersion1ToVersion6() {
         helper.createDatabase(TEST_DATABASE_NAME, 1).close()
 
         helper.runMigrationsAndValidate(
             TEST_DATABASE_NAME,
-            5,
+            6,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
             NeriUserDataDatabase.MIGRATION_2_3,
             NeriUserDataDatabase.MIGRATION_3_4,
-            NeriUserDataDatabase.MIGRATION_4_5
+            NeriUserDataDatabase.MIGRATION_4_5,
+            NeriUserDataDatabase.MIGRATION_5_6
         ).close()
     }
 

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -1,10 +1,13 @@
 package moe.ouom.neriplayer.data.local.database
 
 import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Rule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -20,10 +23,38 @@ class NeriUserDataDatabaseMigrationTest {
 
     @Test
     fun migrateFromVersion1ToVersion14() {
-        helper.createDatabase(TEST_DATABASE_NAME, 1).close()
+        helper.createDatabase(EMPTY_SCHEMA_DATABASE_NAME, 1).close()
 
-        helper.runMigrationsAndValidate(
-            TEST_DATABASE_NAME,
+        migrateToCurrent(EMPTY_SCHEMA_DATABASE_NAME).close()
+    }
+
+    @Test
+    fun migrateFromVersion1ToVersion14PreservesLocalPlaylistAndSyncRecords() {
+        helper.createDatabase(DATA_PRESERVATION_DATABASE_NAME, 1).use { database ->
+            insertVersion1Records(database)
+        }
+
+        migrateToCurrent(DATA_PRESERVATION_DATABASE_NAME).use { database ->
+            database.query(
+                "SELECT `name`, `song_order_version` FROM `local_playlist` " +
+                    "WHERE `playlist_id` = 42"
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("Migration playlist", cursor.getString(0))
+                assertEquals(2, cursor.getInt(1))
+            }
+            assertRowCount(database, "track", 1)
+            assertRowCount(database, "playlist_member", 1)
+            assertRowCount(database, "playlist_member_token", 1)
+            assertRowCount(database, "sync_outbox", 1)
+            assertRowCount(database, "sync_replica_checkpoint", 1)
+            assertRowCount(database, "migration_metadata", 1)
+        }
+    }
+
+    private fun migrateToCurrent(databaseName: String): SupportSQLiteDatabase {
+        return helper.runMigrationsAndValidate(
+            databaseName,
             14,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
@@ -39,10 +70,82 @@ class NeriUserDataDatabaseMigrationTest {
             NeriUserDataDatabase.MIGRATION_11_12,
             NeriUserDataDatabase.MIGRATION_12_13,
             NeriUserDataDatabase.MIGRATION_13_14
-        ).close()
+        )
+    }
+
+    private fun insertVersion1Records(database: SupportSQLiteDatabase) {
+        database.execSQL(
+            """
+            INSERT INTO `local_playlist` (
+                `playlist_id`, `name`, `display_position`, `modified_at`,
+                `song_order_version`, `is_system`
+            ) VALUES (42, 'Migration playlist', 0, 1000, 2, 0)
+            """.trimIndent()
+        )
+        database.execSQL(
+            """
+            INSERT INTO `track` (
+                `identity_key`, `identity_id`, `identity_album`, `song_id`,
+                `name`, `artist`, `album`, `album_id`, `duration_ms`,
+                `payload_schema_version`, `durable_payload_json`
+            ) VALUES ('track-42', 42, 'album-42', 42, 'Migration track',
+                'Migration artist', 'Migration album', 42, 180000, 1, '{}')
+            """.trimIndent()
+        )
+        database.execSQL(
+            """
+            INSERT INTO `playlist_member` (
+                `playlist_id`, `identity_key`, `display_position`, `added_at`,
+                `order_tie_break`, `member_payload_schema_version`,
+                `member_payload_json`
+            ) VALUES (42, 'track-42', 0, 1000, 0, 1, '{}')
+            """.trimIndent()
+        )
+        database.execSQL(
+            """
+            INSERT INTO `playlist_member_token` (
+                `playlist_id`, `identity_key`, `device_id`, `counter`, `token_index`
+            ) VALUES (42, 'track-42', 'device-1', 1, 0)
+            """.trimIndent()
+        )
+        database.execSQL(
+            """
+            INSERT INTO `sync_outbox` (
+                `sequence`, `operation_id`, `expected_domain_revision`,
+                `payload_version`, `mutation_payload_json`, `status`,
+                `attempt_count`, `created_at`, `updated_at`
+            ) VALUES (1, 'operation-1', 1, 1, '{}', 'PENDING', 0, 1000, 1000)
+            """.trimIndent()
+        )
+        database.execSQL(
+            """
+            INSERT INTO `sync_replica_checkpoint` (
+                `transport_id`, `domain_revision`, `status`, `last_synced_at`,
+                `last_attempt_at`
+            ) VALUES ('github', 1, 'SYNCED', 1000, 1000)
+            """.trimIndent()
+        )
+        database.execSQL(
+            """
+            INSERT INTO `migration_metadata` (`key`, `value`, `updated_at`)
+            VALUES ('migration-test', 'complete', 1000)
+            """.trimIndent()
+        )
+    }
+
+    private fun assertRowCount(
+        database: SupportSQLiteDatabase,
+        tableName: String,
+        expectedCount: Int
+    ) {
+        database.query("SELECT COUNT(*) FROM `$tableName`").use { cursor ->
+            assertTrue(cursor.moveToFirst())
+            assertEquals(expectedCount, cursor.getInt(0))
+        }
     }
 
     private companion object {
-        const val TEST_DATABASE_NAME = "neri-user-data-migration-test"
+        const val EMPTY_SCHEMA_DATABASE_NAME = "neri-user-data-migration-empty-test"
+        const val DATA_PRESERVATION_DATABASE_NAME = "neri-user-data-migration-data-test"
     }
 }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/BiliVideoSkipRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/BiliVideoSkipRoomStoreTest.kt
@@ -1,0 +1,58 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.platform.bili.BiliVideoSkipDraft
+import moe.ouom.neriplayer.data.platform.bili.BiliVideoSkipInterval
+import moe.ouom.neriplayer.data.platform.bili.BiliVideoSkipRule
+import moe.ouom.neriplayer.data.platform.bili.BiliVideoSkipTarget
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BiliVideoSkipRoomStoreTest {
+    @Test
+    fun rulesAndDraftsRoundTripWithoutJsonPayloads() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val target = BiliVideoSkipTarget("BV1TEST", 12L)
+            val rule = BiliVideoSkipRule(
+                target = target,
+                intervals = listOf(
+                    BiliVideoSkipInterval(startMs = 1_000L, endMs = 2_000L),
+                    BiliVideoSkipInterval(startMs = 3_000L, endMs = 4_000L)
+                ),
+                modifiedAt = 20L
+            )
+            val draft = BiliVideoSkipDraft(
+                target = target,
+                startText = "00:01",
+                endText = "00:02",
+                modifiedAt = 21L
+            )
+            val store = BiliVideoSkipRoomStore(database)
+
+            store.replaceAll(listOf(rule), listOf(draft), now = 30L)
+
+            assertEquals(
+                BiliVideoSkipRoomSnapshot(listOf(rule), listOf(draft)),
+                store.readIfRoomPrimary()
+            )
+            assertEquals(1, database.biliVideoSkipDao().getRules().size)
+            assertEquals(2, database.biliVideoSkipDao().getIntervals().size)
+            assertEquals(1, database.biliVideoSkipDao().getDrafts().size)
+        } finally {
+            database.close()
+        }
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/BiliVideoSkipRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/BiliVideoSkipRoomStoreTest.kt
@@ -43,6 +43,7 @@ class BiliVideoSkipRoomStoreTest {
             val store = BiliVideoSkipRoomStore(database)
 
             store.replaceAll(listOf(rule), listOf(draft), now = 30L)
+            store.importLegacyAndPromote(emptyList(), emptyList(), now = 40L)
 
             assertEquals(
                 BiliVideoSkipRoomSnapshot(listOf(rule), listOf(draft)),

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/CoverUrlMappingRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/CoverUrlMappingRoomStoreTest.kt
@@ -29,6 +29,7 @@ class CoverUrlMappingRoomStoreTest {
 
             assertNull(store.readIfRoomPrimary())
             store.importLegacyAndPromote(mappings, cleanupEligible = true, now = 100L)
+            store.importLegacyAndPromote(emptyMap(), cleanupEligible = true, now = 200L)
 
             assertEquals(mappings, store.readIfRoomPrimary())
             val state = database.syncMetadataDao().getMigrationMetadata(

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/CoverUrlMappingRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/CoverUrlMappingRoomStoreTest.kt
@@ -1,0 +1,81 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CoverUrlMappingRoomStoreTest {
+    @Test
+    fun importLegacyAndPromoteMakesMappingsRoomPrimary() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val store = CoverUrlMappingRoomStore(database)
+            val mappings = mapOf(
+                "file:///covers/local.jpg" to "https://example.com/covers/local.jpg"
+            )
+
+            assertNull(store.readIfRoomPrimary())
+            store.importLegacyAndPromote(mappings, cleanupEligible = true, now = 100L)
+
+            assertEquals(mappings, store.readIfRoomPrimary())
+            val state = database.syncMetadataDao().getMigrationMetadata(
+                CoverUrlMappingRoomStore.CUTOVER_STATE_METADATA_KEY
+            )
+            assertEquals(CoverUrlMappingRoomStore.ROOM_PRIMARY_STATE, state?.value)
+        } finally {
+            database.close()
+        }
+    }
+
+    @Test
+    fun upsertKeepsLegacyImportFailureBlockedForCleanup() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val store = CoverUrlMappingRoomStore(database)
+            store.importLegacyAndPromote(
+                mappings = emptyMap(),
+                cleanupEligible = false,
+                now = 100L
+            )
+
+            store.upsert(
+                localUrl = "file:///covers/local.jpg",
+                networkUrl = "https://example.com/covers/local.jpg",
+                cleanupEligible = true,
+                now = 200L
+            )
+
+            assertEquals(
+                mapOf("file:///covers/local.jpg" to "https://example.com/covers/local.jpg"),
+                store.readIfRoomPrimary()
+            )
+            val state = database.syncMetadataDao().getMigrationMetadata(
+                CoverUrlMappingRoomStore.CUTOVER_STATE_METADATA_KEY
+            )
+            assertEquals(
+                CoverUrlMappingRoomStore.ROOM_PRIMARY_WITH_LEGACY_IMPORT_FAILURE_STATE,
+                state?.value
+            )
+        } finally {
+            database.close()
+        }
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStoreTest.kt
@@ -6,10 +6,12 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.test.runTest
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.data.playlist.favorite.FavoritePlaylist
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -129,6 +131,46 @@ class FavoritePlaylistRoomStoreTest {
 
             assertEquals(listOf(updatedFirst), store.readIfRoomPrimary())
             assertEquals(1, database.favoritePlaylistDao().getSongs().size)
+        } finally {
+            database.close()
+        }
+    }
+
+    @Test
+    fun staleLegacyMarkerPromotesExistingRoomDataWithoutReplacingIt() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        try {
+            val favorite = favorite(
+                id = 42L,
+                name = "Existing Room Favorite",
+                songs = listOf(testSong(1L, "Existing song"))
+            )
+            val store = FavoritePlaylistRoomStore(database)
+            store.replaceAll(listOf(favorite), now = 10L)
+            database.syncMetadataDao().upsertMigrationMetadata(
+                MigrationMetadataEntity(
+                    key = FavoritePlaylistRoomStore.CUTOVER_STATE_METADATA_KEY,
+                    value = "legacy_json",
+                    updatedAt = 20L
+                )
+            )
+
+            assertNull(store.readIfRoomPrimary())
+            assertEquals(
+                listOf(favorite),
+                store.promoteExistingAndRead(now = 30L)
+            )
+            assertEquals(listOf(favorite), store.readIfRoomPrimary())
+            assertEquals(
+                FavoritePlaylistRoomStore.ROOM_PRIMARY_STATE,
+                database.syncMetadataDao()
+                    .getMigrationMetadata(FavoritePlaylistRoomStore.CUTOVER_STATE_METADATA_KEY)
+                    ?.value
+            )
         } finally {
             database.close()
         }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStoreTest.kt
@@ -85,6 +85,73 @@ class FavoritePlaylistRoomStoreTest {
         }
     }
 
+    @Test
+    fun incrementalWritePreservesUnchangedFavoritesAndReplacesChangedSongs() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        try {
+            val first = favorite(
+                id = 1L,
+                name = "First",
+                songs = listOf(testSong(1L, "First song"))
+            )
+            val second = favorite(
+                id = 2L,
+                name = "Second",
+                songs = listOf(testSong(2L, "Second song"))
+            )
+            val store = FavoritePlaylistRoomStore(database)
+            store.replaceAll(listOf(first, second))
+
+            val updatedFirst = first.copy(
+                name = "First updated",
+                songs = listOf(testSong(3L, "Replacement song")),
+                modifiedAt = 20L
+            )
+            store.writeIncremental(
+                previous = listOf(first, second),
+                next = listOf(updatedFirst, second)
+            )
+
+            assertEquals(
+                listOf(updatedFirst, second),
+                store.readIfRoomPrimary()
+            )
+            assertEquals(2, database.favoritePlaylistDao().getSongs().size)
+
+            store.writeIncremental(
+                previous = listOf(updatedFirst, second),
+                next = listOf(updatedFirst)
+            )
+
+            assertEquals(listOf(updatedFirst), store.readIfRoomPrimary())
+            assertEquals(1, database.favoritePlaylistDao().getSongs().size)
+        } finally {
+            database.close()
+        }
+    }
+
+    private fun favorite(
+        id: Long,
+        name: String,
+        songs: List<SongItem>
+    ): FavoritePlaylist {
+        return FavoritePlaylist(
+            id = id,
+            name = name,
+            coverUrl = null,
+            trackCount = songs.size,
+            source = "netease",
+            songs = songs,
+            addedTime = id,
+            sortOrder = 100L - id,
+            modifiedAt = id
+        )
+    }
+
     private fun testSong(id: Long, name: String): SongItem {
         return SongItem(
             id = id,

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStoreTest.kt
@@ -44,6 +44,7 @@ class FavoritePlaylistRoomStoreTest {
             )
             val store = FavoritePlaylistRoomStore(database)
             store.importLegacyAndPromote(listOf(favorite))
+            store.importLegacyAndPromote(emptyList())
 
             val snapshot = store.readIfRoomPrimary()
             assertNotNull(snapshot)

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStoreTest.kt
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.test.runTest
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+import moe.ouom.neriplayer.data.model.NeteaseArtistSummary
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.data.playlist.favorite.FavoritePlaylist
 import org.junit.Assert.assertEquals
@@ -177,6 +178,37 @@ class FavoritePlaylistRoomStoreTest {
         }
     }
 
+    @Test
+    fun artistRelationsUsePersistedDisplayPositionAfterSongGap() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        try {
+            val favorite = favorite(
+                id = 42L,
+                name = "Gapped",
+                songs = listOf(
+                    testSong(1L, "First song"),
+                    testSong(2L, "Second song")
+                )
+            )
+            val store = FavoritePlaylistRoomStore(database)
+            store.replaceAll(listOf(favorite))
+            database.openHelper.writableDatabase.execSQL(
+                "DELETE FROM favorite_playlist_song " +
+                    "WHERE playlist_id = 42 AND source = 'netease' " +
+                    "AND display_position = 0"
+            )
+
+            val restored = store.readIfRoomPrimary().orEmpty().single()
+            assertEquals(listOf(testSong(2L, "Second song")), restored.songs)
+        } finally {
+            database.close()
+        }
+    }
+
     private fun favorite(
         id: Long,
         name: String,
@@ -206,7 +238,10 @@ class FavoritePlaylistRoomStoreTest {
             coverUrl = "https://example.invalid/$id.jpg",
             mediaUri = "https://example.invalid/$id.mp3",
             matchedLyric = "lyric",
-            customName = "custom-$name"
+            customName = "custom-$name",
+            neteaseArtists = listOf(
+                NeteaseArtistSummary(id = id + 100L, name = "Artist $id")
+            )
         )
     }
 }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStoreTest.kt
@@ -1,0 +1,102 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.playlist.favorite.FavoritePlaylist
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FavoritePlaylistRoomStoreTest {
+    @Test
+    fun favoritePlaylistAndSongOrderRoundTrip() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        try {
+            val favorite = FavoritePlaylist(
+                id = 42L,
+                name = "Favorites",
+                coverUrl = "https://example.invalid/cover.jpg",
+                trackCount = 2,
+                source = "netease",
+                browseId = "browse-42",
+                playlistId = "remote-42",
+                subtitle = "subtitle",
+                songs = listOf(
+                    testSong(1L, "First"),
+                    testSong(2L, "Second")
+                ),
+                addedTime = 10L,
+                sortOrder = 20L,
+                modifiedAt = 30L
+            )
+            val store = FavoritePlaylistRoomStore(database)
+            store.importLegacyAndPromote(listOf(favorite))
+
+            val snapshot = store.readIfRoomPrimary()
+            assertNotNull(snapshot)
+            assertEquals(listOf(favorite), snapshot)
+            assertEquals(
+                2,
+                database.favoritePlaylistDao().getSongs().size
+            )
+        } finally {
+            database.close()
+        }
+    }
+
+    @Test
+    fun deletedFavoriteKeepsTombstoneWithoutSongs() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        try {
+            val favorite = FavoritePlaylist(
+                id = 7L,
+                name = "Removed",
+                coverUrl = null,
+                trackCount = 0,
+                source = "bili",
+                songs = emptyList(),
+                addedTime = 1L,
+                sortOrder = 2L,
+                modifiedAt = 3L,
+                isDeleted = true
+            )
+            val store = FavoritePlaylistRoomStore(database)
+            store.importLegacyAndPromote(listOf(favorite))
+
+            assertEquals(listOf(favorite), store.readIfRoomPrimary())
+            assertEquals(0, database.favoritePlaylistDao().getSongs().size)
+        } finally {
+            database.close()
+        }
+    }
+
+    private fun testSong(id: Long, name: String): SongItem {
+        return SongItem(
+            id = id,
+            name = name,
+            artist = "Artist",
+            album = "Album",
+            albumId = 3L,
+            durationMs = 180_000L,
+            coverUrl = "https://example.invalid/$id.jpg",
+            mediaUri = "https://example.invalid/$id.mp3",
+            matchedLyric = "lyric",
+            customName = "custom-$name"
+        )
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinatorTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinatorTest.kt
@@ -68,7 +68,7 @@ class LegacyJsonCleanupCoordinatorTest {
     }
 
     @Test
-    fun cleanupBlocksWhenATargetHasNotPromotedToRoomYet() = runTest {
+    fun cleanupDeletesEligibleFilesEvenWhenOtherTargetsAreBlocked() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val database = Room.inMemoryDatabaseBuilder(
             context,
@@ -90,7 +90,7 @@ class LegacyJsonCleanupCoordinatorTest {
 
             assertEquals(LegacyJsonCleanupStatus.BLOCKED, result.status)
             assertTrue(result.blockedFiles.contains("last_playback_state.json"))
-            assertTrue(eligibleStatsFile.exists())
+            assertFalse(eligibleStatsFile.exists())
             assertTrue(blockedQueueFile.exists())
 
             val audit = database.syncMetadataDao().getMigrationMetadata(
@@ -98,6 +98,7 @@ class LegacyJsonCleanupCoordinatorTest {
             )
             assertNotNull(audit)
             assertTrue(audit?.value?.contains("status=BLOCKED") == true)
+            assertTrue(audit?.value?.contains("playback_stats_counters.json") == true)
             assertTrue(audit?.value?.contains("last_playback_state.json") == true)
         } finally {
             database.close()

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinatorTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinatorTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.io.File
 import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.core.download.storage.snapshot.ManagedDownloadSnapshotRoomStore
 import moe.ouom.neriplayer.core.player.persistence.PlaybackQueueRoomStore
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
@@ -35,9 +36,14 @@ class LegacyJsonCleanupCoordinatorTest {
                 database = database,
                 key = PlaybackQueueRoomStore.CUTOVER_STATE_METADATA_KEY
             )
+            setRoomPrimary(
+                database = database,
+                key = ManagedDownloadSnapshotRoomStore.CUTOVER_STATE_METADATA_KEY
+            )
 
             val eligibleStatsFile = writeLegacyFile(context, "playback_stats_counters.json")
             val eligibleQueueFile = writeLegacyFile(context, "last_playlist.json")
+            val eligibleSnapshotFile = writeLegacyFile(context, "managed_download_snapshot_v1.json")
             val unrelatedFile = writeLegacyFile(context, "keep_me.json")
 
             val coordinator = LegacyJsonCleanupCoordinator(context, database)
@@ -47,6 +53,7 @@ class LegacyJsonCleanupCoordinatorTest {
             assertEquals(LegacyJsonCleanupStatus.COMPLETED, result.status)
             assertFalse(eligibleStatsFile.exists())
             assertFalse(eligibleQueueFile.exists())
+            assertFalse(eligibleSnapshotFile.exists())
             assertTrue(unrelatedFile.exists())
 
             val audit = database.syncMetadataDao().getMigrationMetadata(
@@ -62,6 +69,7 @@ class LegacyJsonCleanupCoordinatorTest {
                 context,
                 "playback_stats_counters.json",
                 "last_playlist.json",
+                "managed_download_snapshot_v1.json",
                 "keep_me.json"
             )
         }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinatorTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinatorTest.kt
@@ -1,0 +1,136 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.io.File
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.core.player.persistence.PlaybackQueueRoomStore
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LegacyJsonCleanupCoordinatorTest {
+    @Test
+    fun cleanupDeletesEligibleFilesAndKeepsUnrelatedFiles() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            setRoomPrimary(
+                database = database,
+                key = PlaybackStatsRoomStore.CUTOVER_STATE_METADATA_KEY
+            )
+            setRoomPrimary(
+                database = database,
+                key = PlaybackQueueRoomStore.CUTOVER_STATE_METADATA_KEY
+            )
+
+            val eligibleStatsFile = writeLegacyFile(context, "playback_stats_counters.json")
+            val eligibleQueueFile = writeLegacyFile(context, "last_playlist.json")
+            val unrelatedFile = writeLegacyFile(context, "keep_me.json")
+
+            val coordinator = LegacyJsonCleanupCoordinator(context, database)
+            val plan = coordinator.buildPlan()
+            val result = coordinator.execute(plan, confirmed = true)
+
+            assertEquals(LegacyJsonCleanupStatus.COMPLETED, result.status)
+            assertFalse(eligibleStatsFile.exists())
+            assertFalse(eligibleQueueFile.exists())
+            assertTrue(unrelatedFile.exists())
+
+            val audit = database.syncMetadataDao().getMigrationMetadata(
+                LegacyJsonCleanupCoordinator.CLEANUP_AUDIT_METADATA_KEY
+            )
+            assertNotNull(audit)
+            assertTrue(audit?.value?.contains("status=COMPLETED") == true)
+            assertTrue(audit?.value?.contains("playback_stats_counters.json") == true)
+            assertTrue(audit?.value?.contains("last_playlist.json") == true)
+        } finally {
+            database.close()
+            cleanupFiles(
+                context,
+                "playback_stats_counters.json",
+                "last_playlist.json",
+                "keep_me.json"
+            )
+        }
+    }
+
+    @Test
+    fun cleanupBlocksWhenATargetHasNotPromotedToRoomYet() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            setRoomPrimary(
+                database = database,
+                key = PlaybackStatsRoomStore.CUTOVER_STATE_METADATA_KEY
+            )
+
+            val eligibleStatsFile = writeLegacyFile(context, "playback_stats_counters.json")
+            val blockedQueueFile = writeLegacyFile(context, "last_playback_state.json")
+
+            val coordinator = LegacyJsonCleanupCoordinator(context, database)
+            val plan = coordinator.buildPlan()
+            val result = coordinator.execute(plan, confirmed = true)
+
+            assertEquals(LegacyJsonCleanupStatus.BLOCKED, result.status)
+            assertTrue(result.blockedFiles.contains("last_playback_state.json"))
+            assertTrue(eligibleStatsFile.exists())
+            assertTrue(blockedQueueFile.exists())
+
+            val audit = database.syncMetadataDao().getMigrationMetadata(
+                LegacyJsonCleanupCoordinator.CLEANUP_AUDIT_METADATA_KEY
+            )
+            assertNotNull(audit)
+            assertTrue(audit?.value?.contains("status=BLOCKED") == true)
+            assertTrue(audit?.value?.contains("last_playback_state.json") == true)
+        } finally {
+            database.close()
+            cleanupFiles(
+                context,
+                "playback_stats_counters.json",
+                "last_playback_state.json"
+            )
+        }
+    }
+
+    private suspend fun setRoomPrimary(
+        database: NeriUserDataDatabase,
+        key: String
+    ) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = key,
+                value = LegacyJsonCleanupCoordinator.ROOM_PRIMARY_STATE,
+                updatedAt = System.currentTimeMillis()
+            )
+        )
+    }
+
+    private fun writeLegacyFile(context: Context, fileName: String): File {
+        return File(context.filesDir, fileName).apply {
+            writeText("legacy")
+        }
+    }
+
+    private fun cleanupFiles(context: Context, vararg fileNames: String) {
+        fileNames.forEach { fileName ->
+            File(context.filesDir, fileName).delete()
+        }
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistPlaybackRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistPlaybackRoomStoreTest.kt
@@ -1,0 +1,62 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.playlist.usage.LocalPlaylistPlayBucket
+import moe.ouom.neriplayer.data.playlist.usage.LocalPlaylistPlaybackStat
+import moe.ouom.neriplayer.data.sync.model.SyncPlaybackCounterShard
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LocalPlaylistPlaybackRoomStoreTest {
+    @Test
+    fun playbackStatsAndDailyBucketsRoundTrip() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val stat = LocalPlaylistPlaybackStat(
+                playlistId = 42L,
+                totalPlayCount = 5L,
+                firstPlayedAt = 100L,
+                lastPlayedAt = 200L,
+                counterBasePlayCount = 1L,
+                counterShards = listOf(
+                    SyncPlaybackCounterShard(
+                        deviceId = "device-a",
+                        playCount = 4,
+                        firstPlayedAt = 100L,
+                        lastPlayedAt = 200L
+                    )
+                ),
+                dailyPlayBuckets = listOf(
+                    LocalPlaylistPlayBucket(
+                        dayStartAt = 86_400_000L,
+                        playCount = 5L,
+                        firstPlayedAt = 100L,
+                        lastPlayedAt = 200L
+                    )
+                )
+            )
+            val store = LocalPlaylistPlaybackRoomStore(database)
+            store.importLegacyAndPromote(listOf(stat))
+
+            assertEquals(listOf(stat), store.readIfRoomPrimary())
+            assertEquals(
+                2,
+                database.localPlaylistPlaybackDao().getCounterShards().size
+            )
+        } finally {
+            database.close()
+        }
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistPlaybackRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistPlaybackRoomStoreTest.kt
@@ -43,12 +43,21 @@ class LocalPlaylistPlaybackRoomStoreTest {
                         dayStartAt = 86_400_000L,
                         playCount = 5L,
                         firstPlayedAt = 100L,
-                        lastPlayedAt = 200L
+                        lastPlayedAt = 200L,
+                        counterShards = listOf(
+                            SyncPlaybackCounterShard(
+                                deviceId = "device-a",
+                                playCount = 4,
+                                firstPlayedAt = 100L,
+                                lastPlayedAt = 200L
+                            )
+                        )
                     )
                 )
             )
             val store = LocalPlaylistPlaybackRoomStore(database)
             store.importLegacyAndPromote(listOf(stat))
+            store.importLegacyAndPromote(emptyList())
 
             assertEquals(listOf(stat), store.readIfRoomPrimary())
             assertEquals(

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomStoreTest.kt
@@ -1,0 +1,100 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.playlist.model.LocalPlaylist
+import moe.ouom.neriplayer.data.local.playlist.LocalPlaylistSyncMutation
+import moe.ouom.neriplayer.data.local.playlist.LocalPlaylistSyncMutationOutbox
+import moe.ouom.neriplayer.data.model.SongItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LocalPlaylistRoomStoreTest {
+    @Test
+    fun incrementalWriteRemovesMembershipWithoutDeletingSharedTrack() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val song = SongItem(
+                id = 101L,
+                name = "shared",
+                artist = "artist",
+                album = "album",
+                albumId = 1L,
+                durationMs = 180_000L,
+                coverUrl = null
+            )
+            val initial = listOf(
+                LocalPlaylist(
+                    id = 1L,
+                    name = "first",
+                    songs = mutableListOf(song)
+                ),
+                LocalPlaylist(
+                    id = 2L,
+                    name = "second",
+                    songs = mutableListOf(song)
+                )
+            )
+            val store = LocalPlaylistRoomStore(database)
+            store.replacePlaylists(initial, LocalPlaylistRoomStore.domainDigest(initial))
+
+            val next = listOf(initial[1])
+            store.writeIncremental(
+                previous = initial,
+                next = next,
+                sourceDigest = LocalPlaylistRoomStore.domainDigest(next)
+            )
+
+            assertEquals(next, store.readIfRoomPrimary())
+            assertEquals(1, database.localPlaylistDao().getTracks().size)
+            assertEquals(1, database.localPlaylistDao().getMembers().size)
+            assertNotNull(
+                database.syncMetadataDao().getMigrationMetadata(
+                    LocalPlaylistRoomStore.CUTOVER_STATE_METADATA_KEY
+                )
+            )
+        } finally {
+            database.close()
+        }
+    }
+
+    @Test
+    fun pendingSyncOutboxRoundTripsInRoom() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val store = LocalPlaylistRoomStore(database)
+            val outbox = LocalPlaylistSyncMutationOutbox(
+                mutations = listOf(
+                    LocalPlaylistSyncMutation(
+                        expectedPrimaryDigest = "digest"
+                    )
+                )
+            )
+            store.writePendingSyncMutationOutbox(outbox)
+
+            assertEquals(outbox, store.readPendingSyncMutationOutbox())
+
+            store.clearPendingSyncMutationOutbox()
+            assertEquals(null, store.readPendingSyncMutationOutbox())
+        } finally {
+            database.close()
+        }
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomStoreTest.kt
@@ -39,6 +39,9 @@ class PlayHistoryRoomStoreTest {
             )
             val store = PlayHistoryRoomStore(database)
             store.importLegacyAndPromote(listOf(first, second))
+            store.importLegacyAndPromote(emptyList())
+
+            assertEquals(listOf(first, second), store.readIfRoomPrimary())
 
             val updatedFirst = first.copy(
                 resumePositionMs = 4_000L,

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomStoreTest.kt
@@ -1,0 +1,63 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.data.history.PlayedEntry
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PlayHistoryRoomStoreTest {
+    @Test
+    fun incrementalWriteUpdatesOnlyChangedEntries() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val first = PlayedEntry(
+                id = 1L,
+                name = "first",
+                artist = "artist",
+                album = "netease",
+                durationMs = 180_000L,
+                coverUrl = null,
+                playedAt = 100L
+            )
+            val second = first.copy(
+                id = 2L,
+                name = "second",
+                playedAt = 50L
+            )
+            val store = PlayHistoryRoomStore(database)
+            store.importLegacyAndPromote(listOf(first, second))
+
+            val updatedFirst = first.copy(
+                resumePositionMs = 4_000L,
+                playedAt = 200L
+            )
+            store.writeIncremental(
+                previous = listOf(first, second),
+                next = listOf(updatedFirst)
+            )
+
+            assertEquals(listOf(updatedFirst), store.readIfRoomPrimary())
+            assertEquals(1, database.playHistoryDao().getAll().size)
+            assertTrue(
+                database.syncMetadataDao().getMigrationMetadata(
+                    PlayHistoryRoomStore.CUTOVER_STATE_METADATA_KEY
+                ) != null
+            )
+        } finally {
+            database.close()
+        }
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStoreTest.kt
@@ -72,6 +72,13 @@ class PlaybackStatsRoomStoreTest {
                 counterEpochStartedAt = 10L,
                 clearedAt = 5L
             )
+            store.importLegacyAndPromote(
+                stats = emptyList(),
+                dailyStats = emptyList(),
+                counterSnapshot = PlaybackStatsSyncCounterSnapshot(),
+                counterEpochStartedAt = 0L,
+                clearedAt = 0L
+            )
 
             val snapshot = store.readIfRoomPrimary()
             assertNotNull(snapshot)

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStoreTest.kt
@@ -120,6 +120,69 @@ class PlaybackStatsRoomStoreTest {
         }
     }
 
+    @Test
+    fun incrementalWritePersistsCounterOnlyChanges() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        try {
+            val stat = testTrackStat()
+            val previousCounter = PlaybackStatsSyncCounterSnapshot(
+                trackShardsByIdentity = mapOf(
+                    stat.identityKey to listOf(
+                        SyncPlaybackCounterShard(
+                            deviceId = "device-a",
+                            epochStartedAt = 0L,
+                            totalListenMs = 30_000L,
+                            playCount = 1,
+                            firstPlayedAt = 100L,
+                            lastPlayedAt = 100L
+                        )
+                    )
+                )
+            )
+            val nextCounter = PlaybackStatsSyncCounterSnapshot(
+                trackShardsByIdentity = mapOf(
+                    stat.identityKey to listOf(
+                        SyncPlaybackCounterShard(
+                            deviceId = "device-a",
+                            epochStartedAt = 0L,
+                            totalListenMs = 30_000L,
+                            playCount = 2,
+                            firstPlayedAt = 100L,
+                            lastPlayedAt = 200L
+                        )
+                    )
+                )
+            )
+            val store = PlaybackStatsRoomStore(database)
+            store.importLegacyAndPromote(
+                stats = listOf(stat),
+                dailyStats = emptyList(),
+                counterSnapshot = previousCounter,
+                counterEpochStartedAt = 0L,
+                clearedAt = 0L
+            )
+
+            store.writeIncremental(
+                previousStats = listOf(stat),
+                nextStats = listOf(stat),
+                previousDailyStats = emptyList(),
+                nextDailyStats = emptyList(),
+                previousCounterSnapshot = previousCounter,
+                counterSnapshot = nextCounter,
+                counterEpochStartedAt = 0L,
+                clearedAt = 0L
+            )
+
+            assertEquals(nextCounter, store.readIfRoomPrimary()?.counterSnapshot)
+        } finally {
+            database.close()
+        }
+    }
+
     private fun testTrackStat(): TrackStat {
         return TrackStat(
             id = 7L,

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStoreTest.kt
@@ -1,0 +1,145 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.stats.PlaybackStatBucket
+import moe.ouom.neriplayer.data.stats.PlaybackStatsSyncCounterSnapshot
+import moe.ouom.neriplayer.data.stats.TrackStat
+import moe.ouom.neriplayer.data.sync.model.SyncPlaybackCounterShard
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PlaybackStatsRoomStoreTest {
+    @Test
+    fun statsBucketsAndCounterShardsRoundTrip() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        try {
+            val stat = testTrackStat()
+            val bucket = PlaybackStatBucket(
+                dayStartAt = 86_400_000L,
+                id = stat.id,
+                name = stat.name,
+                artist = stat.artist,
+                album = stat.album,
+                albumId = stat.albumId,
+                coverUrl = stat.coverUrl,
+                durationMs = stat.durationMs,
+                totalListenMs = 30_000L,
+                playCount = 1,
+                lastPlayedAt = 200L,
+                firstPlayedAt = 200L,
+                mediaUri = stat.mediaUri,
+                localFilePath = stat.localFilePath,
+                localFileName = stat.localFileName,
+                customName = stat.customName,
+                customArtist = stat.customArtist,
+                customCoverUrl = stat.customCoverUrl,
+                identityKey = stat.identityKey
+            )
+            val shard = SyncPlaybackCounterShard(
+                deviceId = "device-a",
+                epochStartedAt = 10L,
+                totalListenMs = 30_000L,
+                playCount = 1,
+                firstPlayedAt = 200L,
+                lastPlayedAt = 200L
+            )
+            val counters = PlaybackStatsSyncCounterSnapshot(
+                trackShardsByIdentity = mapOf(stat.identityKey to listOf(shard)),
+                dailyShardsByBucketKey = mapOf(
+                    PlaybackStatsSyncCounterSnapshot.dailyCounterKey(
+                        dayStartAt = bucket.dayStartAt,
+                        identityKey = bucket.identityKey
+                    ) to listOf(shard)
+                )
+            )
+            val store = PlaybackStatsRoomStore(database)
+            store.importLegacyAndPromote(
+                stats = listOf(stat),
+                dailyStats = listOf(bucket),
+                counterSnapshot = counters,
+                counterEpochStartedAt = 10L,
+                clearedAt = 5L
+            )
+
+            val snapshot = store.readIfRoomPrimary()
+            assertNotNull(snapshot)
+            assertEquals(listOf(stat), snapshot?.stats)
+            assertEquals(listOf(bucket), snapshot?.dailyStats)
+            assertEquals(counters, snapshot?.counterSnapshot)
+            assertEquals(5L, snapshot?.clearedAt)
+        } finally {
+            database.close()
+        }
+    }
+
+    @Test
+    fun incrementalWriteRemovesDeletedTrackAndItsBuckets() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        try {
+            val stat = testTrackStat()
+            val store = PlaybackStatsRoomStore(database)
+            store.importLegacyAndPromote(
+                stats = listOf(stat),
+                dailyStats = emptyList(),
+                counterSnapshot = PlaybackStatsSyncCounterSnapshot(),
+                counterEpochStartedAt = 0L,
+                clearedAt = 0L
+            )
+            store.writeIncremental(
+                previousStats = listOf(stat),
+                nextStats = emptyList(),
+                previousDailyStats = emptyList(),
+                nextDailyStats = emptyList(),
+                previousCounterSnapshot = PlaybackStatsSyncCounterSnapshot(),
+                counterSnapshot = PlaybackStatsSyncCounterSnapshot(),
+                counterEpochStartedAt = 0L,
+                clearedAt = 0L
+            )
+
+            val snapshot = store.readIfRoomPrimary()
+            assertEquals(emptyList<TrackStat>(), snapshot?.stats)
+            assertEquals(emptyList<PlaybackStatBucket>(), snapshot?.dailyStats)
+        } finally {
+            database.close()
+        }
+    }
+
+    private fun testTrackStat(): TrackStat {
+        return TrackStat(
+            id = 7L,
+            name = "Song",
+            artist = "Artist",
+            album = "Album",
+            albumId = 8L,
+            coverUrl = "https://example.invalid/cover.jpg",
+            durationMs = 180_000L,
+            totalListenMs = 30_000L,
+            playCount = 1,
+            lastPlayedAt = 200L,
+            firstPlayedAt = 200L,
+            mediaUri = "https://example.invalid/song.mp3",
+            localFilePath = null,
+            localFileName = null,
+            customName = null,
+            customArtist = null,
+            customCoverUrl = null,
+            identityKey = "track|7"
+        )
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlaylistUsageRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlaylistUsageRoomStoreTest.kt
@@ -1,0 +1,66 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.playlist.usage.UsageEntry
+import moe.ouom.neriplayer.data.sync.model.SyncPlaybackCounterShard
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PlaylistUsageRoomStoreTest {
+    @Test
+    fun usageEntryAndCounterShardRoundTrip() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val entry = UsageEntry(
+                id = 7L,
+                name = "playlist",
+                picUrl = "cover",
+                trackCount = 3,
+                source = "bili",
+                lastOpened = 200L,
+                openCount = 4,
+                firstOpened = 100L,
+                counterBaseOpenCount = 1L,
+                counterShards = listOf(
+                    SyncPlaybackCounterShard(
+                        deviceId = "device-a",
+                        epochStartedAt = 0L,
+                        playCount = 3,
+                        firstPlayedAt = 100L,
+                        lastPlayedAt = 200L
+                    )
+                ),
+                subtype = "COLLECTION",
+                subtitle = "UP 主"
+            )
+            val store = PlaylistUsageRoomStore(database)
+            store.importLegacyAndPromote(listOf(entry))
+
+            assertEquals(listOf(entry), store.readIfRoomPrimary())
+            assertEquals(
+                1,
+                database.playlistUsageDao().getCounterShards().size
+            )
+            assertTrue(
+                database.syncMetadataDao().getMigrationMetadata(
+                    PlaylistUsageRoomStore.CUTOVER_STATE_METADATA_KEY
+                ) != null
+            )
+        } finally {
+            database.close()
+        }
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlaylistUsageRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlaylistUsageRoomStoreTest.kt
@@ -48,6 +48,7 @@ class PlaylistUsageRoomStoreTest {
             )
             val store = PlaylistUsageRoomStore(database)
             store.importLegacyAndPromote(listOf(entry))
+            store.importLegacyAndPromote(emptyList())
 
             assertEquals(listOf(entry), store.readIfRoomPrimary())
             assertEquals(

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlaylistUsageRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/PlaylistUsageRoomStoreTest.kt
@@ -63,4 +63,74 @@ class PlaylistUsageRoomStoreTest {
             database.close()
         }
     }
+
+    @Test
+    fun incrementalWriteUpdatesOnlyChangedUsageKeys() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val first = UsageEntry(
+                id = 1L,
+                name = "first",
+                picUrl = null,
+                trackCount = 1,
+                source = "netease",
+                lastOpened = 100L,
+                openCount = 1
+            )
+            val second = UsageEntry(
+                id = 2L,
+                name = "second",
+                picUrl = "cover",
+                trackCount = 2,
+                source = "bili",
+                lastOpened = 200L,
+                openCount = 2,
+                counterShards = listOf(
+                    SyncPlaybackCounterShard(
+                        deviceId = "device-a",
+                        epochStartedAt = 0L,
+                        playCount = 2,
+                        firstPlayedAt = 100L,
+                        lastPlayedAt = 200L
+                    )
+                )
+            )
+            val store = PlaylistUsageRoomStore(database)
+            store.replaceAll(listOf(first, second))
+
+            val updatedFirst = first.copy(
+                name = "first updated",
+                lastOpened = 300L,
+                openCount = 3
+            )
+            store.writeIncremental(
+                previous = listOf(first, second),
+                next = listOf(updatedFirst, second)
+            )
+
+            assertEquals(
+                listOf(updatedFirst, second),
+                store.readIfRoomPrimary()
+            )
+            assertEquals(
+                1,
+                database.playlistUsageDao().getCounterShards().size
+            )
+
+            store.writeIncremental(
+                previous = listOf(updatedFirst, second),
+                next = listOf(updatedFirst)
+            )
+
+            assertEquals(listOf(updatedFirst), store.readIfRoomPrimary())
+            assertTrue(database.playlistUsageDao().getCounterShards().isEmpty())
+        } finally {
+            database.close()
+        }
+    }
 }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/TrafficStatsRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/TrafficStatsRoomStoreTest.kt
@@ -1,0 +1,45 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.traffic.TrafficStatsBucket
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TrafficStatsRoomStoreTest {
+    @Test
+    fun trafficBucketsRoundTripAndIncrementalDelete() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        try {
+            val bucket = TrafficStatsBucket(
+                dayStartAt = 86_400_000L,
+                wifiBytes = 10L,
+                playbackNetworkBytes = 10L,
+                requestCount = 1
+            )
+            val store = TrafficStatsRoomStore(database)
+            store.importLegacyAndPromote(listOf(bucket))
+            assertNotNull(store.readIfRoomPrimary())
+            assertEquals(listOf(bucket), store.readIfRoomPrimary())
+
+            store.writeIncremental(
+                previous = listOf(bucket),
+                next = emptyList()
+            )
+            assertEquals(emptyList<TrafficStatsBucket>(), store.readIfRoomPrimary())
+        } finally {
+            database.close()
+        }
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/TrafficStatsRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/TrafficStatsRoomStoreTest.kt
@@ -30,6 +30,7 @@ class TrafficStatsRoomStoreTest {
             )
             val store = TrafficStatsRoomStore(database)
             store.importLegacyAndPromote(listOf(bucket))
+            store.importLegacyAndPromote(emptyList())
             assertNotNull(store.readIfRoomPrimary())
             assertEquals(listOf(bucket), store.readIfRoomPrimary())
 

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/platform/PlatformPlaylistCacheRoomMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/platform/PlatformPlaylistCacheRoomMigrationTest.kt
@@ -1,0 +1,295 @@
+package moe.ouom.neriplayer.data.platform
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.gson.Gson
+import java.io.File
+import java.security.MessageDigest
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheArtistRecord
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRecord
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRoomStore
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheTrackRecord
+import moe.ouom.neriplayer.data.platform.bili.BiliArchiveCacheRepository
+import moe.ouom.neriplayer.data.platform.bili.BiliArchiveContentCache
+import moe.ouom.neriplayer.data.platform.bili.BiliFavoriteFolderCacheRepository
+import moe.ouom.neriplayer.data.platform.bili.BiliFavoriteFolderContentCache
+import moe.ouom.neriplayer.data.platform.bili.CachedBiliArchiveVideo
+import moe.ouom.neriplayer.data.platform.bili.CachedBiliFavoriteVideo
+import moe.ouom.neriplayer.data.platform.bili.biliArchiveCacheFileName
+import moe.ouom.neriplayer.data.platform.netease.CachedNeteaseArtist
+import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistDetail
+import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistHeader
+import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistTrack
+import moe.ouom.neriplayer.data.platform.netease.NeteasePlaylistCacheRepository
+import moe.ouom.neriplayer.data.platform.youtube.CachedYouTubeMusicPlaylistDetail
+import moe.ouom.neriplayer.data.platform.youtube.CachedYouTubeMusicPlaylistTrack
+import moe.ouom.neriplayer.data.platform.youtube.YouTubeMusicPlaylistCacheRepository
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PlatformPlaylistCacheRoomMigrationTest {
+    private val gson = Gson()
+
+    @Test
+    fun roomStoreRoundTripsHeaderTracksAndArtists() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = inMemoryDatabase(context)
+        try {
+            val store = PlatformPlaylistCacheRoomStore(database)
+            val record = PlatformPlaylistCacheRecord(
+                platform = "netease",
+                cacheKey = "42",
+                sourceId = 42L,
+                title = "daily",
+                coverUrl = "https://img.example/cover.jpg",
+                playCount = 1000L,
+                trackCount = 1,
+                totalCount = 1,
+                signaturePrimary = "sig",
+                savedAtMs = 123L,
+                tracks = listOf(
+                    PlatformPlaylistCacheTrackRecord(
+                        itemId = 7L,
+                        name = "song",
+                        artist = "artist",
+                        album = "album",
+                        albumId = 9L,
+                        durationMs = 180_000L,
+                        coverUrl = "https://img.example/song.jpg",
+                        audioId = "7",
+                        artists = listOf(
+                            PlatformPlaylistCacheArtistRecord(id = 1L, name = "artist")
+                        )
+                    )
+                )
+            )
+
+            store.replace(record)
+
+            assertEquals(record, store.read("netease", "42"))
+        } finally {
+            database.close()
+        }
+    }
+
+    @Test
+    fun repositoriesImportLegacyJsonAndDeleteFiles() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = inMemoryDatabase(context)
+        val root = File(context.cacheDir, "platform-cache-room-${System.nanoTime()}")
+        try {
+            val neteaseDir = File(root, "netease_playlist_cache").apply { mkdirs() }
+            val biliFavoriteDir = File(root, "bili_favorite_cache").apply { mkdirs() }
+            val biliArchiveDir = File(root, "bili_archive_cache").apply { mkdirs() }
+            val youtubeDir = File(root, "youtube_music_playlist_cache").apply { mkdirs() }
+
+            val neteaseCache = neteaseCache()
+            val biliFavoriteCache = biliFavoriteCache()
+            val biliArchiveCache = biliArchiveCache()
+            val youtubeCache = youtubeCache()
+
+            val neteaseFile = File(neteaseDir, "playlist_${neteaseCache.playlistId}.json")
+            val biliFavoriteFile = File(biliFavoriteDir, "media_${biliFavoriteCache.mediaId}.json")
+            val biliArchiveFile = File(
+                biliArchiveDir,
+                biliArchiveCacheFileName(biliArchiveCache.mediaId, biliArchiveCache.kind)
+            )
+            val youtubeFile = File(youtubeDir, "${sha256(youtubeCache.browseId)}.json")
+
+            neteaseFile.writeText(gson.toJson(neteaseCache), Charsets.UTF_8)
+            biliFavoriteFile.writeText(gson.toJson(biliFavoriteCache), Charsets.UTF_8)
+            biliArchiveFile.writeText(gson.toJson(biliArchiveCache), Charsets.UTF_8)
+            youtubeFile.writeText(gson.toJson(youtubeCache), Charsets.UTF_8)
+
+            val neteaseRepo = NeteasePlaylistCacheRepository(context, database, neteaseDir)
+            val biliFavoriteRepo = BiliFavoriteFolderCacheRepository(
+                context,
+                database,
+                biliFavoriteDir
+            )
+            val biliArchiveRepo = BiliArchiveCacheRepository(context, database, biliArchiveDir)
+            val youtubeRepo = YouTubeMusicPlaylistCacheRepository(context, database, youtubeDir)
+
+            neteaseRepo.importLegacyCaches()
+            biliFavoriteRepo.importLegacyCaches()
+            biliArchiveRepo.importLegacyCaches()
+            youtubeRepo.importLegacyCaches()
+
+            assertFalse(neteaseFile.exists())
+            assertFalse(biliFavoriteFile.exists())
+            assertFalse(biliArchiveFile.exists())
+            assertFalse(youtubeFile.exists())
+            assertEquals(neteaseCache, neteaseRepo.read(neteaseCache.playlistId))
+            assertEquals(biliFavoriteCache, biliFavoriteRepo.read(biliFavoriteCache.mediaId))
+            assertEquals(
+                biliArchiveCache,
+                biliArchiveRepo.read(biliArchiveCache.mediaId, biliArchiveCache.kind)
+            )
+            assertEquals(youtubeCache, youtubeRepo.read(youtubeCache.browseId))
+            assertNotNull(database.platformPlaylistCacheDao().getCache("netease", "42"))
+
+            neteaseRepo.clear(neteaseCache.playlistId)
+            biliFavoriteRepo.clear(biliFavoriteCache.mediaId)
+            biliArchiveRepo.clear(biliArchiveCache.mediaId, biliArchiveCache.kind)
+            youtubeRepo.clear(youtubeCache.browseId)
+
+            assertNull(neteaseRepo.read(neteaseCache.playlistId))
+            assertNull(biliFavoriteRepo.read(biliFavoriteCache.mediaId))
+            assertNull(biliArchiveRepo.read(biliArchiveCache.mediaId, biliArchiveCache.kind))
+            assertNull(youtubeRepo.read(youtubeCache.browseId))
+        } finally {
+            database.close()
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun legacyImportDeletesStaleJsonWithoutOverwritingNewerRoomRecord() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = inMemoryDatabase(context)
+        val root = File(context.cacheDir, "platform-cache-stale-${System.nanoTime()}")
+        try {
+            val neteaseDir = File(root, "netease_playlist_cache").apply { mkdirs() }
+            val repo = NeteasePlaylistCacheRepository(context, database, neteaseDir)
+            val newerCache = neteaseCache(
+                playlistName = "new room cache",
+                savedAtMs = 500L
+            )
+            val staleCache = neteaseCache(
+                playlistName = "stale json cache",
+                savedAtMs = 100L
+            )
+
+            repo.save(newerCache)
+            val staleFile = File(neteaseDir, "playlist_${staleCache.playlistId}.json")
+            neteaseDir.mkdirs()
+            staleFile.writeText(gson.toJson(staleCache), Charsets.UTF_8)
+
+            repo.importLegacyCaches()
+
+            assertFalse(staleFile.exists())
+            assertEquals(newerCache, repo.read(newerCache.playlistId))
+        } finally {
+            database.close()
+            root.deleteRecursively()
+        }
+    }
+
+    private fun inMemoryDatabase(context: Context): NeriUserDataDatabase {
+        return Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+    }
+
+    private fun neteaseCache(
+        playlistName: String = "NetEase Mix",
+        savedAtMs: Long = 100L
+    ): CachedNeteasePlaylistDetail {
+        return CachedNeteasePlaylistDetail(
+            playlistId = 42L,
+            header = CachedNeteasePlaylistHeader(
+                id = 42L,
+                name = playlistName,
+                coverUrl = "https://img.example/netease.jpg",
+                playCount = 88L,
+                trackCount = 1
+            ),
+            recentTrackSignature = "netease-sig",
+            tracks = listOf(
+                CachedNeteasePlaylistTrack(
+                    id = 7L,
+                    name = "N Song",
+                    artist = "N Artist",
+                    album = "N Album",
+                    albumId = 9L,
+                    durationMs = 200_000L,
+                    coverUrl = "https://img.example/n-song.jpg",
+                    audioId = "7",
+                    artists = listOf(CachedNeteaseArtist(id = 1L, name = "N Artist")),
+                    addedAt = 11L
+                )
+            ),
+            savedAtMs = savedAtMs
+        )
+    }
+
+    private fun biliFavoriteCache(): BiliFavoriteFolderContentCache {
+        return BiliFavoriteFolderContentCache(
+            mediaId = 55L,
+            latestPageSignature = "bili-fav-sig",
+            totalCount = 1,
+            videos = listOf(
+                CachedBiliFavoriteVideo(
+                    id = 10L,
+                    bvid = "BV1fav",
+                    title = "B Favorite",
+                    uploader = "UP",
+                    uploaderMid = 100L,
+                    coverUrl = "https://img.example/fav.jpg",
+                    durationSec = 33
+                )
+            ),
+            savedAtMs = 200L
+        )
+    }
+
+    private fun biliArchiveCache(): BiliArchiveContentCache {
+        return BiliArchiveContentCache(
+            mediaId = 66L,
+            kind = "COLLECTION",
+            totalCount = 1,
+            hasMore = true,
+            videos = listOf(
+                CachedBiliArchiveVideo(
+                    id = 11L,
+                    bvid = "BV1arc",
+                    title = "B Archive",
+                    uploader = "UP2",
+                    uploaderMid = 101L,
+                    coverUrl = "https://img.example/archive.jpg",
+                    durationSec = 44
+                )
+            ),
+            savedAtMs = 300L
+        )
+    }
+
+    private fun youtubeCache(): CachedYouTubeMusicPlaylistDetail {
+        return CachedYouTubeMusicPlaylistDetail(
+            browseId = "VLPL42",
+            playlistId = "PL42",
+            title = "YouTube Mix",
+            subtitle = "mix",
+            creatorName = "creator",
+            coverUrl = "https://img.example/youtube.jpg",
+            trackCount = 1,
+            firstPageSignature = "yt-sig",
+            tracks = listOf(
+                CachedYouTubeMusicPlaylistTrack(
+                    videoId = "video-1",
+                    name = "YT Song",
+                    artist = "YT Artist",
+                    albumName = "YT Album",
+                    durationMs = 240_000L,
+                    coverUrl = "https://img.example/yt-song.jpg"
+                )
+            ),
+            savedAtMs = 400L
+        )
+    }
+
+    private fun sha256(value: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(value.toByteArray(Charsets.UTF_8))
+        return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/platform/PlatformPlaylistCacheRoomMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/platform/PlatformPlaylistCacheRoomMigrationTest.kt
@@ -12,6 +12,7 @@ import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheArtistRecord
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRecord
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRoomStore
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheStore
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheTrackRecord
 import moe.ouom.neriplayer.data.platform.bili.BiliArchiveCacheRepository
 import moe.ouom.neriplayer.data.platform.bili.BiliArchiveContentCache
@@ -32,6 +33,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -184,6 +186,85 @@ class PlatformPlaylistCacheRoomMigrationTest {
         }
     }
 
+    @Test
+    fun roomFailuresKeepLegacyCachesReadableAndRetained() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val root = File(context.cacheDir, "platform-cache-failure-${System.nanoTime()}")
+        try {
+            val neteaseDir = File(root, "netease_playlist_cache").apply { mkdirs() }
+            val biliFavoriteDir = File(root, "bili_favorite_cache").apply { mkdirs() }
+            val biliArchiveDir = File(root, "bili_archive_cache").apply { mkdirs() }
+            val youtubeDir = File(root, "youtube_music_playlist_cache").apply { mkdirs() }
+            val neteaseCache = neteaseCache()
+            val biliFavoriteCache = biliFavoriteCache()
+            val biliArchiveCache = biliArchiveCache()
+            val youtubeCache = youtubeCache()
+            val neteaseFile = File(neteaseDir, "playlist_${neteaseCache.playlistId}.json")
+            val biliFavoriteFile = File(biliFavoriteDir, "media_${biliFavoriteCache.mediaId}.json")
+            val biliArchiveFile = File(
+                biliArchiveDir,
+                biliArchiveCacheFileName(biliArchiveCache.mediaId, biliArchiveCache.kind)
+            )
+            val youtubeFile = File(youtubeDir, "${sha256(youtubeCache.browseId)}.json")
+            val failingStore = FailingPlatformPlaylistCacheStore()
+
+            neteaseFile.writeText(gson.toJson(neteaseCache), Charsets.UTF_8)
+            biliFavoriteFile.writeText(gson.toJson(biliFavoriteCache), Charsets.UTF_8)
+            biliArchiveFile.writeText(gson.toJson(biliArchiveCache), Charsets.UTF_8)
+            youtubeFile.writeText(gson.toJson(youtubeCache), Charsets.UTF_8)
+
+            val neteaseRepo = NeteasePlaylistCacheRepository(failingStore, neteaseDir)
+            val biliFavoriteRepo = BiliFavoriteFolderCacheRepository(failingStore, biliFavoriteDir)
+            val biliArchiveRepo = BiliArchiveCacheRepository(failingStore, biliArchiveDir)
+            val youtubeRepo = YouTubeMusicPlaylistCacheRepository(failingStore, youtubeDir)
+
+            assertEquals(neteaseCache, neteaseRepo.read(neteaseCache.playlistId))
+            assertEquals(biliFavoriteCache, biliFavoriteRepo.read(biliFavoriteCache.mediaId))
+            assertEquals(
+                biliArchiveCache,
+                biliArchiveRepo.read(biliArchiveCache.mediaId, biliArchiveCache.kind)
+            )
+            assertEquals(youtubeCache, youtubeRepo.read(youtubeCache.browseId))
+            assertTrue(neteaseFile.exists())
+            assertTrue(biliFavoriteFile.exists())
+            assertTrue(biliArchiveFile.exists())
+            assertTrue(youtubeFile.exists())
+
+            neteaseRepo.importLegacyCaches()
+            biliFavoriteRepo.importLegacyCaches()
+            biliArchiveRepo.importLegacyCaches()
+            youtubeRepo.importLegacyCaches()
+
+            assertTrue(neteaseFile.exists())
+            assertTrue(biliFavoriteFile.exists())
+            assertTrue(biliArchiveFile.exists())
+            assertTrue(youtubeFile.exists())
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun clearDeletesLegacyCacheWhenRoomClearFails() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val root = File(context.cacheDir, "platform-cache-clear-${System.nanoTime()}")
+        try {
+            val cache = neteaseCache()
+            val cacheDir = File(root, "netease_playlist_cache").apply { mkdirs() }
+            val legacyFile = File(cacheDir, "playlist_${cache.playlistId}.json")
+            legacyFile.writeText(gson.toJson(cache), Charsets.UTF_8)
+
+            NeteasePlaylistCacheRepository(
+                FailingPlatformPlaylistCacheStore(failRead = false, failWrite = false),
+                cacheDir
+            ).clear(cache.playlistId)
+
+            assertFalse(legacyFile.exists())
+        } finally {
+            root.deleteRecursively()
+        }
+    }
+
     private fun inMemoryDatabase(context: Context): NeriUserDataDatabase {
         return Room.inMemoryDatabaseBuilder(
             context,
@@ -291,5 +372,36 @@ class PlatformPlaylistCacheRoomMigrationTest {
     private fun sha256(value: String): String {
         val digest = MessageDigest.getInstance("SHA-256").digest(value.toByteArray(Charsets.UTF_8))
         return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
+    }
+
+    private class FailingPlatformPlaylistCacheStore(
+        private val failRead: Boolean = true,
+        private val failWrite: Boolean = true
+    ) : PlatformPlaylistCacheStore {
+        override suspend fun read(
+            platform: String,
+            cacheKey: String
+        ): PlatformPlaylistCacheRecord? {
+            if (failRead) {
+                throw IllegalStateException("Room read failure")
+            }
+            return null
+        }
+
+        override suspend fun replace(record: PlatformPlaylistCacheRecord) {
+            if (failWrite) {
+                throw IllegalStateException("Room replace failure")
+            }
+        }
+
+        override suspend fun replaceIfNewer(record: PlatformPlaylistCacheRecord) {
+            if (failWrite) {
+                throw IllegalStateException("Room import failure")
+            }
+        }
+
+        override suspend fun clear(platform: String, cacheKey: String) {
+            throw IllegalStateException("Room clear failure")
+        }
     }
 }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/platform/PlatformPlaylistCacheRoomMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/platform/PlatformPlaylistCacheRoomMigrationTest.kt
@@ -187,7 +187,7 @@ class PlatformPlaylistCacheRoomMigrationTest {
     }
 
     @Test
-    fun roomFailuresKeepLegacyCachesReadableAndRetained() = runTest {
+    fun roomFailuresRefuseLegacyFallbackAndRetainCaches() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val root = File(context.cacheDir, "platform-cache-failure-${System.nanoTime()}")
         try {
@@ -218,13 +218,10 @@ class PlatformPlaylistCacheRoomMigrationTest {
             val biliArchiveRepo = BiliArchiveCacheRepository(failingStore, biliArchiveDir)
             val youtubeRepo = YouTubeMusicPlaylistCacheRepository(failingStore, youtubeDir)
 
-            assertEquals(neteaseCache, neteaseRepo.read(neteaseCache.playlistId))
-            assertEquals(biliFavoriteCache, biliFavoriteRepo.read(biliFavoriteCache.mediaId))
-            assertEquals(
-                biliArchiveCache,
-                biliArchiveRepo.read(biliArchiveCache.mediaId, biliArchiveCache.kind)
-            )
-            assertEquals(youtubeCache, youtubeRepo.read(youtubeCache.browseId))
+            assertNull(neteaseRepo.read(neteaseCache.playlistId))
+            assertNull(biliFavoriteRepo.read(biliFavoriteCache.mediaId))
+            assertNull(biliArchiveRepo.read(biliArchiveCache.mediaId, biliArchiveCache.kind))
+            assertNull(youtubeRepo.read(youtubeCache.browseId))
             assertTrue(neteaseFile.exists())
             assertTrue(biliFavoriteFile.exists())
             assertTrue(biliArchiveFile.exists())

--- a/app/src/androidTest/java/moe/ouom/neriplayer/util/security/RecoveringEncryptedSharedPreferencesAndroidTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/util/security/RecoveringEncryptedSharedPreferencesAndroidTest.kt
@@ -1,0 +1,72 @@
+package moe.ouom.neriplayer.util.security
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.security.KeyStore
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val TEST_PREFS_NAME = "recovering_encrypted_preferences_test"
+private const val TEST_MASTER_KEY_ALIAS = "recovering_encrypted_preferences_test_key"
+
+@RunWith(AndroidJUnit4::class)
+class RecoveringEncryptedSharedPreferencesAndroidTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+        clearTestStorage()
+    }
+
+    @After
+    fun tearDown() {
+        clearTestStorage()
+    }
+
+    @Test
+    fun replacedKeystoreKey_resetsUnreadableCredentialsWithoutCrashing() {
+        val initial = openPreferences()
+        assertTrue(initial.edit().putString("secret", "old-value").commit())
+        assertEquals("old-value", initial.getString("secret", null))
+
+        deleteTestMasterKey()
+
+        val recovered = openPreferences()
+        assertNull(recovered.getString("secret", null))
+        assertTrue(recovered.isDurable)
+        assertTrue(recovered.edit().putString("secret", "new-value").commit())
+
+        val reopened = openPreferences()
+        assertEquals("new-value", reopened.getString("secret", null))
+    }
+
+    private fun openPreferences(): RecoveringEncryptedSharedPreferences {
+        return RecoveringEncryptedSharedPreferences(
+            context = context,
+            storageName = TEST_PREFS_NAME,
+            logTag = "RecoveringPreferencesAndroidTest",
+            masterKeyAlias = TEST_MASTER_KEY_ALIAS
+        )
+    }
+
+    private fun clearTestStorage() {
+        context.deleteSharedPreferences(TEST_PREFS_NAME)
+        deleteTestMasterKey()
+    }
+
+    private fun deleteTestMasterKey() {
+        val keyStore = KeyStore.getInstance("AndroidKeyStore")
+        keyStore.load(null)
+        if (keyStore.containsAlias(TEST_MASTER_KEY_ALIAS)) {
+            keyStore.deleteEntry(TEST_MASTER_KEY_ALIAS)
+        }
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/NeriPlayerApplication.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/NeriPlayerApplication.kt
@@ -33,6 +33,7 @@ import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
 import moe.ouom.neriplayer.core.lyricon.LyriconManager
 import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.core.player.lyrics.FloatingLyricsOverlayManager
+import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.core.startup.app.AppImageLoaderInitializer
 import moe.ouom.neriplayer.core.startup.app.AppProcessClassifier
 import moe.ouom.neriplayer.core.startup.app.AppStartupPlanner
@@ -136,6 +137,7 @@ class NeriPlayerApplication : Application() {
 
             // 初始化全局下载管理器
             GlobalDownloadManager.initialize(this)
+            LegacyJsonCleanupScheduler.schedule(this, "app-init")
 
             // 初始化 LyriconManager, 如果用户启用了 Lyricon 功能
             if (readPlaybackPreferenceSnapshotSync(this).lyriconEnabled) {

--- a/app/src/main/java/moe/ouom/neriplayer/NeriPlayerApplication.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/NeriPlayerApplication.kt
@@ -118,6 +118,12 @@ class NeriPlayerApplication : Application() {
                 AppContainer.playbackStatsRepo
             }
             AppContainer.launchBackgroundIo {
+                AppContainer.neteasePlaylistCacheRepo.importLegacyCaches()
+                AppContainer.biliFavoriteFolderCacheRepo.importLegacyCaches()
+                AppContainer.biliArchiveCacheRepo.importLegacyCaches()
+                AppContainer.youtubeMusicPlaylistCacheRepo.importLegacyCaches()
+            }
+            AppContainer.launchBackgroundIo {
                 AppContainer.settingsRepo.usbDeviceAttachHandlingEnabledFlow.collect { enabled ->
                     UsbDeviceAttachHandling.applyComponentState(
                         this@NeriPlayerApplication,

--- a/app/src/main/java/moe/ouom/neriplayer/core/di/AppContainer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/di/AppContainer.kt
@@ -66,6 +66,7 @@ import moe.ouom.neriplayer.data.platform.youtube.YouTubeMusicPlaylistCacheReposi
 import moe.ouom.neriplayer.data.playlist.usage.LocalPlaylistPlaybackStatsRepository
 import moe.ouom.neriplayer.data.playlist.usage.PlaylistUsageRepository
 import moe.ouom.neriplayer.data.stats.PlaybackStatsRepository
+import moe.ouom.neriplayer.data.sync.CoverUrlMapper
 import moe.ouom.neriplayer.data.traffic.TrafficStatsRepository
 import moe.ouom.neriplayer.listentogether.network.http.ListenTogetherApi
 import moe.ouom.neriplayer.listentogether.ListenTogetherSessionManager
@@ -446,6 +447,7 @@ object AppContainer {
         AudioDownloadManager.initialize(app)
         warmLocalPlaylistRepository()
         warmBiliVideoSkipRepository()
+        warmCoverUrlMapper()
         primeProxySetting()
         startCookieObserver()
         startYouTubeAuthObserver()
@@ -472,6 +474,16 @@ object AppContainer {
                 BiliVideoSkipRepository.getInstance(application)
             }.onFailure { error ->
                 NPLogger.e("AppContainer", "Failed to preload Bili video skip rules", error)
+            }
+        }
+    }
+
+    private fun warmCoverUrlMapper() {
+        scope.launch {
+            runCatching {
+                CoverUrlMapper.getInstance(application)
+            }.onFailure { error ->
+                NPLogger.e("AppContainer", "Failed to preload cover URL mappings", error)
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/core/di/AppContainer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/di/AppContainer.kt
@@ -445,6 +445,7 @@ object AppContainer {
         initialized = true
         AudioDownloadManager.initialize(app)
         warmLocalPlaylistRepository()
+        warmBiliVideoSkipRepository()
         primeProxySetting()
         startCookieObserver()
         startYouTubeAuthObserver()
@@ -461,6 +462,16 @@ object AppContainer {
                 }
             }.onFailure { error ->
                 NPLogger.e("AppContainer", "Failed to preload local playlists", error)
+            }
+        }
+    }
+
+    private fun warmBiliVideoSkipRepository() {
+        scope.launch {
+            runCatching {
+                BiliVideoSkipRepository.getInstance(application)
+            }.onFailure { error ->
+                NPLogger.e("AppContainer", "Failed to preload Bili video skip rules", error)
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/GlobalDownloadManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/GlobalDownloadManager.kt
@@ -58,6 +58,7 @@ import moe.ouom.neriplayer.core.download.policy.tagPostProcessingAction
 import moe.ouom.neriplayer.core.download.policy.shouldPreserveCompletedAudioAfterFinalizationFailure
 import moe.ouom.neriplayer.core.download.catalog.projectDownloadedSongMetadata
 import moe.ouom.neriplayer.core.download.catalog.toMetadataPersistenceSong
+import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.core.player.download.AudioDownloadManager
 import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.data.local.media.LocalMediaSupport
@@ -222,7 +223,12 @@ object GlobalDownloadManager {
         scope.launch {
             val startupRecovery = ManagedDownloadStorage.consumeStartupRecoveryResult()
             val restoredCatalog = restorePersistedDownloadedSongs(appContext)
+            runCatching { ManagedDownloadStorage.listCancelledDownloadKeys(appContext) }
+                .onFailure { error ->
+                    NPLogger.w(TAG, "预热已取消下载标记失败: ${error.message}")
+                }
             recoverPendingDownloadsForStartup(appContext)
+            LegacyJsonCleanupScheduler.schedule(appContext, "download-startup")
             if (
                 !shouldRunInitialDownloadScan(
                     catalogReady = restoredCatalog,

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/GlobalDownloadManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/GlobalDownloadManager.kt
@@ -1572,7 +1572,7 @@ object GlobalDownloadManager {
             downloadedSongMetadataRevision.incrementAndGet()
             val snapshot = ManagedDownloadStorage.cachedDownloadLibrarySnapshot(
                 context = context,
-                restoreFromDisk = false
+                restorePersisted = false
             )?.takeIf { cachedSnapshot ->
                 cachedSnapshot.audioEntriesByLookupKey.containsKey(storedAudio.reference) ||
                     cachedSnapshot.audioEntriesByLookupKey.containsKey(storedAudio.mediaUri)
@@ -1957,7 +1957,7 @@ object GlobalDownloadManager {
 
                 val snapshot = ManagedDownloadStorage.cachedDownloadLibrarySnapshot(
                     context = appContext,
-                    restoreFromDisk = false
+                    restorePersisted = false
                 )
                 val storedAudio = snapshot?.audioEntriesByLookupKey?.get(playbackReference)
                 val playbackUri = storedAudio?.playbackUri
@@ -2776,7 +2776,7 @@ object GlobalDownloadManager {
         val reference = resolveDownloadedSongPlaybackReference(downloadedSong) ?: return null
         val snapshot = ManagedDownloadStorage.cachedDownloadLibrarySnapshot(
             context = context,
-            restoreFromDisk = false
+            restorePersisted = false
         )
         if (!shouldTrustFastDownloadedSongCatalogHit(reference, snapshot?.knownReferences)) {
             NPLogger.w(

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/ManagedDownloadRecoveryFiles.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/ManagedDownloadRecoveryFiles.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import moe.ouom.neriplayer.core.download.storage.DOWNLOAD_STAGING_DIR_NAME
+import moe.ouom.neriplayer.core.download.storage.CANCELLED_DOWNLOAD_KEYS_FILE_NAME
 import moe.ouom.neriplayer.core.download.storage.ManagedDownloadStorageJsonCodec
+import moe.ouom.neriplayer.core.download.storage.PENDING_DOWNLOAD_QUEUE_FILE_NAME
 import moe.ouom.neriplayer.core.download.storage.queue.ManagedDownloadQueueStore
 import moe.ouom.neriplayer.core.download.storage.queue.DownloadRecoveryRoomStore
 import moe.ouom.neriplayer.core.download.storage.working.ManagedDownloadWorkingStore
@@ -120,50 +122,90 @@ internal object ManagedDownloadRecoveryFiles {
     }
 
     fun upsertPendingDownloadQueue(context: Context, songs: List<SongItem>) {
-        runBlocking(Dispatchers.IO) {
-            roomStore(context).upsertPendingDownloadQueue(songs)
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore(context).upsertPendingDownloadQueue(songs)
+            }
+        }.onFailure { error ->
+            NPLogger.w(TAG, "写入下载队列失败，等待下次恢复: ${error.message}")
         }
     }
 
     fun listPendingQueuedDownloads(context: Context): List<ManagedDownloadStorage.PendingDownloadQueueEntry> {
-        return runBlocking(Dispatchers.IO) {
-            roomStore(context).listPendingQueuedDownloads()
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore(context).listPendingQueuedDownloads()
+            }
+        }.onFailure { error ->
+            NPLogger.w(TAG, "读取下载队列数据库失败，尝试旧恢复文件: ${error.message}")
+        }.getOrElse {
+            listPendingQueuedDownloadsFromFile(
+                File(context.applicationContext.filesDir, PENDING_DOWNLOAD_QUEUE_FILE_NAME)
+            )
         }
     }
 
     fun removePendingDownloadQueueEntries(context: Context, songKeys: Collection<String>) {
-        runBlocking(Dispatchers.IO) {
-            roomStore(context).removePendingDownloadQueueEntries(songKeys)
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore(context).removePendingDownloadQueueEntries(songKeys)
+            }
+        }.onFailure { error ->
+            NPLogger.w(TAG, "删除下载队列条目失败: ${error.message}")
         }
     }
 
     fun clearPendingDownloadQueue(context: Context) {
-        runBlocking(Dispatchers.IO) {
-            roomStore(context).clearPendingDownloadQueue()
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore(context).clearPendingDownloadQueue()
+            }
+        }.onFailure { error ->
+            NPLogger.w(TAG, "清空下载队列失败: ${error.message}")
         }
     }
 
     fun markCancelledDownloadKeys(context: Context, songKeys: Collection<String>) {
-        runBlocking(Dispatchers.IO) {
-            roomStore(context).markCancelledDownloadKeys(songKeys)
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore(context).markCancelledDownloadKeys(songKeys)
+            }
+        }.onFailure { error ->
+            NPLogger.w(TAG, "写入下载取消标记失败: ${error.message}")
         }
     }
 
     fun listCancelledDownloadKeys(context: Context): Set<String> {
-        return runBlocking(Dispatchers.IO) {
-            roomStore(context).listCancelledDownloadKeys()
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore(context).listCancelledDownloadKeys()
+            }
+        }.onFailure { error ->
+            NPLogger.w(TAG, "读取下载取消标记数据库失败，尝试旧恢复文件: ${error.message}")
+        }.getOrElse {
+            listCancelledDownloadKeysFromFile(
+                File(context.applicationContext.filesDir, CANCELLED_DOWNLOAD_KEYS_FILE_NAME)
+            )
         }
     }
 
     fun removeCancelledDownloadKeys(context: Context, songKeys: Collection<String>) {
-        runBlocking(Dispatchers.IO) {
-            roomStore(context).removeCancelledDownloadKeys(songKeys)
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore(context).removeCancelledDownloadKeys(songKeys)
+            }
+        }.onFailure { error ->
+            NPLogger.w(TAG, "删除下载取消标记失败: ${error.message}")
         }
     }
 
     fun clearCancelledDownloadKeys(context: Context) {
-        runBlocking(Dispatchers.IO) {
-            roomStore(context).clearCancelledDownloadKeys()
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore(context).clearCancelledDownloadKeys()
+            }
+        }.onFailure { error ->
+            NPLogger.w(TAG, "清空下载取消标记失败: ${error.message}")
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/ManagedDownloadRecoveryFiles.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/ManagedDownloadRecoveryFiles.kt
@@ -1,14 +1,16 @@
 package moe.ouom.neriplayer.core.download
 
 import android.content.Context
-import moe.ouom.neriplayer.core.download.storage.CANCELLED_DOWNLOAD_KEYS_FILE_NAME
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import moe.ouom.neriplayer.core.download.storage.DOWNLOAD_STAGING_DIR_NAME
 import moe.ouom.neriplayer.core.download.storage.ManagedDownloadStorageJsonCodec
-import moe.ouom.neriplayer.core.download.storage.PENDING_DOWNLOAD_QUEUE_FILE_NAME
 import moe.ouom.neriplayer.core.download.storage.queue.ManagedDownloadQueueStore
+import moe.ouom.neriplayer.core.download.storage.queue.DownloadRecoveryRoomStore
 import moe.ouom.neriplayer.core.download.storage.working.ManagedDownloadWorkingStore
 import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import java.io.File
 
 internal object ManagedDownloadRecoveryFiles {
@@ -118,47 +120,51 @@ internal object ManagedDownloadRecoveryFiles {
     }
 
     fun upsertPendingDownloadQueue(context: Context, songs: List<SongItem>) {
-        upsertPendingDownloadQueueInFile(
-            queueFile = pendingDownloadQueueFile(context),
-            songs = songs
-        )
+        runBlocking(Dispatchers.IO) {
+            roomStore(context).upsertPendingDownloadQueue(songs)
+        }
     }
 
     fun listPendingQueuedDownloads(context: Context): List<ManagedDownloadStorage.PendingDownloadQueueEntry> {
-        return listPendingQueuedDownloadsFromFile(pendingDownloadQueueFile(context))
+        return runBlocking(Dispatchers.IO) {
+            roomStore(context).listPendingQueuedDownloads()
+        }
     }
 
     fun removePendingDownloadQueueEntries(context: Context, songKeys: Collection<String>) {
-        removePendingDownloadQueueEntriesFromFile(
-            queueFile = pendingDownloadQueueFile(context),
-            songKeys = songKeys
-        )
+        runBlocking(Dispatchers.IO) {
+            roomStore(context).removePendingDownloadQueueEntries(songKeys)
+        }
     }
 
     fun clearPendingDownloadQueue(context: Context) {
-        clearPendingDownloadQueueFile(pendingDownloadQueueFile(context))
+        runBlocking(Dispatchers.IO) {
+            roomStore(context).clearPendingDownloadQueue()
+        }
     }
 
     fun markCancelledDownloadKeys(context: Context, songKeys: Collection<String>) {
-        markCancelledDownloadKeysInFile(
-            keysFile = cancelledDownloadKeysFile(context),
-            songKeys = songKeys
-        )
+        runBlocking(Dispatchers.IO) {
+            roomStore(context).markCancelledDownloadKeys(songKeys)
+        }
     }
 
     fun listCancelledDownloadKeys(context: Context): Set<String> {
-        return listCancelledDownloadKeysFromFile(cancelledDownloadKeysFile(context))
+        return runBlocking(Dispatchers.IO) {
+            roomStore(context).listCancelledDownloadKeys()
+        }
     }
 
     fun removeCancelledDownloadKeys(context: Context, songKeys: Collection<String>) {
-        removeCancelledDownloadKeysFromFile(
-            keysFile = cancelledDownloadKeysFile(context),
-            songKeys = songKeys
-        )
+        runBlocking(Dispatchers.IO) {
+            roomStore(context).removeCancelledDownloadKeys(songKeys)
+        }
     }
 
     fun clearCancelledDownloadKeys(context: Context) {
-        clearCancelledDownloadKeysFile(cancelledDownloadKeysFile(context))
+        runBlocking(Dispatchers.IO) {
+            roomStore(context).clearCancelledDownloadKeys()
+        }
     }
 
     fun upsertPendingDownloadQueueInFile(
@@ -268,11 +274,10 @@ internal object ManagedDownloadRecoveryFiles {
         }
     }
 
-    private fun pendingDownloadQueueFile(context: Context): File {
-        return File(context.filesDir, PENDING_DOWNLOAD_QUEUE_FILE_NAME)
-    }
-
-    private fun cancelledDownloadKeysFile(context: Context): File {
-        return File(context.filesDir, CANCELLED_DOWNLOAD_KEYS_FILE_NAME)
+    private fun roomStore(context: Context): DownloadRecoveryRoomStore {
+        return DownloadRecoveryRoomStore(
+            context = context.applicationContext,
+            database = NeriUserDataDatabase.getInstance(context.applicationContext)
+        )
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorage.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorage.kt
@@ -479,9 +479,9 @@ internal object ManagedDownloadStorage {
 
     internal fun cachedDownloadLibrarySnapshot(
         context: Context,
-        restoreFromDisk: Boolean = true
+        restorePersisted: Boolean = true
     ): DownloadLibrarySnapshot? {
-        return snapshotCacheStore.cachedSnapshot(context, restoreFromDisk)
+        return snapshotCacheStore.cachedSnapshot(context, restorePersisted)
     }
 
     internal fun directoryIdentity(uriString: String?): String? {
@@ -936,9 +936,9 @@ internal object ManagedDownloadStorage {
     ): DownloadLibrarySnapshot = synchronized(snapshotBuildLock) {
         val cacheKey = snapshotCacheStore.currentKey(context)
         if (!forceRefresh) {
-            snapshotCacheStore.cachedSnapshot(context, restoreFromDisk = false)
+            snapshotCacheStore.cachedSnapshot(context, restorePersisted = false)
                 ?.let { return@synchronized it }
-            snapshotCacheStore.restoreFromDisk(context, expectedKey = cacheKey)
+            snapshotCacheStore.restorePersisted(context, expectedKey = cacheKey)
                 ?.let { return@synchronized it }
         }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogRoomStore.kt
@@ -55,7 +55,7 @@ internal class DownloadedSongCatalogRoomStore(
         songs: List<DownloadedSong>
     ) {
         val dao = database.downloadedSongCatalogDao()
-        dao.clearSongs()
+        dao.clearSongs(rootKey)
         dao.upsertSongs(
             songs
                 .distinctBy(::catalogRowKey)

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogRoomStore.kt
@@ -1,0 +1,217 @@
+package moe.ouom.neriplayer.core.download.catalog
+
+import android.content.Context
+import androidx.room.withTransaction
+import java.io.File
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import moe.ouom.neriplayer.core.download.DownloadedSong
+import moe.ouom.neriplayer.core.download.withRecoveredRemoteSourceStableKey
+import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.DownloadedSongCatalogEntity
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+
+internal class DownloadedSongCatalogRoomStore(
+    private val context: Context,
+    private val database: NeriUserDataDatabase,
+    private val cacheFileName: String,
+    private val snapshotCacheKeyProvider: (Context) -> String,
+    private val loggerTag: String
+) {
+    suspend fun restore(): List<DownloadedSong>? {
+        globalMutex.withLock {
+            val rootKey = snapshotCacheKeyProvider(context)
+            if (isRoomPrimary()) {
+                if (readRootKey() != rootKey) {
+                    return null
+                }
+                return database.downloadedSongCatalogDao()
+                    .getSongs(rootKey)
+                    .map(DownloadedSongCatalogEntity::toDownloadedSong)
+            }
+
+            val legacySongs = readLegacyCatalog(rootKey) ?: return null
+            database.withTransaction {
+                replaceCatalog(rootKey, legacySongs)
+                markRoomPrimary(rootKey)
+            }
+            return legacySongs
+        }
+    }
+
+    suspend fun persist(songs: List<DownloadedSong>) {
+        globalMutex.withLock {
+            val rootKey = snapshotCacheKeyProvider(context)
+            database.withTransaction {
+                replaceCatalog(rootKey, songs)
+                markRoomPrimary(rootKey)
+            }
+        }
+    }
+
+    private suspend fun replaceCatalog(
+        rootKey: String,
+        songs: List<DownloadedSong>
+    ) {
+        val dao = database.downloadedSongCatalogDao()
+        dao.clearSongs()
+        dao.upsertSongs(
+            songs
+                .distinctBy(::catalogRowKey)
+                .mapIndexed { index, song -> song.toEntity(rootKey, index) }
+        )
+    }
+
+    private suspend fun isRoomPrimary(): Boolean {
+        return database.syncMetadataDao()
+            .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+            ?.value == ROOM_PRIMARY_STATE
+    }
+
+    private suspend fun readRootKey(): String? {
+        return database.syncMetadataDao()
+            .getMigrationMetadata(ROOT_KEY_METADATA_KEY)
+            ?.value
+    }
+
+    private suspend fun markRoomPrimary(rootKey: String) {
+        val nowMs = System.currentTimeMillis()
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = CUTOVER_STATE_METADATA_KEY,
+                value = ROOM_PRIMARY_STATE,
+                updatedAt = nowMs
+            )
+        )
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = ROOT_KEY_METADATA_KEY,
+                value = rootKey,
+                updatedAt = nowMs
+            )
+        )
+    }
+
+    private fun readLegacyCatalog(rootKey: String): List<DownloadedSong>? {
+        val file = File(context.filesDir, cacheFileName)
+        if (!file.exists()) {
+            return null
+        }
+        val rawPayload = runCatching { file.readText(Charsets.UTF_8) }
+            .onFailure { error ->
+                NPLogger.w(loggerTag, "读取旧下载歌曲目录失败: ${error.message}")
+            }
+            .getOrNull()
+            ?: return null
+        if (rawPayload.isBlank()) {
+            return null
+        }
+        return runCatching {
+            deserializeDownloadedSongsCatalog(
+                raw = rawPayload,
+                expectedCacheKey = rootKey
+            )
+        }.onFailure { error ->
+            NPLogger.w(loggerTag, "解析旧下载歌曲目录失败，保留文件等待下次迁移: ${error.message}")
+        }.getOrNull()
+    }
+
+    companion object {
+        const val CUTOVER_STATE_METADATA_KEY = "downloaded_song_catalog_cutover_state"
+        const val ROOT_KEY_METADATA_KEY = "downloaded_song_catalog_root_key"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+        private val globalMutex = Mutex()
+    }
+}
+
+private fun DownloadedSong.toEntity(
+    rootKey: String,
+    displayPosition: Int
+): DownloadedSongCatalogEntity {
+    return DownloadedSongCatalogEntity(
+        catalogKey = catalogRowKey(this),
+        rootKey = rootKey,
+        displayPosition = displayPosition,
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        filePath = filePath,
+        fileSize = fileSize,
+        downloadTime = downloadTime,
+        coverPath = coverPath,
+        coverUrl = coverUrl,
+        matchedLyric = matchedLyric,
+        matchedTranslatedLyric = matchedTranslatedLyric,
+        matchedLyricSource = matchedLyricSource,
+        matchedSongId = matchedSongId,
+        userLyricOffsetMs = userLyricOffsetMs,
+        customCoverUrl = customCoverUrl,
+        customName = customName,
+        customArtist = customArtist,
+        originalName = originalName,
+        originalArtist = originalArtist,
+        originalCoverUrl = originalCoverUrl,
+        originalLyric = originalLyric,
+        originalTranslatedLyric = originalTranslatedLyric,
+        mediaUri = mediaUri,
+        durationMs = durationMs,
+        stableKey = stableKey,
+        sourceIdentityAlbum = sourceIdentityAlbum,
+        sourceMediaUri = sourceMediaUri,
+        sourceChannelId = sourceChannelId,
+        sourceAudioId = sourceAudioId,
+        sourceSubAudioId = sourceSubAudioId,
+        sourcePlaylistContextId = sourcePlaylistContextId
+    )
+}
+
+private fun DownloadedSongCatalogEntity.toDownloadedSong(): DownloadedSong {
+    return DownloadedSong(
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        filePath = filePath,
+        fileSize = fileSize,
+        downloadTime = downloadTime,
+        coverPath = coverPath,
+        coverUrl = coverUrl,
+        matchedLyric = matchedLyric,
+        matchedTranslatedLyric = matchedTranslatedLyric,
+        matchedLyricSource = matchedLyricSource,
+        matchedSongId = matchedSongId,
+        userLyricOffsetMs = userLyricOffsetMs,
+        customCoverUrl = customCoverUrl,
+        customName = customName,
+        customArtist = customArtist,
+        originalName = originalName,
+        originalArtist = originalArtist,
+        originalCoverUrl = originalCoverUrl,
+        originalLyric = originalLyric,
+        originalTranslatedLyric = originalTranslatedLyric,
+        mediaUri = mediaUri,
+        durationMs = durationMs,
+        stableKey = stableKey,
+        sourceIdentityAlbum = sourceIdentityAlbum,
+        sourceMediaUri = sourceMediaUri,
+        sourceChannelId = sourceChannelId,
+        sourceAudioId = sourceAudioId,
+        sourceSubAudioId = sourceSubAudioId,
+        sourcePlaylistContextId = sourcePlaylistContextId
+    ).withRecoveredRemoteSourceStableKey()
+}
+
+private fun catalogRowKey(song: DownloadedSong): String {
+    song.filePath
+        .takeIf(String::isNotBlank)
+        ?.let { return "file:$it" }
+    song.mediaUri
+        ?.takeIf(String::isNotBlank)
+        ?.let { return "uri:$it" }
+    song.stableKey
+        ?.takeIf(String::isNotBlank)
+        ?.let { return "stable:$it" }
+    return "legacy:${song.id}|${song.name}|${song.artist}"
+}

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogStore.kt
@@ -1,10 +1,11 @@
 package moe.ouom.neriplayer.core.download.catalog
 
 import android.content.Context
-import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import moe.ouom.neriplayer.core.download.DownloadedSong
-import moe.ouom.neriplayer.core.download.storage.ManagedDownloadAtomicFile
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 
 internal class DownloadedSongCatalogStore(
     private val cacheFileName: String,
@@ -12,39 +13,33 @@ internal class DownloadedSongCatalogStore(
     private val loggerTag: String
 ) {
     fun restore(context: Context): List<DownloadedSong>? {
-        val rawPayload = runCatching {
-            cacheFile(context).takeIf(File::exists)?.readText(Charsets.UTF_8)
-        }.onFailure {
-            NPLogger.w(loggerTag, "读取下载歌曲目录缓存失败: ${it.message}")
-        }.getOrNull() ?: return null
-
         return runCatching {
-            deserializeDownloadedSongsCatalog(
-                raw = rawPayload,
-                expectedCacheKey = snapshotCacheKeyProvider(context)
-            )
+            runBlocking(Dispatchers.IO) {
+                roomStore(context).restore()
+            }
         }.onFailure {
-            NPLogger.w(loggerTag, "解析下载歌曲目录缓存失败: ${it.message}")
+            NPLogger.w(loggerTag, "读取下载歌曲目录失败: ${it.message}")
         }.getOrNull()
     }
 
     fun persist(context: Context, songs: List<DownloadedSong>) {
         runCatching {
-            val content = serializeDownloadedSongsCatalog(
-                cacheKey = snapshotCacheKeyProvider(context),
-                songs = songs
-            )
-            assert(content.isNotBlank()) { "下载目录缓存序列化为空，songs=${songs.size}" }
-            ManagedDownloadAtomicFile.writeTextAtomically(
-                target = cacheFile(context),
-                content = content
-            )
+            runBlocking(Dispatchers.IO) {
+                roomStore(context).persist(songs)
+            }
         }.onFailure {
-            NPLogger.e(loggerTag, "写入下载歌曲目录缓存失败", it)
+            NPLogger.e(loggerTag, "写入下载歌曲目录失败", it)
         }
     }
 
-    private fun cacheFile(context: Context): File {
-        return File(context.filesDir, cacheFileName)
+    private fun roomStore(context: Context): DownloadedSongCatalogRoomStore {
+        val appContext = context.applicationContext
+        return DownloadedSongCatalogRoomStore(
+            context = appContext,
+            database = NeriUserDataDatabase.getInstance(appContext),
+            cacheFileName = cacheFileName,
+            snapshotCacheKeyProvider = snapshotCacheKeyProvider,
+            loggerTag = loggerTag
+        )
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/queue/DownloadRecoveryRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/queue/DownloadRecoveryRoomStore.kt
@@ -77,7 +77,9 @@ internal class DownloadRecoveryRoomStore(
         }
         globalMigrationMutex.withLock {
             ensurePendingQueueImported()
-            database.downloadRecoveryDao().deletePendingQueue(keys)
+            keys.chunked(500).forEach { chunk ->
+                database.downloadRecoveryDao().deletePendingQueue(chunk)
+            }
         }
     }
 
@@ -125,7 +127,9 @@ internal class DownloadRecoveryRoomStore(
         }
         globalMigrationMutex.withLock {
             ensureCancelledKeysImported()
-            database.downloadRecoveryDao().deleteCancelledKeys(keys)
+            keys.chunked(500).forEach { chunk ->
+                database.downloadRecoveryDao().deleteCancelledKeys(chunk)
+            }
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/queue/DownloadRecoveryRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/queue/DownloadRecoveryRoomStore.kt
@@ -1,0 +1,331 @@
+package moe.ouom.neriplayer.core.download.storage.queue
+
+import android.content.Context
+import androidx.room.withTransaction
+import java.io.File
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
+import moe.ouom.neriplayer.core.download.storage.CANCELLED_DOWNLOAD_KEYS_FILE_NAME
+import moe.ouom.neriplayer.core.download.storage.ManagedDownloadStorageJsonCodec
+import moe.ouom.neriplayer.core.download.storage.PENDING_DOWNLOAD_QUEUE_FILE_NAME
+import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.DownloadCancelledKeyEntity
+import moe.ouom.neriplayer.data.local.database.entity.DownloadPendingQueueEntity
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+import moe.ouom.neriplayer.core.api.search.MusicPlatform
+import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.model.stableKey
+
+internal class DownloadRecoveryRoomStore(
+    private val context: Context,
+    private val database: NeriUserDataDatabase
+) {
+    suspend fun upsertPendingDownloadQueue(
+        songs: List<SongItem>,
+        nowMs: Long = System.currentTimeMillis()
+    ) {
+        val distinctSongs = songs.distinctBy(SongItem::stableKey)
+        if (distinctSongs.isEmpty()) {
+            return
+        }
+        globalMigrationMutex.withLock {
+            ensurePendingQueueImported(nowMs)
+            database.withTransaction {
+                val dao = database.downloadRecoveryDao()
+                val existingEntries = dao.getPendingQueue()
+                    .associateBy(DownloadPendingQueueEntity::stableKey)
+                var nextOrder = (existingEntries.values.maxOfOrNull { it.queueOrder } ?: -1) + 1
+                dao.upsertPendingQueue(
+                    distinctSongs.map { song ->
+                        val stableKey = song.stableKey()
+                        val existing = existingEntries[stableKey]
+                        song.toEntity(
+                            stableKey = stableKey,
+                            queueOrder = existing?.queueOrder ?: nextOrder++,
+                            queuedAtMs = existing?.queuedAtMs ?: nowMs
+                        )
+                    }
+                )
+            }
+        }
+    }
+
+    suspend fun listPendingQueuedDownloads(): List<ManagedDownloadStorage.PendingDownloadQueueEntry> {
+        globalMigrationMutex.withLock {
+            ensurePendingQueueImported()
+            return database.downloadRecoveryDao()
+                .getPendingQueue()
+                .map { entity ->
+                    ManagedDownloadStorage.PendingDownloadQueueEntry(
+                        stableKey = entity.stableKey,
+                        song = entity.toSong(),
+                        order = entity.queueOrder,
+                        queuedAtMs = entity.queuedAtMs
+                    )
+                }
+        }
+    }
+
+    suspend fun removePendingDownloadQueueEntries(
+        songKeys: Collection<String>
+    ) {
+        val keys = songKeys.filter(String::isNotBlank).distinct()
+        if (keys.isEmpty()) {
+            return
+        }
+        globalMigrationMutex.withLock {
+            ensurePendingQueueImported()
+            database.downloadRecoveryDao().deletePendingQueue(keys)
+        }
+    }
+
+    suspend fun clearPendingDownloadQueue() {
+        globalMigrationMutex.withLock {
+            ensurePendingQueueImported()
+            database.downloadRecoveryDao().clearPendingQueue()
+        }
+    }
+
+    suspend fun markCancelledDownloadKeys(
+        songKeys: Collection<String>,
+        nowMs: Long = System.currentTimeMillis()
+    ) {
+        val keys = songKeys.filter(String::isNotBlank).distinct()
+        if (keys.isEmpty()) {
+            return
+        }
+        globalMigrationMutex.withLock {
+            ensureCancelledKeysImported(nowMs)
+            database.downloadRecoveryDao().insertCancelledKeys(
+                keys.map { stableKey ->
+                    DownloadCancelledKeyEntity(
+                        stableKey = stableKey,
+                        cancelledAtMs = nowMs
+                    )
+                }
+            )
+        }
+    }
+
+    suspend fun listCancelledDownloadKeys(): Set<String> {
+        globalMigrationMutex.withLock {
+            ensureCancelledKeysImported()
+            return database.downloadRecoveryDao()
+                .getCancelledKeys()
+                .toSet()
+        }
+    }
+
+    suspend fun removeCancelledDownloadKeys(songKeys: Collection<String>) {
+        val keys = songKeys.filter(String::isNotBlank).distinct()
+        if (keys.isEmpty()) {
+            return
+        }
+        globalMigrationMutex.withLock {
+            ensureCancelledKeysImported()
+            database.downloadRecoveryDao().deleteCancelledKeys(keys)
+        }
+    }
+
+    suspend fun clearCancelledDownloadKeys() {
+        globalMigrationMutex.withLock {
+            ensureCancelledKeysImported()
+            database.downloadRecoveryDao().clearCancelledKeys()
+        }
+    }
+
+    private suspend fun ensurePendingQueueImported(
+        nowMs: Long = System.currentTimeMillis()
+    ) {
+        if (isRoomPrimary(PENDING_QUEUE_CUTOVER_STATE_KEY)) {
+            return
+        }
+        val legacyEntries = readLegacyPendingQueue() ?: return
+        database.withTransaction {
+            if (isRoomPrimary(PENDING_QUEUE_CUTOVER_STATE_KEY)) {
+                return@withTransaction
+            }
+            val dao = database.downloadRecoveryDao()
+            dao.clearPendingQueue()
+            dao.upsertPendingQueue(
+                legacyEntries.map { entry ->
+                    entry.song.toEntity(
+                        stableKey = entry.stableKey,
+                        queueOrder = entry.order,
+                        queuedAtMs = entry.queuedAtMs
+                    )
+                }
+            )
+            markRoomPrimary(PENDING_QUEUE_CUTOVER_STATE_KEY, nowMs)
+        }
+    }
+
+    private suspend fun ensureCancelledKeysImported(
+        nowMs: Long = System.currentTimeMillis()
+    ) {
+        if (isRoomPrimary(CANCELLED_KEYS_CUTOVER_STATE_KEY)) {
+            return
+        }
+        val legacyKeys = readLegacyCancelledKeys() ?: return
+        database.withTransaction {
+            if (isRoomPrimary(CANCELLED_KEYS_CUTOVER_STATE_KEY)) {
+                return@withTransaction
+            }
+            val dao = database.downloadRecoveryDao()
+            dao.clearCancelledKeys()
+            dao.insertCancelledKeys(
+                legacyKeys.map { stableKey ->
+                    DownloadCancelledKeyEntity(
+                        stableKey = stableKey,
+                        cancelledAtMs = nowMs
+                    )
+                }
+            )
+            markRoomPrimary(CANCELLED_KEYS_CUTOVER_STATE_KEY, nowMs)
+        }
+    }
+
+    private suspend fun isRoomPrimary(key: String): Boolean {
+        return database.syncMetadataDao()
+            .getMigrationMetadata(key)
+            ?.value == ROOM_PRIMARY_STATE
+    }
+
+    private suspend fun markRoomPrimary(key: String, nowMs: Long) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = key,
+                value = ROOM_PRIMARY_STATE,
+                updatedAt = nowMs
+            )
+        )
+    }
+
+    private fun readLegacyPendingQueue(): List<ManagedDownloadStorage.PendingDownloadQueueEntry>? {
+        val file = File(context.filesDir, PENDING_DOWNLOAD_QUEUE_FILE_NAME)
+        if (!file.exists()) {
+            return emptyList()
+        }
+        val rawPayload = runCatching { file.readText(Charsets.UTF_8) }
+            .onFailure { error ->
+                NPLogger.w(TAG, "读取旧下载队列失败: ${error.message}")
+            }
+            .getOrNull()
+            ?: return null
+        if (rawPayload.isBlank()) {
+            return emptyList()
+        }
+        return runCatching {
+            ManagedDownloadStorageJsonCodec.parsePendingDownloadQueuePayload(rawPayload)
+        }.onFailure { error ->
+            NPLogger.w(TAG, "解析旧下载队列失败，保留文件等待下次迁移: ${error.message}")
+        }.getOrNull()
+    }
+
+    private fun readLegacyCancelledKeys(): Set<String>? {
+        val file = File(context.filesDir, CANCELLED_DOWNLOAD_KEYS_FILE_NAME)
+        if (!file.exists()) {
+            return emptySet()
+        }
+        val rawPayload = runCatching { file.readText(Charsets.UTF_8) }
+            .onFailure { error ->
+                NPLogger.w(TAG, "读取旧下载取消标记失败: ${error.message}")
+            }
+            .getOrNull()
+            ?: return null
+        if (rawPayload.isBlank()) {
+            return emptySet()
+        }
+        return runCatching {
+            ManagedDownloadStorageJsonCodec.parseCancelledDownloadKeysPayload(rawPayload)
+        }.onFailure { error ->
+            NPLogger.w(TAG, "解析旧下载取消标记失败，保留文件等待下次迁移: ${error.message}")
+        }.getOrNull()
+    }
+
+    companion object {
+        const val PENDING_QUEUE_CUTOVER_STATE_KEY = "download_pending_queue_cutover_state"
+        const val CANCELLED_KEYS_CUTOVER_STATE_KEY = "download_cancelled_keys_cutover_state"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+        private const val TAG = "DownloadRecoveryRoomStore"
+        private val globalMigrationMutex = Mutex()
+    }
+}
+
+private fun SongItem.toEntity(
+    stableKey: String,
+    queueOrder: Int,
+    queuedAtMs: Long
+): DownloadPendingQueueEntity {
+    return DownloadPendingQueueEntity(
+        stableKey = stableKey,
+        queueOrder = queueOrder,
+        queuedAtMs = queuedAtMs,
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        albumId = albumId,
+        durationMs = durationMs,
+        coverUrl = coverUrl,
+        mediaUri = mediaUri,
+        matchedLyric = matchedLyric,
+        matchedTranslatedLyric = matchedTranslatedLyric,
+        matchedLyricSource = matchedLyricSource?.name,
+        matchedSongId = matchedSongId,
+        userLyricOffsetMs = userLyricOffsetMs,
+        customCoverUrl = customCoverUrl,
+        customName = customName,
+        customArtist = customArtist,
+        originalName = originalName,
+        originalArtist = originalArtist,
+        originalCoverUrl = originalCoverUrl,
+        originalLyric = originalLyric,
+        originalTranslatedLyric = originalTranslatedLyric,
+        localFileName = localFileName,
+        localFilePath = localFilePath,
+        channelId = channelId,
+        audioId = audioId,
+        subAudioId = subAudioId,
+        playlistContextId = playlistContextId,
+        sourceStableKey = sourceStableKey,
+        streamUrl = streamUrl
+    )
+}
+
+private fun DownloadPendingQueueEntity.toSong(): SongItem {
+    return SongItem(
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        albumId = albumId,
+        durationMs = durationMs,
+        coverUrl = coverUrl,
+        mediaUri = mediaUri,
+        matchedLyric = matchedLyric,
+        matchedTranslatedLyric = matchedTranslatedLyric,
+        matchedLyricSource = matchedLyricSource
+            ?.let { value -> runCatching { MusicPlatform.valueOf(value) }.getOrNull() },
+        matchedSongId = matchedSongId,
+        userLyricOffsetMs = userLyricOffsetMs,
+        customCoverUrl = customCoverUrl,
+        customName = customName,
+        customArtist = customArtist,
+        originalName = originalName,
+        originalArtist = originalArtist,
+        originalCoverUrl = originalCoverUrl,
+        originalLyric = originalLyric,
+        originalTranslatedLyric = originalTranslatedLyric,
+        localFileName = localFileName,
+        localFilePath = localFilePath,
+        channelId = channelId,
+        audioId = audioId,
+        subAudioId = subAudioId,
+        playlistContextId = playlistContextId,
+        sourceStableKey = sourceStableKey,
+        streamUrl = streamUrl
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotCacheStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotCacheStore.kt
@@ -8,11 +8,16 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
 import moe.ouom.neriplayer.core.download.storage.SNAPSHOT_CACHE_PERSIST_DEBOUNCE_MS
+import moe.ouom.neriplayer.core.logging.NPLogger
 
 internal class ManagedDownloadSnapshotCacheStore(
     private val scope: CoroutineScope,
     private val cacheKeyProvider: (Context) -> String
 ) {
+    private companion object {
+        const val TAG = "ManagedDownloadSnapshot"
+    }
+
     private data class SnapshotCache(
         val key: String,
         val snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
@@ -152,8 +157,15 @@ internal class ManagedDownloadSnapshotCacheStore(
             snapshotPersistJob = null
         }
         val appContext = context?.applicationContext ?: return
-        runBlocking {
-            ManagedDownloadSnapshotRoomStore(appContext).clear()
+        runCatching {
+            val cleared = runBlocking {
+                ManagedDownloadSnapshotRoomStore(appContext).clear()
+            }
+            if (!cleared) {
+                NPLogger.w(TAG, "下载索引数据库未清理成功，保留旧恢复缓存")
+            }
+        }.onFailure { error ->
+            NPLogger.w(TAG, "清理下载索引缓存失败: ${error.message}")
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotCacheStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotCacheStore.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
 import moe.ouom.neriplayer.core.download.storage.SNAPSHOT_CACHE_PERSIST_DEBOUNCE_MS
 
@@ -40,12 +41,12 @@ internal class ManagedDownloadSnapshotCacheStore(
         if (currentCache?.key == cacheKey) {
             return true
         }
-        return restoreFromDisk(appContext, expectedKey = cacheKey) != null
+        return restorePersisted(appContext, expectedKey = cacheKey) != null
     }
 
     fun cachedSnapshot(
         context: Context,
-        restoreFromDisk: Boolean = true
+        restorePersisted: Boolean = true
     ): ManagedDownloadStorage.DownloadLibrarySnapshot? {
         val appContext = context.applicationContext
         val cacheKey = currentKey(appContext)
@@ -53,10 +54,10 @@ internal class ManagedDownloadSnapshotCacheStore(
             ?.takeIf { it.key == cacheKey }
             ?.snapshot
             ?.let { return it }
-        if (!restoreFromDisk) {
+        if (!restorePersisted) {
             return null
         }
-        return restoreFromDisk(appContext, expectedKey = cacheKey)
+        return restorePersisted(appContext, expectedKey = cacheKey)
     }
 
     fun putSnapshot(
@@ -68,14 +69,14 @@ internal class ManagedDownloadSnapshotCacheStore(
         schedulePersist(context.applicationContext, cacheKey)
     }
 
-    fun restoreFromDisk(
+    fun restorePersisted(
         context: Context,
         expectedKey: String? = null
     ): ManagedDownloadStorage.DownloadLibrarySnapshot? {
-        val restored = ManagedDownloadSnapshotDiskCache.restore(
-            context = context.applicationContext,
-            expectedKey = expectedKey
-        ) ?: return null
+        val appContext = context.applicationContext
+        val restored = runBlocking {
+            ManagedDownloadSnapshotRoomStore(appContext).restore(expectedKey)
+        } ?: return null
         snapshotCache = SnapshotCache(key = restored.first, snapshot = restored.second)
         return restored.second
     }
@@ -90,7 +91,7 @@ internal class ManagedDownloadSnapshotCacheStore(
         val currentSnapshot = snapshotCache
             ?.takeIf { it.key == cacheKey }
             ?.snapshot
-            ?: restoreFromDisk(appContext, expectedKey = cacheKey)
+            ?: restorePersisted(appContext, expectedKey = cacheKey)
             ?: return true
         val updatedSnapshot = ManagedDownloadSnapshotIndex.applyMetadataWrite(
             snapshot = currentSnapshot,
@@ -111,7 +112,7 @@ internal class ManagedDownloadSnapshotCacheStore(
         val currentSnapshot = snapshotCache
             ?.takeIf { it.key == cacheKey }
             ?.snapshot
-            ?: restoreFromDisk(appContext, expectedKey = cacheKey)
+            ?: restorePersisted(appContext, expectedKey = cacheKey)
             ?: return false
         val updatedSnapshot = ManagedDownloadSnapshotIndex.applyStoredEntryWrite(
             snapshot = currentSnapshot,
@@ -134,7 +135,7 @@ internal class ManagedDownloadSnapshotCacheStore(
         val currentSnapshot = snapshotCache
             ?.takeIf { it.key == cacheKey }
             ?.snapshot
-            ?: restoreFromDisk(appContext, expectedKey = cacheKey)
+            ?: restorePersisted(appContext, expectedKey = cacheKey)
             ?: return true
         val updatedSnapshot = ManagedDownloadSnapshotIndex.applyReferenceDeletes(
             snapshot = currentSnapshot,
@@ -151,7 +152,9 @@ internal class ManagedDownloadSnapshotCacheStore(
             snapshotPersistJob = null
         }
         val appContext = context?.applicationContext ?: return
-        ManagedDownloadSnapshotDiskCache.delete(appContext)
+        runBlocking {
+            ManagedDownloadSnapshotRoomStore(appContext).clear()
+        }
     }
 
     private fun schedulePersist(
@@ -166,11 +169,12 @@ internal class ManagedDownloadSnapshotCacheStore(
                 val currentCache = snapshotCache
                     ?.takeIf { it.key == expectedKey }
                     ?: return@launch
-                ManagedDownloadSnapshotDiskCache.persist(
-                    context = appContext,
+                if (ManagedDownloadSnapshotRoomStore(appContext).persist(
                     cacheKey = currentCache.key,
                     snapshot = currentCache.snapshot
-                )
+                )) {
+                    ManagedDownloadSnapshotDiskCache.delete(appContext)
+                }
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotDiskCache.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotDiskCache.kt
@@ -31,14 +31,15 @@ internal object ManagedDownloadSnapshotDiskCache {
         }.getOrNull()
     }
 
-    fun delete(context: Context) {
-        runCatching {
+    fun delete(context: Context): Boolean {
+        return runCatching {
             val cacheFile = cacheFile(context)
             if (cacheFile.exists() && !cacheFile.delete()) {
                 throw IOException("无法删除旧下载索引缓存")
             }
+            true
         }.onFailure {
             NPLogger.w(TAG, "清理下载索引缓存失败: ${it.message}")
-        }
+        }.getOrDefault(false)
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotDiskCache.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotDiskCache.kt
@@ -14,21 +14,6 @@ internal object ManagedDownloadSnapshotDiskCache {
         return File(context.filesDir, SNAPSHOT_CACHE_FILE_NAME)
     }
 
-    fun persist(
-        context: Context,
-        cacheKey: String,
-        snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
-    ) {
-        runCatching {
-            cacheFile(context).writeText(
-                ManagedDownloadSnapshotIndex.serializePayload(cacheKey, snapshot),
-                Charsets.UTF_8
-            )
-        }.onFailure {
-            NPLogger.w(TAG, "写入下载索引缓存失败: ${it.message}")
-        }
-    }
-
     fun restore(
         context: Context,
         expectedKey: String? = null

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomMapper.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomMapper.kt
@@ -1,0 +1,172 @@
+package moe.ouom.neriplayer.core.download.storage.snapshot
+
+import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
+import moe.ouom.neriplayer.data.local.database.entity.DownloadSnapshotEntryEntity
+import moe.ouom.neriplayer.data.local.database.entity.DownloadSnapshotMetadataEntity
+
+internal object ManagedDownloadSnapshotRoomMapper {
+    const val BUCKET_AUDIO = "audio"
+    const val BUCKET_METADATA = "metadata"
+    const val BUCKET_COVER = "cover"
+    const val BUCKET_LYRIC = "lyric"
+
+    fun toEntryEntities(
+        rootKey: String,
+        snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
+    ): List<DownloadSnapshotEntryEntity> {
+        return buildList {
+            addAll(snapshot.audioEntries.toEntryEntities(rootKey, BUCKET_AUDIO))
+            addAll(
+                snapshot.metadataEntriesByAudioName.values
+                    .toList()
+                    .toEntryEntities(rootKey, BUCKET_METADATA)
+            )
+            addAll(
+                snapshot.coverEntriesByName.values
+                    .toList()
+                    .toEntryEntities(rootKey, BUCKET_COVER)
+            )
+            addAll(
+                snapshot.lyricEntriesByName.values
+                    .toList()
+                    .toEntryEntities(rootKey, BUCKET_LYRIC)
+            )
+        }
+    }
+
+    fun toMetadataEntities(
+        rootKey: String,
+        snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
+    ): List<DownloadSnapshotMetadataEntity> {
+        return snapshot.metadataByAudioName
+            .entries
+            .sortedBy { it.key }
+            .map { (audioName, metadata) ->
+                DownloadSnapshotMetadataEntity(
+                    rootKey = rootKey,
+                    audioName = audioName,
+                    stableKey = metadata.stableKey,
+                    songId = metadata.songId,
+                    identityAlbum = metadata.identityAlbum,
+                    name = metadata.name,
+                    artist = metadata.artist,
+                    coverUrl = metadata.coverUrl,
+                    matchedLyric = metadata.matchedLyric,
+                    matchedTranslatedLyric = metadata.matchedTranslatedLyric,
+                    matchedLyricSource = metadata.matchedLyricSource,
+                    matchedSongId = metadata.matchedSongId,
+                    userLyricOffsetMs = metadata.userLyricOffsetMs,
+                    customCoverUrl = metadata.customCoverUrl,
+                    customName = metadata.customName,
+                    customArtist = metadata.customArtist,
+                    originalName = metadata.originalName,
+                    originalArtist = metadata.originalArtist,
+                    originalCoverUrl = metadata.originalCoverUrl,
+                    originalLyric = metadata.originalLyric,
+                    originalTranslatedLyric = metadata.originalTranslatedLyric,
+                    mediaUri = metadata.mediaUri,
+                    channelId = metadata.channelId,
+                    audioId = metadata.audioId,
+                    subAudioId = metadata.subAudioId,
+                    playlistContextId = metadata.playlistContextId,
+                    coverPath = metadata.coverPath,
+                    lyricPath = metadata.lyricPath,
+                    translatedLyricPath = metadata.translatedLyricPath,
+                    durationMs = metadata.durationMs,
+                    downloadFinalized = metadata.downloadFinalized
+                )
+            }
+    }
+
+    fun toSnapshot(
+        audioEntries: List<DownloadSnapshotEntryEntity>,
+        metadataEntries: List<DownloadSnapshotEntryEntity>,
+        metadata: List<DownloadSnapshotMetadataEntity>,
+        coverEntries: List<DownloadSnapshotEntryEntity>,
+        lyricEntries: List<DownloadSnapshotEntryEntity>
+    ): ManagedDownloadStorage.DownloadLibrarySnapshot {
+        return ManagedDownloadSnapshotIndex.compose(
+            audioEntries = audioEntries.map { it.toStoredEntry() },
+            metadataEntries = metadataEntries.map { it.toStoredEntry() },
+            metadataByAudioName = metadata.associate { entity ->
+                entity.audioName to entity.toDownloadedAudioMetadata()
+            },
+            coverEntries = coverEntries.map { it.toStoredEntry() },
+            lyricEntries = lyricEntries.map { it.toStoredEntry() }
+        )
+    }
+
+    private fun List<ManagedDownloadStorage.StoredEntry>.toEntryEntities(
+        rootKey: String,
+        bucket: String
+    ): List<DownloadSnapshotEntryEntity> {
+        return distinctBy(::entryKey)
+            .mapIndexed { index, entry ->
+                DownloadSnapshotEntryEntity(
+                    rootKey = rootKey,
+                    bucket = bucket,
+                    entryKey = entryKey(entry),
+                    displayPosition = index,
+                    name = entry.name,
+                    reference = entry.reference,
+                    mediaUri = entry.mediaUri,
+                    localFilePath = entry.localFilePath,
+                    sizeBytes = entry.sizeBytes,
+                    lastModifiedMs = entry.lastModifiedMs,
+                    isDirectory = entry.isDirectory
+                )
+            }
+    }
+
+    private fun DownloadSnapshotEntryEntity.toStoredEntry(): ManagedDownloadStorage.StoredEntry {
+        return ManagedDownloadStorage.StoredEntry(
+            name = name,
+            reference = reference,
+            mediaUri = mediaUri,
+            localFilePath = localFilePath,
+            sizeBytes = sizeBytes,
+            lastModifiedMs = lastModifiedMs,
+            isDirectory = isDirectory
+        )
+    }
+
+    private fun DownloadSnapshotMetadataEntity.toDownloadedAudioMetadata(): ManagedDownloadStorage.DownloadedAudioMetadata {
+        return ManagedDownloadStorage.DownloadedAudioMetadata(
+            stableKey = stableKey,
+            songId = songId,
+            identityAlbum = identityAlbum,
+            name = name,
+            artist = artist,
+            coverUrl = coverUrl,
+            matchedLyric = matchedLyric,
+            matchedTranslatedLyric = matchedTranslatedLyric,
+            matchedLyricSource = matchedLyricSource,
+            matchedSongId = matchedSongId,
+            userLyricOffsetMs = userLyricOffsetMs,
+            customCoverUrl = customCoverUrl,
+            customName = customName,
+            customArtist = customArtist,
+            originalName = originalName,
+            originalArtist = originalArtist,
+            originalCoverUrl = originalCoverUrl,
+            originalLyric = originalLyric,
+            originalTranslatedLyric = originalTranslatedLyric,
+            mediaUri = mediaUri,
+            channelId = channelId,
+            audioId = audioId,
+            subAudioId = subAudioId,
+            playlistContextId = playlistContextId,
+            coverPath = coverPath,
+            lyricPath = lyricPath,
+            translatedLyricPath = translatedLyricPath,
+            durationMs = durationMs,
+            downloadFinalized = downloadFinalized
+        )
+    }
+
+    private fun entryKey(entry: ManagedDownloadStorage.StoredEntry): String {
+        entry.reference.takeIf(String::isNotBlank)?.let { return it }
+        entry.mediaUri.takeIf(String::isNotBlank)?.let { return "uri:$it" }
+        return "name:${entry.name}"
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomStore.kt
@@ -1,0 +1,147 @@
+package moe.ouom.neriplayer.core.download.storage.snapshot
+
+import android.content.Context
+import androidx.room.withTransaction
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
+import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+
+internal class ManagedDownloadSnapshotRoomStore(
+    private val context: Context,
+    private val database: NeriUserDataDatabase =
+        NeriUserDataDatabase.getInstance(context.applicationContext)
+) {
+    suspend fun restore(
+        expectedKey: String? = null
+    ): Pair<String, ManagedDownloadStorage.DownloadLibrarySnapshot>? {
+        return globalMutex.withLock {
+            runCatching {
+                restoreLocked(expectedKey)
+            }.onFailure { error ->
+                NPLogger.w(TAG, "读取下载索引数据库缓存失败: ${error.message}")
+            }.getOrNull()
+        }
+    }
+
+    suspend fun persist(
+        cacheKey: String,
+        snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
+    ): Boolean {
+        return globalMutex.withLock {
+            persistLocked(cacheKey, snapshot)
+        }
+    }
+
+    suspend fun clear() {
+        globalMutex.withLock {
+            runCatching {
+                database.withTransaction {
+                    database.downloadSnapshotDao().clearEntries()
+                    database.downloadSnapshotDao().clearMetadata()
+                    database.syncMetadataDao().deleteMigrationMetadata(
+                        listOf(CUTOVER_STATE_METADATA_KEY, ROOT_KEY_METADATA_KEY)
+                    )
+                }
+            }.onFailure { error ->
+                NPLogger.w(TAG, "清理下载索引数据库缓存失败: ${error.message}")
+            }
+        }
+        ManagedDownloadSnapshotDiskCache.delete(context.applicationContext)
+    }
+
+    private suspend fun restoreLocked(
+        expectedKey: String?
+    ): Pair<String, ManagedDownloadStorage.DownloadLibrarySnapshot>? {
+        if (isRoomPrimary()) {
+            val rootKey = readRootKey() ?: return null
+            if (expectedKey != null && expectedKey != rootKey) {
+                return null
+            }
+            return rootKey to readSnapshot(rootKey)
+        }
+
+        val legacy = ManagedDownloadSnapshotDiskCache.restore(
+            context = context.applicationContext,
+            expectedKey = expectedKey
+        ) ?: return null
+        if (persistLocked(legacy.first, legacy.second)) {
+            ManagedDownloadSnapshotDiskCache.delete(context.applicationContext)
+        }
+        return legacy
+    }
+
+    private suspend fun persistLocked(
+        cacheKey: String,
+        snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
+    ): Boolean {
+        return runCatching {
+            database.withTransaction {
+                val dao = database.downloadSnapshotDao()
+                dao.clearEntries()
+                dao.clearMetadata()
+                dao.upsertEntries(
+                    ManagedDownloadSnapshotRoomMapper.toEntryEntities(cacheKey, snapshot)
+                )
+                dao.upsertMetadata(
+                    ManagedDownloadSnapshotRoomMapper.toMetadataEntities(cacheKey, snapshot)
+                )
+                markRoomPrimary(cacheKey)
+            }
+            true
+        }.onFailure { error ->
+            NPLogger.w(TAG, "写入下载索引数据库缓存失败: ${error.message}")
+        }.getOrDefault(false)
+    }
+
+    private suspend fun readSnapshot(rootKey: String): ManagedDownloadStorage.DownloadLibrarySnapshot {
+        val dao = database.downloadSnapshotDao()
+        return ManagedDownloadSnapshotRoomMapper.toSnapshot(
+            audioEntries = dao.getEntries(rootKey, ManagedDownloadSnapshotRoomMapper.BUCKET_AUDIO),
+            metadataEntries = dao.getEntries(rootKey, ManagedDownloadSnapshotRoomMapper.BUCKET_METADATA),
+            metadata = dao.getMetadata(rootKey),
+            coverEntries = dao.getEntries(rootKey, ManagedDownloadSnapshotRoomMapper.BUCKET_COVER),
+            lyricEntries = dao.getEntries(rootKey, ManagedDownloadSnapshotRoomMapper.BUCKET_LYRIC)
+        )
+    }
+
+    private suspend fun isRoomPrimary(): Boolean {
+        return database.syncMetadataDao()
+            .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+            ?.value == ROOM_PRIMARY_STATE
+    }
+
+    private suspend fun readRootKey(): String? {
+        return database.syncMetadataDao()
+            .getMigrationMetadata(ROOT_KEY_METADATA_KEY)
+            ?.value
+    }
+
+    private suspend fun markRoomPrimary(rootKey: String) {
+        val nowMs = System.currentTimeMillis()
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = CUTOVER_STATE_METADATA_KEY,
+                value = ROOM_PRIMARY_STATE,
+                updatedAt = nowMs
+            )
+        )
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = ROOT_KEY_METADATA_KEY,
+                value = rootKey,
+                updatedAt = nowMs
+            )
+        )
+    }
+
+    companion object {
+        const val CUTOVER_STATE_METADATA_KEY = "managed_download_snapshot_cutover_state"
+        const val ROOT_KEY_METADATA_KEY = "managed_download_snapshot_root_key"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+        private const val TAG = "ManagedDownloadStorage"
+        private val globalMutex = Mutex()
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomStore.kt
@@ -39,9 +39,10 @@ internal class ManagedDownloadSnapshotRoomStore(
         return globalMutex.withLock {
             val roomCleared = runCatching {
                 val nowMs = System.currentTimeMillis()
+                val rootKey = readRootKey() ?: CLEARED_ROOT_KEY
                 database.withTransaction {
-                    database.downloadSnapshotDao().clearEntries()
-                    database.downloadSnapshotDao().clearMetadata()
+                    database.downloadSnapshotDao().clearEntries(rootKey)
+                    database.downloadSnapshotDao().clearMetadata(rootKey)
                     database.syncMetadataDao().upsertMigrationMetadata(
                         MigrationMetadataEntity(
                             key = CUTOVER_STATE_METADATA_KEY,
@@ -99,8 +100,8 @@ internal class ManagedDownloadSnapshotRoomStore(
         return runCatching {
             database.withTransaction {
                 val dao = database.downloadSnapshotDao()
-                dao.clearEntries()
-                dao.clearMetadata()
+                dao.clearEntries(cacheKey)
+                dao.clearMetadata(cacheKey)
                 dao.upsertEntries(
                     ManagedDownloadSnapshotRoomMapper.toEntryEntities(cacheKey, snapshot)
                 )

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomStore.kt
@@ -35,21 +35,37 @@ internal class ManagedDownloadSnapshotRoomStore(
         }
     }
 
-    suspend fun clear() {
-        globalMutex.withLock {
-            runCatching {
+    suspend fun clear(): Boolean {
+        return globalMutex.withLock {
+            val roomCleared = runCatching {
+                val nowMs = System.currentTimeMillis()
                 database.withTransaction {
                     database.downloadSnapshotDao().clearEntries()
                     database.downloadSnapshotDao().clearMetadata()
-                    database.syncMetadataDao().deleteMigrationMetadata(
-                        listOf(CUTOVER_STATE_METADATA_KEY, ROOT_KEY_METADATA_KEY)
+                    database.syncMetadataDao().upsertMigrationMetadata(
+                        MigrationMetadataEntity(
+                            key = CUTOVER_STATE_METADATA_KEY,
+                            value = ROOM_PRIMARY_STATE,
+                            updatedAt = nowMs
+                        )
+                    )
+                    database.syncMetadataDao().upsertMigrationMetadata(
+                        MigrationMetadataEntity(
+                            key = ROOT_KEY_METADATA_KEY,
+                            value = CLEARED_ROOT_KEY,
+                            updatedAt = nowMs
+                        )
                     )
                 }
+                true
             }.onFailure { error ->
                 NPLogger.w(TAG, "清理下载索引数据库缓存失败: ${error.message}")
+            }.getOrDefault(false)
+            if (!roomCleared) {
+                return@withLock false
             }
+            ManagedDownloadSnapshotDiskCache.delete(context.applicationContext)
         }
-        ManagedDownloadSnapshotDiskCache.delete(context.applicationContext)
     }
 
     private suspend fun restoreLocked(
@@ -57,6 +73,9 @@ internal class ManagedDownloadSnapshotRoomStore(
     ): Pair<String, ManagedDownloadStorage.DownloadLibrarySnapshot>? {
         if (isRoomPrimary()) {
             val rootKey = readRootKey() ?: return null
+            if (rootKey == CLEARED_ROOT_KEY) {
+                return null
+            }
             if (expectedKey != null && expectedKey != rootKey) {
                 return null
             }
@@ -141,6 +160,7 @@ internal class ManagedDownloadSnapshotRoomStore(
         const val CUTOVER_STATE_METADATA_KEY = "managed_download_snapshot_cutover_state"
         const val ROOT_KEY_METADATA_KEY = "managed_download_snapshot_root_key"
         const val ROOM_PRIMARY_STATE = "room_primary"
+        private const val CLEARED_ROOT_KEY = "__cleared__"
         private const val TAG = "ManagedDownloadStorage"
         private val globalMutex = Mutex()
     }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -526,6 +526,8 @@ object PlayerManager {
     val currentSongFlow: StateFlow<SongItem?> = _currentSongFlow
     @Volatile
     internal var localPlaylistPlaybackSource: LocalPlaylistPlaybackSource? = null
+    internal val _playbackSourceRouteFlow = MutableStateFlow<String?>(null)
+    val playbackSourceRouteFlow: StateFlow<String?> = _playbackSourceRouteFlow
     internal val playbackDemandArbiter = PlaybackDemandArbiter()
 
     internal val _currentQueueFlow = MutableStateFlow<List<SongItem>>(emptyList())

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/download/AudioDownloadManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/download/AudioDownloadManager.kt
@@ -1004,7 +1004,7 @@ object AudioDownloadManager {
         } else {
             ManagedDownloadStorage.cachedDownloadLibrarySnapshot(
                 context = context,
-                restoreFromDisk = false
+                restorePersisted = false
             )
         }
         for (lookupKey in lookupKeys) {
@@ -2432,7 +2432,7 @@ object AudioDownloadManager {
         }
         val snapshot = ManagedDownloadStorage.cachedDownloadLibrarySnapshot(context)
             ?: if (ManagedDownloadStorage.ensureSnapshotCacheReady(context)) {
-                ManagedDownloadStorage.cachedDownloadLibrarySnapshot(context, restoreFromDisk = false)
+                ManagedDownloadStorage.cachedDownloadLibrarySnapshot(context, restorePersisted = false)
             } else {
                 null
             }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/model/PersistedPlayerState.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/model/PersistedPlayerState.kt
@@ -142,7 +142,8 @@ internal data class PersistedState(
     val repeatMode: Int? = null,
     val shuffleEnabled: Boolean? = null,
     val shuffleRestorePlaylist: List<PersistedSongItem>? = null,
-    val shuffleRestoreIndex: Int? = null
+    val shuffleRestoreIndex: Int? = null,
+    val sourceRoute: String? = null
 )
 
 internal data class PersistedPlaybackState(

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStore.kt
@@ -48,6 +48,28 @@ internal class PlaybackQueueRoomStore(
         }
     }
 
+    suspend fun importLegacyAndPromote(
+        state: PersistedState,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            if (isRoomPrimary()) {
+                return@withTransaction
+            }
+            val dao = database.playbackQueueDao()
+            dao.deleteSongs()
+            dao.upsertSongs(
+                state.playlist.mapIndexed { position, song ->
+                    song.toEntity(PLAYBACK_QUEUE_MAIN, position)
+                } + state.shuffleRestorePlaylist.orEmpty().mapIndexed { position, song ->
+                    song.toEntity(PLAYBACK_QUEUE_SHUFFLE_RESTORE, position)
+                }
+            )
+            dao.upsertState(state.toEntity(now))
+            markRoomPrimary(now)
+        }
+    }
+
     suspend fun updatePlaybackState(
         state: PersistedPlaybackState,
         now: Long = System.currentTimeMillis()

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStore.kt
@@ -44,6 +44,7 @@ internal class PlaybackQueueRoomStore(
                 }
             )
             dao.upsertState(state.toEntity(now))
+            writeSourceRoute(state.sourceRoute, now)
             markRoomPrimary(now)
         }
     }
@@ -66,6 +67,7 @@ internal class PlaybackQueueRoomStore(
                 }
             )
             dao.upsertState(state.toEntity(now))
+            writeSourceRoute(state.sourceRoute, now)
             markRoomPrimary(now)
         }
     }
@@ -88,10 +90,27 @@ internal class PlaybackQueueRoomStore(
         }
     }
 
+    suspend fun updateSourceRoute(
+        sourceRoute: String?,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            val roomPrimary = isRoomPrimary()
+            val hasPersistedQueue = database.playbackQueueDao().getState() != null
+            writeSourceRoute(sourceRoute, now)
+            if (roomPrimary || hasPersistedQueue) {
+                markRoomPrimary(now)
+            }
+        }
+    }
+
     suspend fun clear(now: Long = System.currentTimeMillis()) {
         database.withTransaction {
             database.playbackQueueDao().deleteState()
             database.playbackQueueDao().deleteSongs()
+            database.syncMetadataDao().deleteMigrationMetadata(
+                listOf(SOURCE_ROUTE_METADATA_KEY)
+            )
             markRoomPrimary(now)
         }
     }
@@ -114,9 +133,28 @@ internal class PlaybackQueueRoomStore(
                 } else {
                     null
                 },
-                shuffleRestoreIndex = state.shuffleRestoreIndex
+                shuffleRestoreIndex = state.shuffleRestoreIndex,
+                sourceRoute = database.syncMetadataDao()
+                    .getMigrationMetadata(SOURCE_ROUTE_METADATA_KEY)
+                    ?.value
+                    ?.takeIf { it.length <= MAX_SOURCE_ROUTE_LENGTH }
             )
         }
+    }
+
+    private suspend fun writeSourceRoute(sourceRoute: String?, now: Long) {
+        val metadataDao = database.syncMetadataDao()
+        if (sourceRoute == null || sourceRoute.length > MAX_SOURCE_ROUTE_LENGTH) {
+            metadataDao.deleteMigrationMetadata(listOf(SOURCE_ROUTE_METADATA_KEY))
+            return
+        }
+        metadataDao.upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = SOURCE_ROUTE_METADATA_KEY,
+                value = sourceRoute,
+                updatedAt = now
+            )
+        )
     }
 
     private suspend fun markRoomPrimary(now: Long) {
@@ -131,7 +169,9 @@ internal class PlaybackQueueRoomStore(
 
     companion object {
         const val CUTOVER_STATE_METADATA_KEY = "playback_queue_cutover_state"
+        const val SOURCE_ROUTE_METADATA_KEY = "playback_queue_source_route"
         const val ROOM_PRIMARY_STATE = "room_primary"
+        private const val MAX_SOURCE_ROUTE_LENGTH = 16 * 1024
     }
 }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStore.kt
@@ -1,0 +1,218 @@
+package moe.ouom.neriplayer.core.player.persistence
+
+import androidx.room.withTransaction
+import moe.ouom.neriplayer.core.api.search.MusicPlatform
+import moe.ouom.neriplayer.core.player.model.PersistedPlaybackState
+import moe.ouom.neriplayer.core.player.model.PersistedSongItem
+import moe.ouom.neriplayer.core.player.model.PersistedState
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+import moe.ouom.neriplayer.data.local.database.entity.PLAYBACK_QUEUE_MAIN
+import moe.ouom.neriplayer.data.local.database.entity.PLAYBACK_QUEUE_SHUFFLE_RESTORE
+import moe.ouom.neriplayer.data.local.database.entity.PLAYBACK_QUEUE_STATE_ID
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueSongEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueStateEntity
+
+internal class PlaybackQueueRoomStore(
+    private val database: NeriUserDataDatabase
+) {
+    suspend fun isRoomPrimary(): Boolean {
+        return database.syncMetadataDao()
+            .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+            ?.value == ROOM_PRIMARY_STATE
+    }
+
+    suspend fun readIfRoomPrimary(): PersistedState? {
+        if (!isRoomPrimary()) {
+            return null
+        }
+        return readState()
+    }
+
+    suspend fun replaceSnapshot(
+        state: PersistedState,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            val dao = database.playbackQueueDao()
+            dao.deleteSongs()
+            dao.upsertSongs(
+                state.playlist.mapIndexed { position, song ->
+                    song.toEntity(PLAYBACK_QUEUE_MAIN, position)
+                } + state.shuffleRestorePlaylist.orEmpty().mapIndexed { position, song ->
+                    song.toEntity(PLAYBACK_QUEUE_SHUFFLE_RESTORE, position)
+                }
+            )
+            dao.upsertState(state.toEntity(now))
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun updatePlaybackState(
+        state: PersistedPlaybackState,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            val dao = database.playbackQueueDao()
+            val previous = dao.getState()
+            dao.upsertState(
+                state.toEntity(
+                    now = now,
+                    shuffleRestoreIndex = previous?.shuffleRestoreIndex
+                        ?.takeIf { state.shuffleEnabled == true }
+                )
+            )
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun clear(now: Long = System.currentTimeMillis()) {
+        database.withTransaction {
+            database.playbackQueueDao().deleteState()
+            database.playbackQueueDao().deleteSongs()
+            markRoomPrimary(now)
+        }
+    }
+
+    private suspend fun readState(): PersistedState? {
+        return database.withTransaction {
+            val dao = database.playbackQueueDao()
+            val state = dao.getState() ?: return@withTransaction null
+            PersistedState(
+                playlist = dao.getSongs(PLAYBACK_QUEUE_MAIN).map(PlaybackQueueSongEntity::toPersistedSong),
+                index = state.currentIndex,
+                mediaUrl = state.mediaUrl,
+                positionMs = state.positionMs,
+                shouldResumePlayback = state.shouldResumePlayback,
+                repeatMode = state.repeatMode,
+                shuffleEnabled = state.shuffleEnabled,
+                shuffleRestorePlaylist = if (state.shuffleEnabled == true) {
+                    dao.getSongs(PLAYBACK_QUEUE_SHUFFLE_RESTORE)
+                        .map(PlaybackQueueSongEntity::toPersistedSong)
+                } else {
+                    null
+                },
+                shuffleRestoreIndex = state.shuffleRestoreIndex
+            )
+        }
+    }
+
+    private suspend fun markRoomPrimary(now: Long) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = CUTOVER_STATE_METADATA_KEY,
+                value = ROOM_PRIMARY_STATE,
+                updatedAt = now
+            )
+        )
+    }
+
+    companion object {
+        const val CUTOVER_STATE_METADATA_KEY = "playback_queue_cutover_state"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+    }
+}
+
+private fun PersistedSongItem.toEntity(
+    queueId: String,
+    position: Int
+): PlaybackQueueSongEntity {
+    return PlaybackQueueSongEntity(
+        queueId = queueId,
+        position = position,
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        albumId = albumId,
+        durationMs = durationMs,
+        coverUrl = coverUrl,
+        mediaUri = mediaUri,
+        matchedLyric = matchedLyric,
+        matchedTranslatedLyric = matchedTranslatedLyric,
+        matchedLyricSource = matchedLyricSource?.name,
+        matchedSongId = matchedSongId,
+        userLyricOffsetMs = userLyricOffsetMs,
+        customCoverUrl = customCoverUrl,
+        customName = customName,
+        customArtist = customArtist,
+        originalName = originalName,
+        originalArtist = originalArtist,
+        originalCoverUrl = originalCoverUrl,
+        originalLyric = originalLyric,
+        originalTranslatedLyric = originalTranslatedLyric,
+        localFileName = localFileName,
+        localFilePath = localFilePath,
+        channelId = channelId,
+        audioId = audioId,
+        subAudioId = subAudioId,
+        playlistContextId = playlistContextId,
+        streamUrl = streamUrl
+    )
+}
+
+private fun PlaybackQueueSongEntity.toPersistedSong(): PersistedSongItem {
+    return PersistedSongItem(
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        albumId = albumId,
+        durationMs = durationMs,
+        coverUrl = coverUrl,
+        mediaUri = mediaUri,
+        matchedLyric = matchedLyric,
+        matchedTranslatedLyric = matchedTranslatedLyric,
+        matchedLyricSource = matchedLyricSource?.let { value ->
+            runCatching { MusicPlatform.valueOf(value) }.getOrNull()
+        },
+        matchedSongId = matchedSongId,
+        userLyricOffsetMs = userLyricOffsetMs,
+        customCoverUrl = customCoverUrl,
+        customName = customName,
+        customArtist = customArtist,
+        originalName = originalName,
+        originalArtist = originalArtist,
+        originalCoverUrl = originalCoverUrl,
+        originalLyric = originalLyric,
+        originalTranslatedLyric = originalTranslatedLyric,
+        localFileName = localFileName,
+        localFilePath = localFilePath,
+        channelId = channelId,
+        audioId = audioId,
+        subAudioId = subAudioId,
+        playlistContextId = playlistContextId,
+        streamUrl = streamUrl
+    )
+}
+
+private fun PersistedState.toEntity(now: Long): PlaybackQueueStateEntity {
+    return PlaybackQueueStateEntity(
+        id = PLAYBACK_QUEUE_STATE_ID,
+        currentIndex = index,
+        mediaUrl = mediaUrl,
+        positionMs = positionMs,
+        shouldResumePlayback = shouldResumePlayback,
+        repeatMode = repeatMode,
+        shuffleEnabled = shuffleEnabled,
+        shuffleRestoreIndex = shuffleRestoreIndex,
+        updatedAt = now
+    )
+}
+
+private fun PersistedPlaybackState.toEntity(
+    now: Long,
+    shuffleRestoreIndex: Int? = null
+): PlaybackQueueStateEntity {
+    return PlaybackQueueStateEntity(
+        id = PLAYBACK_QUEUE_STATE_ID,
+        currentIndex = index,
+        mediaUrl = mediaUrl,
+        positionMs = positionMs,
+        shouldResumePlayback = shouldResumePlayback,
+        repeatMode = repeatMode,
+        shuffleEnabled = shuffleEnabled,
+        shuffleRestoreIndex = shuffleRestoreIndex,
+        updatedAt = now
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -468,7 +468,7 @@ internal fun PlayerManager.setPlaybackSourceRoute(sourceRoute: String?) {
             runCatching {
                 PlaybackQueueRoomStore(
                     NeriUserDataDatabase.getInstance(application.applicationContext)
-                ).updateSourceRoute(sourceRoute)
+                ).updateSourceRoute(_playbackSourceRouteFlow.value)
             }.onFailure { error ->
                 NPLogger.w(
                     "NERI-PlayerManager",

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -51,6 +51,7 @@ import moe.ouom.neriplayer.data.local.media.LocalMediaMetadataWriteOutcome
 import moe.ouom.neriplayer.data.local.media.LocalMediaSupport
 import moe.ouom.neriplayer.data.local.media.LocalSongSupport
 import moe.ouom.neriplayer.data.local.media.CustomSongCoverStorage
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthState
 import moe.ouom.neriplayer.data.settings.rebaseLyricUserOffsetMs
 import moe.ouom.neriplayer.data.settings.shouldRebaseLyricOffsetForSource
@@ -62,7 +63,6 @@ import moe.ouom.neriplayer.data.model.sameIdentityAs
 import moe.ouom.neriplayer.data.model.stableKey
 import moe.ouom.neriplayer.ui.feedback.AppFeedback
 import java.io.File
-import java.io.OutputStreamWriter
 import java.lang.reflect.Type
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -170,60 +170,37 @@ private fun PlayerManager.buildPersistedPlaylistState(
     )
 }
 
-private fun PlayerManager.writeJson(file: File, payload: Any) {
-    file.parentFile?.mkdirs()
-    val tempFile = File(file.parentFile ?: File("."), ".${file.name}.${System.nanoTime()}.tmp")
-    try {
-        tempFile.outputStream().use { stream ->
-            val writer = OutputStreamWriter(stream, Charsets.UTF_8).buffered()
-            gson.toJson(payload, writer)
-            writer.flush()
-            stream.fd.sync()
-        }
-        if (file.exists() && !file.delete()) {
-            error("Unable to replace ${file.name}")
-        }
-        if (!tempFile.renameTo(file)) {
-            error("Unable to commit ${file.name}")
-        }
-    } catch (error: Throwable) {
-        tempFile.delete()
-        throw error
-    }
-}
-
 private fun <T> PlayerManager.readJson(file: File, type: Type): T {
     file.inputStream().bufferedReader().use { reader ->
         return gson.fromJson(reader, type)
     }
 }
 
-private fun loadRestoredStateSnapshot(
-    app: Application,
+private fun loadPersistedStateFromLegacy(
     stateFile: File,
-    playbackStateFile: File,
+    playbackStateFile: File
+): PersistedState? {
+    if (!stateFile.exists()) {
+        return null
+    }
+    val type = object : TypeToken<PersistedState>() {}.type
+    val legacyData: PersistedState = PlayerManager.readJson(stateFile, type)
+    val playbackState = playbackStateFile.takeIf(File::exists)?.runCatching {
+        PlayerManager.readJson<PersistedPlaybackState>(
+            this,
+            PersistedPlaybackState::class.java
+        )
+    }?.getOrNull()
+    return playbackState?.let(legacyData::withPlaybackState) ?: legacyData
+}
+
+private fun buildRestoredStateSnapshot(
+    app: Application,
+    data: PersistedState,
     keepLastPlaybackProgressEnabled: Boolean,
     keepPlaybackModeStateEnabled: Boolean
 ): RestoredPlayerStateSnapshot? {
-    if (!stateFile.exists()) {
-        NPLogger.d("NERI-PlayerManager", "restoreState: skipped because state file does not exist")
-        return null
-    }
-
     return runCatching {
-        NPLogger.d(
-            "NERI-PlayerManager",
-            "restoreState: reading ${stateFile.absolutePath}"
-        )
-        val type = object : TypeToken<PersistedState>() {}.type
-        val legacyData: PersistedState = PlayerManager.readJson(stateFile, type)
-        val playbackState = playbackStateFile.takeIf(File::exists)?.runCatching {
-            PlayerManager.readJson<PersistedPlaybackState>(
-                this,
-                PersistedPlaybackState::class.java
-            )
-        }?.getOrNull()
-        val data = playbackState?.let(legacyData::withPlaybackState) ?: legacyData
         val playlist = data.playlist.map { persistedSong -> persistedSong.toSongItem() }
         val currentlyUnreadableLocalCount = playlist.count { song ->
             LocalSongSupport.isLocalSong(song, app) &&
@@ -309,14 +286,84 @@ internal suspend fun preloadRestoredStateSnapshot(
     val startupStateFile = File(app.filesDir, "last_playlist.json")
     val startupPlaybackStateFile = File(app.filesDir, "last_playback_state.json")
     return withContext(Dispatchers.IO) {
-        loadRestoredStateSnapshot(
+        val roomStore = PlaybackQueueRoomStore(
+            NeriUserDataDatabase.getInstance(app.applicationContext)
+        )
+        val roomData = runCatching { roomStore.readIfRoomPrimary() }
+            .onFailure { error ->
+                NPLogger.w(
+                    "NERI-PlayerManager",
+                    "restoreState: Room read failed, trying legacy JSON: ${error.message}"
+                )
+            }
+            .getOrNull()
+        val roomPrimary = runCatching { roomStore.isRoomPrimary() }
+            .onFailure { error ->
+                NPLogger.w(
+                    "NERI-PlayerManager",
+                    "restoreState: Room marker read failed: ${error.message}"
+                )
+            }
+            .getOrDefault(false)
+        val data = if (roomPrimary) {
+            roomData
+        } else {
+            runCatching {
+                loadPersistedStateFromLegacy(
+                    stateFile = startupStateFile,
+                    playbackStateFile = startupPlaybackStateFile
+                )
+            }.onFailure { error ->
+                NPLogger.w(
+                    "NERI-PlayerManager",
+                    "Failed to read legacy playback state: ${error.message}"
+                )
+            }.getOrNull()?.also { legacyData ->
+                runCatching {
+                    roomStore.replaceSnapshot(legacyData)
+                }.onFailure { error ->
+                    NPLogger.w(
+                        "NERI-PlayerManager",
+                        "Failed to import legacy playback state into Room: ${error.message}"
+                    )
+                }
+            }
+        }
+        if (data == null) {
+            NPLogger.d("NERI-PlayerManager", "restoreState: no persisted playback state")
+            null
+        } else {
+            buildRestoredStateSnapshot(
+                app = app,
+                data = data,
+                keepLastPlaybackProgressEnabled = keepLastPlaybackProgressEnabled,
+                keepPlaybackModeStateEnabled = keepPlaybackModeStateEnabled
+            )
+        }
+    }
+}
+
+private fun loadRestoredStateSnapshot(
+    app: Application,
+    stateFile: File,
+    playbackStateFile: File,
+    keepLastPlaybackProgressEnabled: Boolean,
+    keepPlaybackModeStateEnabled: Boolean
+): RestoredPlayerStateSnapshot? {
+    return runCatching {
+        val data = loadPersistedStateFromLegacy(
+            stateFile = stateFile,
+            playbackStateFile = playbackStateFile
+        ) ?: return@runCatching null
+        buildRestoredStateSnapshot(
             app = app,
-            stateFile = startupStateFile,
-            playbackStateFile = startupPlaybackStateFile,
+            data = data,
             keepLastPlaybackProgressEnabled = keepLastPlaybackProgressEnabled,
             keepPlaybackModeStateEnabled = keepPlaybackModeStateEnabled
         )
-    }
+    }.onFailure { error ->
+        NPLogger.w("NERI-PlayerManager", "Failed to restore state: ${error.message}")
+    }.getOrNull()
 }
 
 internal fun PlayerManager.applyRestoredStateSnapshot(snapshot: RestoredPlayerStateSnapshot) {
@@ -516,9 +563,13 @@ internal suspend fun PlayerManager.persistStateImpl(
     withContext(Dispatchers.IO) {
         statePersistMutex.withLock {
             try {
+                val roomStore = PlaybackQueueRoomStore(
+                    NeriUserDataDatabase.getInstance(application.applicationContext)
+                )
                 if (playlistReference.isEmpty()) {
                     restoredResumePositionMs = 0L
                     restoredShouldResumePlayback = false
+                    roomStore.clear()
                     stateFile.delete()
                     playbackStateFile.delete()
                     shuffleRestorePlaylistReference = null
@@ -537,23 +588,25 @@ internal suspend fun PlayerManager.persistStateImpl(
                 val shouldWritePlaybackState =
                     shouldWriteLegacyState ||
                         playbackStateSnapshot != lastPersistedPlaybackState ||
-                        !playbackStateFile.exists()
+                        lastPersistedPlaybackState == null
 
                 if (shouldWriteLegacyState) {
                     val data = buildPersistedPlaylistState(
                         playlistReference = playlistReference,
                         playbackStateSnapshot = playbackStateSnapshot
                     )
-                    writeJson(stateFile, data)
+                    roomStore.replaceSnapshot(data)
                     lastPersistedPlaylistReference = playlistReference
                     NPLogger.d(
                         "NERI-PlayerManager",
-                        "persistState: wrote state file, path=${stateFile.absolutePath}, queueSize=${playlistReference.size}, index=$currentIndexSnapshot"
+                        "persistState: wrote Room queue state, queueSize=${playlistReference.size}, index=$currentIndexSnapshot"
                     )
                 }
 
                 if (shouldWritePlaybackState) {
-                    writeJson(playbackStateFile, playbackStateSnapshot)
+                    if (!shouldWriteLegacyState) {
+                        roomStore.updatePlaybackState(playbackStateSnapshot)
+                    }
                     lastPersistedPlaybackState = playbackStateSnapshot
                 }
 
@@ -561,6 +614,8 @@ internal suspend fun PlayerManager.persistStateImpl(
                     lastStatePersistAtMs = SystemClock.elapsedRealtime()
                 }
             } catch (e: Exception) {
+                lastPersistedPlaylistReference = null
+                lastPersistedPlaybackState = null
                 NPLogger.e("PlayerManager", "Failed to persist state", e)
             }
         }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -73,6 +73,7 @@ internal data class RestoredPlayerStateSnapshot(
     val playlist: List<SongItem>,
     val currentIndex: Int,
     val currentMediaUrl: String?,
+    val sourceRoute: String?,
     val repeatMode: Int,
     val shuffleEnabled: Boolean,
     val shuffleRestorePlaylist: List<SongItem>?,
@@ -150,6 +151,7 @@ private fun PlayerManager.buildPersistedPlaylistState(
         shouldResumePlayback = playbackStateSnapshot.shouldResumePlayback,
         repeatMode = playbackStateSnapshot.repeatMode,
         shuffleEnabled = playbackStateSnapshot.shuffleEnabled,
+        sourceRoute = _playbackSourceRouteFlow.value,
         shuffleRestorePlaylist = if (playbackStateSnapshot.shuffleEnabled == true) {
             restorePlaylistReference?.map { song ->
                 song.toPersistedSongItem(
@@ -252,6 +254,7 @@ private fun buildRestoredStateSnapshot(
             playlist = playlist,
             currentIndex = currentIndex,
             currentMediaUrl = currentMediaUrl,
+            sourceRoute = data.sourceRoute,
             repeatMode = repeatMode,
             shuffleEnabled = keepPlaybackModeStateEnabled && (data.shuffleEnabled == true),
             shuffleRestorePlaylist = if (keepPlaybackModeStateEnabled && data.shuffleEnabled == true) {
@@ -294,19 +297,12 @@ internal suspend fun preloadRestoredStateSnapshot(
             .onFailure { error ->
                 NPLogger.w(
                     "NERI-PlayerManager",
-                    "restoreState: Room read failed, trying legacy JSON: ${error.message}"
+                    "restoreState: Room read failed, refusing stale legacy fallback: " +
+                        error.message
                 )
             }
-            .getOrNull()
-        val roomPrimary = runCatching { roomStore.isRoomPrimary() }
-            .onFailure { error ->
-                NPLogger.w(
-                    "NERI-PlayerManager",
-                    "restoreState: Room marker read failed: ${error.message}"
-                )
-            }
-            .getOrDefault(false)
-        val data = if (roomPrimary) {
+            .getOrElse { return@withContext null }
+        val data = if (roomData != null) {
             roomData
         } else {
             runCatching {
@@ -362,7 +358,7 @@ private fun loadRestoredStateSnapshot(
                         "restoreState: Room marker read failed: ${error.message}"
                     )
                 }
-                .getOrDefault(false)
+                .getOrElse { throw it }
             if (roomPrimary) {
                 roomStore.readIfRoomPrimary()
             } else {
@@ -403,6 +399,7 @@ internal fun PlayerManager.applyRestoredStateSnapshot(snapshot: RestoredPlayerSt
         _currentQueueFlow.value = emptyList()
         setCurrentSongForPlayback(null)
         _currentMediaUrl.value = null
+        _playbackSourceRouteFlow.value = null
         _currentPlaybackAudioInfo.value = null
         _playbackPositionMs.value = 0L
         currentMediaUrlResolvedAtMs = 0L
@@ -418,6 +415,7 @@ internal fun PlayerManager.applyRestoredStateSnapshot(snapshot: RestoredPlayerSt
     _currentQueueFlow.value = currentPlaylist
     setCurrentSongForPlayback(currentPlaylist.getOrNull(currentIndex))
     _currentMediaUrl.value = snapshot.currentMediaUrl
+    _playbackSourceRouteFlow.value = snapshot.sourceRoute
     repeatModeSetting = snapshot.repeatMode
     syncExoRepeatMode()
     _repeatModeFlow.value = repeatModeSetting
@@ -460,6 +458,24 @@ internal fun PlayerManager.scheduleStatePersist(
             positionMs = positionMs,
             shouldResumePlayback = shouldResumePlayback
         )
+    }
+}
+
+internal fun PlayerManager.setPlaybackSourceRoute(sourceRoute: String?) {
+    _playbackSourceRouteFlow.value = sourceRoute
+    ioScope.launch {
+        statePersistMutex.withLock {
+            runCatching {
+                PlaybackQueueRoomStore(
+                    NeriUserDataDatabase.getInstance(application.applicationContext)
+                ).updateSourceRoute(sourceRoute)
+            }.onFailure { error ->
+                NPLogger.w(
+                    "NERI-PlayerManager",
+                    "Failed to persist playback source route: ${error.message}"
+                )
+            }
+        }
     }
 }
 
@@ -595,6 +611,7 @@ internal suspend fun PlayerManager.persistStateImpl(
                 if (playlistReference.isEmpty()) {
                     restoredResumePositionMs = 0L
                     restoredShouldResumePlayback = false
+                    _playbackSourceRouteFlow.value = null
                     roomStore.clear()
                     stateFile.delete()
                     playbackStateFile.delete()

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -321,7 +321,7 @@ internal suspend fun preloadRestoredStateSnapshot(
                 )
             }.getOrNull()?.also { legacyData ->
                 runCatching {
-                    roomStore.replaceSnapshot(legacyData)
+                    roomStore.importLegacyAndPromote(legacyData)
                 }.onFailure { error ->
                     NPLogger.w(
                         "NERI-PlayerManager",
@@ -371,7 +371,7 @@ private fun loadRestoredStateSnapshot(
                     playbackStateFile = playbackStateFile
                 )?.also { legacyData ->
                     runCatching {
-                        roomStore.replaceSnapshot(legacyData)
+                        roomStore.importLegacyAndPromote(legacyData)
                     }.onFailure { error ->
                         NPLogger.w(
                             "NERI-PlayerManager",

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -351,10 +352,35 @@ private fun loadRestoredStateSnapshot(
     keepPlaybackModeStateEnabled: Boolean
 ): RestoredPlayerStateSnapshot? {
     return runCatching {
-        val data = loadPersistedStateFromLegacy(
-            stateFile = stateFile,
-            playbackStateFile = playbackStateFile
-        ) ?: return@runCatching null
+        val data = runBlocking(Dispatchers.IO) {
+            val database = NeriUserDataDatabase.getInstance(app.applicationContext)
+            val roomStore = PlaybackQueueRoomStore(database)
+            val roomPrimary = runCatching { roomStore.isRoomPrimary() }
+                .onFailure { error ->
+                    NPLogger.w(
+                        "NERI-PlayerManager",
+                        "restoreState: Room marker read failed: ${error.message}"
+                    )
+                }
+                .getOrDefault(false)
+            if (roomPrimary) {
+                roomStore.readIfRoomPrimary()
+            } else {
+                loadPersistedStateFromLegacy(
+                    stateFile = stateFile,
+                    playbackStateFile = playbackStateFile
+                )?.also { legacyData ->
+                    runCatching {
+                        roomStore.replaceSnapshot(legacyData)
+                    }.onFailure { error ->
+                        NPLogger.w(
+                            "NERI-PlayerManager",
+                            "restoreState: failed to import legacy playback state: ${error.message}"
+                        )
+                    }
+                }
+            }
+        } ?: return@runCatching null
         buildRestoredStateSnapshot(
             app = app,
             data = data,

--- a/app/src/main/java/moe/ouom/neriplayer/core/startup/LegacyJsonCleanupScheduler.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/startup/LegacyJsonCleanupScheduler.kt
@@ -2,6 +2,7 @@ package moe.ouom.neriplayer.core.startup
 
 import android.content.Context
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.delay
 import moe.ouom.neriplayer.core.di.AppContainer
 import moe.ouom.neriplayer.core.logging.NPLogger
@@ -12,6 +13,7 @@ import moe.ouom.neriplayer.data.local.database.store.LegacyJsonCleanupStatus
 internal object LegacyJsonCleanupScheduler {
     private const val TAG = "NERI-LegacyJsonCleanup"
     private val running = AtomicBoolean(false)
+    private val pendingReason = AtomicReference<String?>(null)
     private val retryDelaysMs = longArrayOf(
         0L,
         1_500L,
@@ -24,6 +26,7 @@ internal object LegacyJsonCleanupScheduler {
     fun schedule(context: Context, reason: String) {
         val appContext = context.applicationContext
         if (!running.compareAndSet(false, true)) {
+            pendingReason.set(reason)
             return
         }
 
@@ -45,7 +48,8 @@ internal object LegacyJsonCleanupScheduler {
                     if (lastResult.status == LegacyJsonCleanupStatus.COMPLETED) {
                         NPLogger.d(
                             TAG,
-                            "Legacy JSON cleanup completed: reason=$reason, deleted=${lastResult.deletedFiles.size}"
+                            "Legacy JSON cleanup completed: reason=$reason, " +
+                                "deleted=${lastResult.deletedFiles.size}"
                         )
                         return@launchBackgroundIo
                     }
@@ -55,11 +59,15 @@ internal object LegacyJsonCleanupScheduler {
                     NPLogger.d(
                         TAG,
                         "Legacy JSON cleanup pending: reason=$reason, status=${result.status}, " +
-                            "blocked=${result.blockedFiles.size}, failed=${result.failedFiles.size}"
+                            "deleted=${result.deletedFiles.size}, " +
+                            "blocked=${result.blockedFiles}, failed=${result.failedFiles}"
                     )
                 }
             } finally {
                 running.set(false)
+                pendingReason.getAndSet(null)?.let { nextReason ->
+                    schedule(appContext, nextReason)
+                }
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/core/startup/LegacyJsonCleanupScheduler.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/startup/LegacyJsonCleanupScheduler.kt
@@ -1,0 +1,66 @@
+package moe.ouom.neriplayer.core.startup
+
+import android.content.Context
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.delay
+import moe.ouom.neriplayer.core.di.AppContainer
+import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.data.local.database.store.LegacyJsonCleanupCoordinator
+import moe.ouom.neriplayer.data.local.database.store.LegacyJsonCleanupResult
+import moe.ouom.neriplayer.data.local.database.store.LegacyJsonCleanupStatus
+
+internal object LegacyJsonCleanupScheduler {
+    private const val TAG = "NERI-LegacyJsonCleanup"
+    private val running = AtomicBoolean(false)
+    private val retryDelaysMs = longArrayOf(
+        0L,
+        1_500L,
+        3_000L,
+        5_000L,
+        8_000L,
+        13_000L
+    )
+
+    fun schedule(context: Context, reason: String) {
+        val appContext = context.applicationContext
+        if (!running.compareAndSet(false, true)) {
+            return
+        }
+
+        AppContainer.launchBackgroundIo {
+            try {
+                val coordinator = LegacyJsonCleanupCoordinator(appContext)
+                var lastResult: LegacyJsonCleanupResult? = null
+                for (attemptIndex in retryDelaysMs.indices) {
+                    if (attemptIndex > 0) {
+                        delay(retryDelaysMs[attemptIndex])
+                    }
+
+                    val plan = coordinator.buildPlan()
+                    if (plan.targets.none { it.exists }) {
+                        return@launchBackgroundIo
+                    }
+
+                    lastResult = coordinator.execute(plan, confirmed = true)
+                    if (lastResult.status == LegacyJsonCleanupStatus.COMPLETED) {
+                        NPLogger.d(
+                            TAG,
+                            "Legacy JSON cleanup completed: reason=$reason, deleted=${lastResult.deletedFiles.size}"
+                        )
+                        return@launchBackgroundIo
+                    }
+                }
+
+                lastResult?.let { result ->
+                    NPLogger.d(
+                        TAG,
+                        "Legacy JSON cleanup pending: reason=$reason, status=${result.status}, " +
+                            "blocked=${result.blockedFiles.size}, failed=${result.failedFiles.size}"
+                    )
+                }
+            } finally {
+                running.set(false)
+            }
+        }
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/core/startup/player/PlayerStartupBootstrapper.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/startup/player/PlayerStartupBootstrapper.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.core.player.audio.focus.StartupAudioFocusController
 import moe.ouom.neriplayer.core.player.persistence.preloadRestoredStateSnapshot
@@ -31,6 +32,7 @@ internal class PlayerStartupBootstrapper(
             startupPlaybackPreferences = playbackPreferences,
             restoredStateSnapshot = restoredStateSnapshot
         )
+        LegacyJsonCleanupScheduler.schedule(app, "player-bootstrap")
         NPLogger.d("NERI-App", "PlayerManager.initialize called")
         NPLogger.d(
             "NERI-App",

--- a/app/src/main/java/moe/ouom/neriplayer/data/auth/bili/BiliCookieRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/auth/bili/BiliCookieRepository.kt
@@ -26,13 +26,10 @@ package moe.ouom.neriplayer.data.auth.bili
  */
 
 import android.content.Context
-import android.content.SharedPreferences
 import androidx.core.content.edit
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -41,6 +38,7 @@ import kotlinx.coroutines.runBlocking
 import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthHealth
 import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthState
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.util.security.RecoveringEncryptedSharedPreferences
 import org.json.JSONObject
 
 private const val BILI_AUTH_PREFS = "bili_auth_secure_prefs"
@@ -139,7 +137,7 @@ internal fun evaluateBiliAuthHealth(
 }
 
 class BiliCookieRepository(private val context: Context) {
-    private var encryptedPrefs: SharedPreferences
+    private val encryptedPrefs: RecoveringEncryptedSharedPreferences
     private val _authFlow: MutableStateFlow<BiliAuthBundle>
     private val _cookieFlow: MutableStateFlow<Map<String, String>>
     private val _authHealthFlow: MutableStateFlow<SavedCookieAuthHealth>
@@ -151,7 +149,11 @@ class BiliCookieRepository(private val context: Context) {
         get() = _authHealthFlow.asStateFlow()
 
     init {
-        encryptedPrefs = openEncryptedPrefsWithRecovery()
+        encryptedPrefs = RecoveringEncryptedSharedPreferences(
+            context = context,
+            storageName = BILI_AUTH_PREFS,
+            logTag = "NERI-BiliCookieRepo"
+        )
         val initialBundle = loadAuthBundle()
         _authFlow = MutableStateFlow(initialBundle)
         _cookieFlow = MutableStateFlow(initialBundle.cookies)
@@ -233,12 +235,19 @@ class BiliCookieRepository(private val context: Context) {
         encryptedPrefs.edit {
             putString(KEY_BILI_AUTH_BUNDLE, migrated.toJson())
         }
-        runCatching {
-            runBlocking {
-                context.biliCookieStore.edit { prefs ->
-                    prefs.remove(BiliCookieKeys.COOKIE_JSON)
+        if (encryptedPrefs.isDurable) {
+            runCatching {
+                runBlocking {
+                    context.biliCookieStore.edit { prefs ->
+                        prefs.remove(BiliCookieKeys.COOKIE_JSON)
+                    }
                 }
             }
+        } else {
+            NPLogger.w(
+                "NERI-BiliCookieRepo",
+                "Kept legacy Bili credentials because secure storage is not durable yet."
+            )
         }
         return migrated
     }
@@ -254,42 +263,4 @@ class BiliCookieRepository(private val context: Context) {
         return out
     }
 
-    private fun openEncryptedPrefsWithRecovery(): SharedPreferences {
-        return runCatching {
-            createEncryptedPrefs()
-        }.getOrElse { error ->
-            NPLogger.w(
-                "NERI-BiliCookieRepo",
-                "Failed to open Bili secure prefs, clearing storage and recreating.",
-                error
-            )
-            clearEncryptedStorage()
-            createEncryptedPrefs()
-        }
-    }
-
-    private fun createEncryptedPrefs(): SharedPreferences {
-        val masterKey = MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-        return EncryptedSharedPreferences.create(
-            context,
-            BILI_AUTH_PREFS,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
-    }
-
-    private fun clearEncryptedStorage() {
-        runCatching {
-            context.deleteSharedPreferences(BILI_AUTH_PREFS)
-        }.onFailure { error ->
-            NPLogger.w(
-                "NERI-BiliCookieRepo",
-                "Failed to delete corrupted Bili secure prefs file.",
-                error
-            )
-        }
-    }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/auth/netease/NeteaseCookieRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/auth/netease/NeteaseCookieRepository.kt
@@ -26,13 +26,10 @@ package moe.ouom.neriplayer.data.auth.netease
  */
 
 import android.content.Context
-import android.content.SharedPreferences
 import androidx.core.content.edit
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -41,6 +38,7 @@ import kotlinx.coroutines.runBlocking
 import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthHealth
 import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthState
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.util.security.RecoveringEncryptedSharedPreferences
 import org.json.JSONObject
 
 private const val NETEASE_AUTH_PREFS = "netease_auth_secure_prefs"
@@ -183,7 +181,7 @@ internal fun evaluateNeteaseAuthHealth(
 }
 
 class NeteaseCookieRepository(private val context: Context) {
-    private var encryptedPrefs: SharedPreferences
+    private val encryptedPrefs: RecoveringEncryptedSharedPreferences
     private val _authFlow: MutableStateFlow<NeteaseAuthBundle>
     private val _cookieFlow: MutableStateFlow<Map<String, String>>
     private val _authHealthFlow: MutableStateFlow<SavedCookieAuthHealth>
@@ -195,7 +193,11 @@ class NeteaseCookieRepository(private val context: Context) {
         get() = _authHealthFlow.asStateFlow()
 
     init {
-        encryptedPrefs = openEncryptedPrefsWithRecovery()
+        encryptedPrefs = RecoveringEncryptedSharedPreferences(
+            context = context,
+            storageName = NETEASE_AUTH_PREFS,
+            logTag = "NERI-CookieRepo"
+        )
         val initialBundle = loadAuthBundle()
         _authFlow = MutableStateFlow(initialBundle)
         _cookieFlow = MutableStateFlow(initialBundle.cookies)
@@ -264,17 +266,7 @@ class NeteaseCookieRepository(private val context: Context) {
     }
 
     private fun loadAuthBundle(): NeteaseAuthBundle {
-        val raw = runCatching {
-            encryptedPrefs.getString(KEY_NETEASE_AUTH_BUNDLE, null).orEmpty()
-        }.getOrElse { error ->
-            NPLogger.w(
-                "NERI-CookieRepo",
-                "Failed to read NetEase secure prefs, clearing corrupted storage and retrying.",
-                error
-            )
-            rebuildEncryptedStorage()
-            ""
-        }
+        val raw = encryptedPrefs.getString(KEY_NETEASE_AUTH_BUNDLE, null).orEmpty()
         if (raw.isNotBlank()) {
             return NeteaseAuthBundle.fromJson(raw)
         }
@@ -303,12 +295,19 @@ class NeteaseCookieRepository(private val context: Context) {
         encryptedPrefs.edit {
             putString(KEY_NETEASE_AUTH_BUNDLE, migrated.toJson())
         }
-        runCatching {
-            runBlocking {
-                context.cookieDataStore.edit { prefs ->
-                    prefs.remove(CookieKeys.NETEASE_COOKIE_JSON)
+        if (encryptedPrefs.isDurable) {
+            runCatching {
+                runBlocking {
+                    context.cookieDataStore.edit { prefs ->
+                        prefs.remove(CookieKeys.NETEASE_COOKIE_JSON)
+                    }
                 }
             }
+        } else {
+            NPLogger.w(
+                "NERI-CookieRepo",
+                "Kept legacy NetEase credentials because secure storage is not durable yet."
+            )
         }
         return migrated
     }
@@ -324,47 +323,4 @@ class NeteaseCookieRepository(private val context: Context) {
         return result
     }
 
-    private fun openEncryptedPrefsWithRecovery(): SharedPreferences {
-        return runCatching {
-            createEncryptedPrefs()
-        }.getOrElse { error ->
-            NPLogger.w(
-                "NERI-CookieRepo",
-                "Failed to open NetEase secure prefs, clearing storage and recreating.",
-                error
-            )
-            clearEncryptedStorage()
-            createEncryptedPrefs()
-        }
-    }
-
-    private fun rebuildEncryptedStorage() {
-        clearEncryptedStorage()
-        encryptedPrefs = openEncryptedPrefsWithRecovery()
-    }
-
-    private fun clearEncryptedStorage() {
-        runCatching {
-            context.deleteSharedPreferences(NETEASE_AUTH_PREFS)
-        }.onFailure { error ->
-            NPLogger.w(
-                "NERI-CookieRepo",
-                "Failed to delete corrupted NetEase secure prefs file.",
-                error
-            )
-        }
-    }
-
-    private fun createEncryptedPrefs(): SharedPreferences {
-        val masterKey = MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-        return EncryptedSharedPreferences.create(
-            context,
-            NETEASE_AUTH_PREFS,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
-    }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/auth/youtube/YouTubeAuthRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/auth/youtube/YouTubeAuthRepository.kt
@@ -205,6 +205,7 @@ internal fun parseCookieHeader(raw: String): LinkedHashMap<String, String> {
 class YouTubeAuthRepository(private val context: Context) {
     private var encryptedPrefs: RecoveringEncryptedSharedPreferences
     private var usingRecoveryStorage = false
+    private val recoveryPrefs by lazy { createRecoveryEncryptedPrefs() }
     private val _authFlow: MutableStateFlow<YouTubeAuthBundle>
     private val _authHealthFlow: MutableStateFlow<YouTubeAuthHealth>
     private val authMutationLock = Any()
@@ -297,7 +298,6 @@ class YouTubeAuthRepository(private val context: Context) {
         val raw = encryptedPrefs.getString(KEY_YOUTUBE_AUTH_BUNDLE, null).orEmpty()
         if (raw.isBlank() && !usingRecoveryStorage) {
             // 旧的恢复存储可能是在一次加密异常后写入的, 优先取它以免恢复成功后又显示游客态
-            val recoveryPrefs = createRecoveryEncryptedPrefs()
             val recoveryRaw = recoveryPrefs.getString(KEY_YOUTUBE_AUTH_BUNDLE, null).orEmpty()
             if (recoveryRaw.isNotBlank()) {
                 encryptedPrefs = recoveryPrefs
@@ -320,15 +320,15 @@ class YouTubeAuthRepository(private val context: Context) {
     }
 
     private fun switchToRecoveryStorage() {
-        encryptedPrefs = createRecoveryEncryptedPrefs()
+        encryptedPrefs = recoveryPrefs
         usingRecoveryStorage = true
     }
 
     private fun persistAuthBundle(bundle: YouTubeAuthBundle) {
         val serialized = bundle.toJson()
         if (!usingRecoveryStorage) {
-            commitAuthBundle(encryptedPrefs, serialized)
-            if (encryptedPrefs.isDurable) {
+            val committed = commitAuthBundle(encryptedPrefs, serialized)
+            if (committed && encryptedPrefs.isDurable) {
                 persistRecoveryBackup(serialized)
                 return
             }
@@ -338,7 +338,10 @@ class YouTubeAuthRepository(private val context: Context) {
             )
             switchToRecoveryStorage()
         }
-        commitAuthBundle(encryptedPrefs, serialized)
+        val committed = commitAuthBundle(encryptedPrefs, serialized)
+        if (!committed) {
+            NPLogger.w("NERI-YouTubeAuthRepo", "Failed to persist YouTube auth bundle")
+        }
         if (!encryptedPrefs.isDurable) {
             NPLogger.w(
                 "NERI-YouTubeAuthRepo",
@@ -349,9 +352,11 @@ class YouTubeAuthRepository(private val context: Context) {
 
     private fun persistRecoveryBackup(serialized: String) {
         // 主存储正常时也保留独立加密副本, 主文件损坏后仍能恢复最近一次登录
-        val recoveryPrefs = createRecoveryEncryptedPrefs()
-        commitAuthBundle(recoveryPrefs, serialized)
-        if (!recoveryPrefs.isDurable) {
+        val activeRecoveryPrefs = recoveryPrefs
+        if (!commitAuthBundle(activeRecoveryPrefs, serialized)) {
+            NPLogger.w("NERI-YouTubeAuthRepo", "Failed to persist YouTube recovery backup")
+        }
+        if (!activeRecoveryPrefs.isDurable) {
             NPLogger.w(
                 "NERI-YouTubeAuthRepo",
                 "YouTube recovery backup is memory-only; primary auth remains available."

--- a/app/src/main/java/moe/ouom/neriplayer/data/auth/youtube/YouTubeAuthRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/auth/youtube/YouTubeAuthRepository.kt
@@ -25,14 +25,12 @@ package moe.ouom.neriplayer.data.auth.youtube
 import android.content.Context
 import android.content.SharedPreferences
 import android.annotation.SuppressLint
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.util.security.RecoveringEncryptedSharedPreferences
 import org.json.JSONObject
-import java.io.IOException
 
 const val YOUTUBE_MUSIC_ORIGIN: String = "https://music.youtube.com"
 private const val YOUTUBE_AUTH_PREFS = "youtube_auth_secure_prefs"
@@ -205,7 +203,7 @@ internal fun parseCookieHeader(raw: String): LinkedHashMap<String, String> {
 }
 
 class YouTubeAuthRepository(private val context: Context) {
-    private var encryptedPrefs: SharedPreferences
+    private var encryptedPrefs: RecoveringEncryptedSharedPreferences
     private var usingRecoveryStorage = false
     private val _authFlow: MutableStateFlow<YouTubeAuthBundle>
     private val _authHealthFlow: MutableStateFlow<YouTubeAuthHealth>
@@ -218,7 +216,7 @@ class YouTubeAuthRepository(private val context: Context) {
         get() = _authHealthFlow.asStateFlow()
 
     init {
-        encryptedPrefs = openEncryptedPrefsWithRecovery()
+        encryptedPrefs = createEncryptedPrefs(YOUTUBE_AUTH_PREFS)
         val initialBundle = loadAuthBundle()
         _authFlow = MutableStateFlow(initialBundle)
         _authHealthFlow = MutableStateFlow(
@@ -278,25 +276,9 @@ class YouTubeAuthRepository(private val context: Context) {
             clearStoredAuth(encryptedPrefs, "active")
             // 恢复存储可能保留着上一次加密异常时写入的凭据, 显式清除不能留下第二份
             if (usingRecoveryStorage) {
-                runCatching { createEncryptedPrefs(YOUTUBE_AUTH_PREFS) }
-                    .onSuccess { clearStoredAuth(it, "primary") }
-                    .onFailure { error ->
-                        NPLogger.w(
-                            "NERI-YouTubeAuthRepo",
-                            "Failed to clear primary YouTube secure prefs.",
-                            error
-                        )
-                    }
+                clearStoredAuth(createEncryptedPrefs(YOUTUBE_AUTH_PREFS), "primary")
             } else {
-                runCatching { createRecoveryEncryptedPrefs() }
-                    .onSuccess { clearStoredAuth(it, "recovery") }
-                    .onFailure { error ->
-                        NPLogger.w(
-                            "NERI-YouTubeAuthRepo",
-                            "Failed to clear recovery YouTube secure prefs.",
-                            error
-                        )
-                    }
+                clearStoredAuth(createRecoveryEncryptedPrefs(), "recovery")
             }
             val cleared = YouTubeAuthBundle()
             _authFlow.value = cleared
@@ -312,33 +294,15 @@ class YouTubeAuthRepository(private val context: Context) {
     }
 
     private fun loadAuthBundle(): YouTubeAuthBundle {
-        val primaryRead = runCatching {
-            encryptedPrefs.getString(KEY_YOUTUBE_AUTH_BUNDLE, null)
-        }
-        if (primaryRead.isFailure && !usingRecoveryStorage) {
-            NPLogger.w(
-                "NERI-YouTubeAuthRepo",
-                "Failed to read primary YouTube secure prefs, preserving it and switching to recovery storage.",
-                primaryRead.exceptionOrNull()
-            )
-            if (switchToRecoveryStorage()) {
-                return readRecoveryAuthBundle()
-            }
-        }
-
-        val raw = primaryRead.getOrNull().orEmpty()
+        val raw = encryptedPrefs.getString(KEY_YOUTUBE_AUTH_BUNDLE, null).orEmpty()
         if (raw.isBlank() && !usingRecoveryStorage) {
             // 旧的恢复存储可能是在一次加密异常后写入的, 优先取它以免恢复成功后又显示游客态
-            runCatching { createRecoveryEncryptedPrefs() }
-                .onSuccess { recoveryPrefs ->
-                    val recoveryRaw = runCatching {
-                        recoveryPrefs.getString(KEY_YOUTUBE_AUTH_BUNDLE, null).orEmpty()
-                    }.getOrDefault("")
-                    if (recoveryRaw.isNotBlank()) {
-                        encryptedPrefs = recoveryPrefs
-                        usingRecoveryStorage = true
-                    }
-                }
+            val recoveryPrefs = createRecoveryEncryptedPrefs()
+            val recoveryRaw = recoveryPrefs.getString(KEY_YOUTUBE_AUTH_BUNDLE, null).orEmpty()
+            if (recoveryRaw.isNotBlank()) {
+                encryptedPrefs = recoveryPrefs
+                usingRecoveryStorage = true
+            }
         }
         if (usingRecoveryStorage) {
             return readRecoveryAuthBundle()
@@ -350,74 +314,47 @@ class YouTubeAuthRepository(private val context: Context) {
     }
 
     private fun readRecoveryAuthBundle(): YouTubeAuthBundle {
-        val raw = runCatching {
-            encryptedPrefs.getString(KEY_YOUTUBE_AUTH_BUNDLE, null).orEmpty()
-        }.onFailure { error ->
-            NPLogger.w(
-                "NERI-YouTubeAuthRepo",
-                "Failed to read YouTube recovery secure prefs.",
-                error
-            )
-        }.getOrDefault("")
+        val raw = encryptedPrefs.getString(KEY_YOUTUBE_AUTH_BUNDLE, null).orEmpty()
         return raw.takeIf(String::isNotBlank)?.let(YouTubeAuthBundle::fromJson)
             ?: YouTubeAuthBundle()
     }
 
-    private fun switchToRecoveryStorage(): Boolean {
-        val recoveryPrefs = runCatching { createRecoveryEncryptedPrefs() }
-            .onFailure { error ->
-                NPLogger.e(
-                    "NERI-YouTubeAuthRepo",
-                    "Failed to open YouTube recovery secure prefs; original storage was preserved.",
-                    error
-                )
-            }
-            .getOrNull()
-            ?: return false
-        encryptedPrefs = recoveryPrefs
+    private fun switchToRecoveryStorage() {
+        encryptedPrefs = createRecoveryEncryptedPrefs()
         usingRecoveryStorage = true
-        return true
     }
 
     private fun persistAuthBundle(bundle: YouTubeAuthBundle) {
         val serialized = bundle.toJson()
-        val primaryWrite = runCatching {
+        if (!usingRecoveryStorage) {
             commitAuthBundle(encryptedPrefs, serialized)
-        }
-        if (primaryWrite.getOrNull() != true) {
-            if (usingRecoveryStorage) {
-                throw primaryWrite.exceptionOrNull()
-                    ?: IOException("Failed to commit YouTube recovery secure prefs")
+            if (encryptedPrefs.isDurable) {
+                persistRecoveryBackup(serialized)
+                return
             }
             NPLogger.w(
                 "NERI-YouTubeAuthRepo",
-                "Failed to commit primary YouTube secure prefs, preserving it and switching to recovery storage.",
-                primaryWrite.exceptionOrNull()
+                "Primary YouTube secure prefs are unavailable; using recovery storage."
             )
-            if (!switchToRecoveryStorage()) {
-                throw primaryWrite.exceptionOrNull()
-                    ?: IOException("Failed to commit YouTube primary secure prefs")
-            }
-            if (!commitAuthBundle(encryptedPrefs, serialized)) {
-                throw IOException("Failed to commit YouTube recovery secure prefs")
-            }
-            return
+            switchToRecoveryStorage()
         }
-
-        // 主存储正常时也保留独立加密副本, 主文件损坏后仍能恢复最近一次登录
-        runCatching {
-            val recoveryPrefs = createRecoveryEncryptedPrefs()
-            if (!commitAuthBundle(recoveryPrefs, serialized)) {
-                NPLogger.w(
-                    "NERI-YouTubeAuthRepo",
-                    "Failed to commit YouTube recovery backup; primary auth remains available"
-                )
-            }
-        }.onFailure { error ->
+        commitAuthBundle(encryptedPrefs, serialized)
+        if (!encryptedPrefs.isDurable) {
             NPLogger.w(
                 "NERI-YouTubeAuthRepo",
-                "Failed to update YouTube recovery backup; primary auth remains available.",
-                error
+                "YouTube credentials are memory-only until secure storage becomes available."
+            )
+        }
+    }
+
+    private fun persistRecoveryBackup(serialized: String) {
+        // 主存储正常时也保留独立加密副本, 主文件损坏后仍能恢复最近一次登录
+        val recoveryPrefs = createRecoveryEncryptedPrefs()
+        commitAuthBundle(recoveryPrefs, serialized)
+        if (!recoveryPrefs.isDurable) {
+            NPLogger.w(
+                "NERI-YouTubeAuthRepo",
+                "YouTube recovery backup is memory-only; primary auth remains available."
             )
         }
     }
@@ -429,39 +366,7 @@ class YouTubeAuthRepository(private val context: Context) {
         putString(KEY_YOUTUBE_AUTH_BUNDLE, serialized)
     }
 
-    private fun openEncryptedPrefsWithRecovery(): SharedPreferences {
-        return runCatching {
-            createEncryptedPrefs(YOUTUBE_AUTH_PREFS)
-        }.getOrElse { error ->
-            NPLogger.w(
-                "NERI-YouTubeAuthRepo",
-                "Failed to open primary YouTube secure prefs, preserving it and using recovery storage.",
-                error
-            )
-            switchToRecoveryStorageOrThrow()
-        }
-    }
-
-    private fun switchToRecoveryStorageOrThrow(): SharedPreferences {
-        val recoveryPrefs = runCatching { createRecoveryEncryptedPrefs() }
-            .onFailure { recoveryError ->
-                NPLogger.e(
-                    "NERI-YouTubeAuthRepo",
-                    "Unable to open either YouTube secure storage; original storage was preserved.",
-                    recoveryError
-                )
-            }
-            .getOrElse { recoveryError ->
-                throw IllegalStateException(
-                    "Unable to open YouTube secure storage without deleting credentials",
-                    recoveryError
-                )
-            }
-        usingRecoveryStorage = true
-        return recoveryPrefs
-    }
-
-    private fun createRecoveryEncryptedPrefs(): SharedPreferences {
+    private fun createRecoveryEncryptedPrefs(): RecoveringEncryptedSharedPreferences {
         return createEncryptedPrefs(
             name = YOUTUBE_AUTH_RECOVERY_PREFS,
             masterKeyAlias = YOUTUBE_AUTH_RECOVERY_MASTER_KEY_ALIAS
@@ -471,34 +376,20 @@ class YouTubeAuthRepository(private val context: Context) {
     private fun createEncryptedPrefs(
         name: String,
         masterKeyAlias: String? = null
-    ): SharedPreferences {
-        val masterKeyBuilder = if (masterKeyAlias.isNullOrBlank()) {
-            MasterKey.Builder(context)
-        } else {
-            MasterKey.Builder(context, masterKeyAlias)
-        }
-        val masterKey = masterKeyBuilder
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-        return EncryptedSharedPreferences.create(
-            context,
-            name,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    ): RecoveringEncryptedSharedPreferences {
+        return RecoveringEncryptedSharedPreferences(
+            context = context,
+            storageName = name,
+            logTag = "NERI-YouTubeAuthRepo",
+            masterKeyAlias = masterKeyAlias
         )
     }
 
     private fun clearStoredAuth(prefs: SharedPreferences, label: String) {
-        runCatching {
-            if (!prefs.commitEdit { remove(KEY_YOUTUBE_AUTH_BUNDLE) }) {
-                throw IOException("SharedPreferences commit returned false")
-            }
-        }.onFailure { error ->
+        if (!prefs.commitEdit { remove(KEY_YOUTUBE_AUTH_BUNDLE) }) {
             NPLogger.w(
                 "NERI-YouTubeAuthRepo",
-                "Failed to clear $label YouTube secure prefs.",
-                error
+                "Failed to clear $label YouTube secure prefs."
             )
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
@@ -163,8 +163,6 @@ class PlayHistoryRepository private constructor(
     private val file: File by lazy { File(app.filesDir, "play_history.json") }
     @Volatile
     private var roomStorageEnabled = roomStore != null
-    private val legacyProjectionMutex = Mutex()
-    private var legacyProjectionGeneration = 0L
     private val _history = MutableStateFlow(loadInitialHistory())
     val historyFlow: StateFlow<List<PlayedEntry>> = _history
     private val storage by lazy { SecureTokenStorage(app) }
@@ -258,7 +256,6 @@ class PlayHistoryRepository private constructor(
                 )
             }.isSuccess
             if (roomWriteSucceeded) {
-                enqueueLegacyProjection(next)
                 return
             }
         }
@@ -273,22 +270,6 @@ class PlayHistoryRepository private constructor(
                     "Failed to mark legacy history fallback state",
                     error
                 )
-            }
-        }
-    }
-
-    private fun enqueueLegacyProjection(entries: List<PlayedEntry>) {
-        synchronized(this) {
-            legacyProjectionGeneration += 1L
-        }
-        val generation = synchronized(this) { legacyProjectionGeneration }
-        scope.launch {
-            legacyProjectionMutex.withLock {
-                val isLatest = synchronized(this@PlayHistoryRepository) {
-                    generation == legacyProjectionGeneration
-                }
-                if (!isLatest) return@withLock
-                persistToDisk(entries)
             }
         }
     }
@@ -526,7 +507,6 @@ class PlayHistoryRepository private constructor(
                                 error
                             )
                         }
-                        .onSuccess { enqueueLegacyProjection(emptyList()) }
                 }
                 if (!roomStorageEnabled) {
                     persistToDisk(emptyList())

--- a/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
@@ -222,7 +222,7 @@ class PlayHistoryRepository private constructor(
             }.getOrNull()
             if (imported?.status == PlayHistoryRoomImportStatus.SKIPPED_NOT_EQUIVALENT) {
                 roomStorageEnabled = false
-                needsRoomRecovery = false
+                needsRoomRecovery = true
                 NPLogger.w(
                     "PlayHistoryRepo",
                     "Room history mapper is not equivalent; keep legacy JSON"
@@ -256,6 +256,7 @@ class PlayHistoryRepository private constructor(
     ) {
         val activeRoomStore = roomStore
         if (!roomStorageEnabled || activeRoomStore == null) {
+            persistLegacySnapshot(next)
             NPLogger.w(
                 "PlayHistoryRepo",
                 "Play history update remains in memory until Room is available."
@@ -281,26 +282,30 @@ class PlayHistoryRepository private constructor(
     }
 
     private fun schedulePersistenceRetry() {
-        if (!roomStorageEnabled || retryJob?.isActive == true) return
-        retryJob = scope.launch {
+        synchronized(this) {
+            if (!roomStorageEnabled || retryJob?.isActive == true) return
+            retryJob = scope.launch {
             delay(ROOM_RETRY_DELAY_MS)
             historyMutex.withLock {
-                retryJob = null
+                synchronized(this@PlayHistoryRepository) { retryJob = null }
                 persistSnapshot(_history.value)
             }
+        }
         }
     }
 
     private fun scheduleRoomRecovery() {
-        if (roomStorageEnabled || roomRecoveryBaseline == null || retryJob?.isActive == true) {
-            return
-        }
-        retryJob = scope.launch {
+        synchronized(this) {
+            if (roomStorageEnabled || roomRecoveryBaseline == null || retryJob?.isActive == true) {
+                return
+            }
+            retryJob = scope.launch {
             delay(ROOM_RETRY_DELAY_MS)
             historyMutex.withLock {
-                retryJob = null
+                synchronized(this@PlayHistoryRepository) { retryJob = null }
                 recoverRoomStorage()
             }
+        }
         }
     }
 
@@ -342,7 +347,8 @@ class PlayHistoryRepository private constructor(
             )
         }.getOrNull()
         if (recovered == null) {
-            scheduleRoomRecovery()
+            roomRecoveryBaseline = null
+            NPLogger.e("PlayHistoryRepo", "Room history migration is not equivalent; keeping legacy JSON")
             return
         }
 
@@ -352,6 +358,13 @@ class PlayHistoryRepository private constructor(
         _history.value = recovered
         LegacyJsonCleanupScheduler.schedule(app, "play-history-room-recovery")
         flushPostPersistenceActions(recovered)
+    }
+
+    private fun persistLegacySnapshot(next: List<PlayedEntry>) {
+        runCatching { file.writeText(gson.toJson(next)) }
+            .onFailure { error ->
+                NPLogger.e("PlayHistoryRepo", "Failed to persist legacy play history", error)
+            }
     }
 
     private suspend fun mergeRecoveredRoomHistory(

--- a/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
@@ -48,7 +48,6 @@ import moe.ouom.neriplayer.data.sync.SyncPreferences
 import moe.ouom.neriplayer.data.sync.github.GitHubSyncWorker
 import moe.ouom.neriplayer.data.sync.github.SecureTokenStorage
 import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
-import moe.ouom.neriplayer.util.io.writeTextAtomically
 import moe.ouom.neriplayer.data.sync.model.SyncRecentPlayDeletion
 import moe.ouom.neriplayer.data.sync.webdav.WebDavSyncWorker
 import moe.ouom.neriplayer.data.model.SongItem
@@ -164,13 +163,16 @@ class PlayHistoryRepository private constructor(
     private val file: File by lazy { File(app.filesDir, "play_history.json") }
     @Volatile
     private var roomStorageEnabled = roomStore != null
-    private val _history = MutableStateFlow(loadInitialHistory())
+    private val initialHistory = loadInitialHistory()
+    private val _history = MutableStateFlow(initialHistory)
+    private var persistedHistory = initialHistory
     val historyFlow: StateFlow<List<PlayedEntry>> = _history
     private val storage by lazy { SecureTokenStorage(app) }
     private val syncPreferences by lazy { SyncPreferences(app) }
     private var lastBatchSyncTime = 0L
     private val historyMutex = Mutex()
     private var pendingSettledSyncJob: Job? = null
+    private var retryJob: Job? = null
 
     private fun loadInitialHistory(): List<PlayedEntry> {
         if (roomStorageEnabled && roomStore != null) {
@@ -235,45 +237,40 @@ class PlayHistoryRepository private constructor(
         }
     }
 
-    private fun persistToDisk(list: List<PlayedEntry>) {
-        runCatching {
-            file.writeTextAtomically(gson.toJson(list))
+    private suspend fun persistSnapshot(
+        next: List<PlayedEntry>
+    ) {
+        val activeRoomStore = roomStore
+        if (!roomStorageEnabled || activeRoomStore == null) {
+            NPLogger.w(
+                "PlayHistoryRepo",
+                "Play history update remains in memory until Room is available."
+            )
+            return
+        }
+        val roomWriteSucceeded = runCatching {
+            activeRoomStore.writeIncremental(previous = persistedHistory, next = next)
         }.onFailure { error ->
-            NPLogger.e("PlayHistoryRepo", "Failed to persist play history", error)
+            NPLogger.e(
+                "PlayHistoryRepo",
+                "Failed to write Room history; keeping JSON migration data read-only",
+                error
+            )
+        }.isSuccess
+        if (roomWriteSucceeded) {
+            persistedHistory = next
+        } else {
+            schedulePersistenceRetry()
         }
     }
 
-    private suspend fun persistSnapshot(
-        previous: List<PlayedEntry>,
-        next: List<PlayedEntry>
-    ) {
-        if (roomStorageEnabled && roomStore != null) {
-            val activeRoomStore = roomStore
-            val roomWriteSucceeded = runCatching {
-                activeRoomStore.writeIncremental(previous = previous, next = next)
-            }.onFailure { error ->
-                roomStorageEnabled = false
-                NPLogger.e(
-                    "PlayHistoryRepo",
-                    "Failed to write Room history; falling back to legacy JSON",
-                    error
-                )
-            }.isSuccess
-            if (roomWriteSucceeded) {
-                return
-            }
-        }
-
-        persistToDisk(next)
-        roomStore?.let { fallbackStore ->
-            runCatching {
-                fallbackStore.markLegacyJsonPrimary()
-            }.onFailure { error ->
-                NPLogger.e(
-                    "PlayHistoryRepo",
-                    "Failed to mark legacy history fallback state",
-                    error
-                )
+    private fun schedulePersistenceRetry() {
+        if (!roomStorageEnabled || retryJob?.isActive == true) return
+        retryJob = scope.launch {
+            delay(ROOM_RETRY_DELAY_MS)
+            historyMutex.withLock {
+                retryJob = null
+                persistSnapshot(_history.value)
             }
         }
     }
@@ -369,7 +366,7 @@ class PlayHistoryRepository private constructor(
                 markSyncMutation()
                 NPLogger.d("PlayHistoryRepo", "Updated history size: ${updated.size}, latest: ${updated.firstOrNull()?.name}")
                 _history.value = updated
-                persistSnapshot(previous = current, next = updated)
+                persistSnapshot(next = updated)
 
                 if (!LocalSongSupport.isLocalSong(song.album, song.mediaUri, song.albumId, app)) {
                     storage.removeRecentPlayDeletion(song.identityKey())
@@ -432,7 +429,7 @@ class PlayHistoryRepository private constructor(
 
                 markSyncMutation()
                 _history.value = updated
-                persistSnapshot(previous = current, next = updated)
+                persistSnapshot(next = updated)
                 if (!LocalSongSupport.isLocalSong(song.album, song.mediaUri, song.albumId, app)) {
                     storage.removeRecentPlayDeletion(song.identityKey())
                 }
@@ -473,7 +470,7 @@ class PlayHistoryRepository private constructor(
                     .take(1000)
 
                 _history.value = updated
-                persistSnapshot(previous = current, next = updated)
+                persistSnapshot(next = updated)
                 if (triggerSync) {
                     triggerSyncIfNeeded(PlayHistorySyncUrgency.SETTLED)
                 }
@@ -501,20 +498,7 @@ class PlayHistoryRepository private constructor(
                 }
 
                 _history.value = emptyList()
-                if (roomStorageEnabled && roomStore != null) {
-                    runCatching { roomStore.clear() }
-                        .onFailure { error ->
-                            roomStorageEnabled = false
-                            NPLogger.e(
-                                "PlayHistoryRepo",
-                                "Failed to clear Room history; falling back to legacy JSON",
-                                error
-                            )
-                        }
-                }
-                if (!roomStorageEnabled) {
-                    persistToDisk(emptyList())
-                }
+                persistSnapshot(next = emptyList())
                 triggerSyncIfNeeded(markMutation = false)
             }
         }
@@ -547,7 +531,7 @@ class PlayHistoryRepository private constructor(
 
                 val updated = current.filterNot { it.identityKey() in removalKeys }
                 _history.value = updated
-                persistSnapshot(previous = current, next = updated)
+                persistSnapshot(next = updated)
                 triggerSyncIfNeeded(markMutation = false)
             }
         }
@@ -561,9 +545,8 @@ class PlayHistoryRepository private constructor(
                 .distinctBy { it.identityKey() }
                 .take(1000)
             NPLogger.d("PlayHistoryRepo", "updateHistory() setting history to ${clipped.size} entries, latest: ${clipped.firstOrNull()?.name}")
-            val previous = _history.value
             _history.value = clipped
-            persistSnapshot(previous = previous, next = clipped)
+            persistSnapshot(next = clipped)
         }
     }
 
@@ -579,9 +562,8 @@ class PlayHistoryRepository private constructor(
                 .sortedByDescending { it.playedAt }
                 .distinctBy { it.identityKey() }
                 .take(1000)
-            val previous = _history.value
             _history.value = clipped
-            persistSnapshot(previous = previous, next = clipped)
+            persistSnapshot(next = clipped)
             true
         }
     }
@@ -637,6 +619,8 @@ class PlayHistoryRepository private constructor(
     }
 
     companion object {
+        private const val ROOM_RETRY_DELAY_MS = 15_000L
+
         @SuppressLint("StaticFieldLeak")
         @Volatile
         private var INSTANCE: PlayHistoryRepository? = null

--- a/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
@@ -35,8 +35,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.PlayHistoryRoomImportStatus
+import moe.ouom.neriplayer.data.local.database.store.PlayHistoryRoomStore
 import moe.ouom.neriplayer.data.local.media.LocalSongSupport
 import moe.ouom.neriplayer.data.model.SongIdentity
 import moe.ouom.neriplayer.data.sync.PlayHistoryUpdateMode
@@ -150,11 +154,18 @@ internal fun playHistoryAutoSyncDelayMillis(urgency: PlayHistorySyncUrgency): Lo
     }
 }
 
-class PlayHistoryRepository private constructor(private val app: Context) {
+class PlayHistoryRepository private constructor(
+    private val app: Context,
+    private val roomStore: PlayHistoryRoomStore? = null
+) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val gson = Gson()
     private val file: File by lazy { File(app.filesDir, "play_history.json") }
-    private val _history = MutableStateFlow(loadFromDisk())
+    @Volatile
+    private var roomStorageEnabled = roomStore != null
+    private val legacyProjectionMutex = Mutex()
+    private var legacyProjectionGeneration = 0L
+    private val _history = MutableStateFlow(loadInitialHistory())
     val historyFlow: StateFlow<List<PlayedEntry>> = _history
     private val storage by lazy { SecureTokenStorage(app) }
     private val syncPreferences by lazy { SyncPreferences(app) }
@@ -162,7 +173,53 @@ class PlayHistoryRepository private constructor(private val app: Context) {
     private val historyMutex = Mutex()
     private var pendingSettledSyncJob: Job? = null
 
-    private fun loadFromDisk(): List<PlayedEntry> {
+    private fun loadInitialHistory(): List<PlayedEntry> {
+        if (roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            val roomEntries = runCatching {
+                runBlocking {
+                    activeRoomStore.readIfRoomPrimary()
+                }
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                NPLogger.e(
+                    "PlayHistoryRepo",
+                    "Failed to read Room history; falling back to legacy JSON",
+                    error
+                )
+            }.getOrNull()
+            if (roomEntries != null) {
+                return roomEntries
+            }
+        }
+
+        val legacyEntries = loadLegacyFromDisk()
+        if (roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            val imported = runCatching {
+                runBlocking {
+                    activeRoomStore.importLegacyAndPromote(legacyEntries)
+                }
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                NPLogger.e(
+                    "PlayHistoryRepo",
+                    "Failed to promote legacy history to Room",
+                    error
+                )
+            }.getOrNull()
+            if (imported?.status == PlayHistoryRoomImportStatus.SKIPPED_NOT_EQUIVALENT) {
+                roomStorageEnabled = false
+                NPLogger.w(
+                    "PlayHistoryRepo",
+                    "Room history mapper is not equivalent; keep legacy JSON"
+                )
+            }
+        }
+        return legacyEntries
+    }
+
+    private fun loadLegacyFromDisk(): List<PlayedEntry> {
         return try {
             if (!file.exists()) return emptyList()
             val raw = file.readText()
@@ -181,6 +238,58 @@ class PlayHistoryRepository private constructor(private val app: Context) {
             file.writeTextAtomically(gson.toJson(list))
         }.onFailure { error ->
             NPLogger.e("PlayHistoryRepo", "Failed to persist play history", error)
+        }
+    }
+
+    private suspend fun persistSnapshot(
+        previous: List<PlayedEntry>,
+        next: List<PlayedEntry>
+    ) {
+        if (roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            val roomWriteSucceeded = runCatching {
+                activeRoomStore.writeIncremental(previous = previous, next = next)
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                NPLogger.e(
+                    "PlayHistoryRepo",
+                    "Failed to write Room history; falling back to legacy JSON",
+                    error
+                )
+            }.isSuccess
+            if (roomWriteSucceeded) {
+                enqueueLegacyProjection(next)
+                return
+            }
+        }
+
+        persistToDisk(next)
+        roomStore?.let { fallbackStore ->
+            runCatching {
+                fallbackStore.markLegacyJsonPrimary()
+            }.onFailure { error ->
+                NPLogger.e(
+                    "PlayHistoryRepo",
+                    "Failed to mark legacy history fallback state",
+                    error
+                )
+            }
+        }
+    }
+
+    private fun enqueueLegacyProjection(entries: List<PlayedEntry>) {
+        synchronized(this) {
+            legacyProjectionGeneration += 1L
+        }
+        val generation = synchronized(this) { legacyProjectionGeneration }
+        scope.launch {
+            legacyProjectionMutex.withLock {
+                val isLatest = synchronized(this@PlayHistoryRepository) {
+                    generation == legacyProjectionGeneration
+                }
+                if (!isLatest) return@withLock
+                persistToDisk(entries)
+            }
         }
     }
 
@@ -275,7 +384,7 @@ class PlayHistoryRepository private constructor(private val app: Context) {
                 markSyncMutation()
                 NPLogger.d("PlayHistoryRepo", "Updated history size: ${updated.size}, latest: ${updated.firstOrNull()?.name}")
                 _history.value = updated
-                persistToDisk(updated)
+                persistSnapshot(previous = current, next = updated)
 
                 if (!LocalSongSupport.isLocalSong(song.album, song.mediaUri, song.albumId, app)) {
                     storage.removeRecentPlayDeletion(song.identityKey())
@@ -338,7 +447,7 @@ class PlayHistoryRepository private constructor(private val app: Context) {
 
                 markSyncMutation()
                 _history.value = updated
-                persistToDisk(updated)
+                persistSnapshot(previous = current, next = updated)
                 if (!LocalSongSupport.isLocalSong(song.album, song.mediaUri, song.albumId, app)) {
                     storage.removeRecentPlayDeletion(song.identityKey())
                 }
@@ -379,7 +488,7 @@ class PlayHistoryRepository private constructor(private val app: Context) {
                     .take(1000)
 
                 _history.value = updated
-                persistToDisk(updated)
+                persistSnapshot(previous = current, next = updated)
                 if (triggerSync) {
                     triggerSyncIfNeeded(PlayHistorySyncUrgency.SETTLED)
                 }
@@ -407,7 +516,21 @@ class PlayHistoryRepository private constructor(private val app: Context) {
                 }
 
                 _history.value = emptyList()
-                persistToDisk(emptyList())
+                if (roomStorageEnabled && roomStore != null) {
+                    runCatching { roomStore.clear() }
+                        .onFailure { error ->
+                            roomStorageEnabled = false
+                            NPLogger.e(
+                                "PlayHistoryRepo",
+                                "Failed to clear Room history; falling back to legacy JSON",
+                                error
+                            )
+                        }
+                        .onSuccess { enqueueLegacyProjection(emptyList()) }
+                }
+                if (!roomStorageEnabled) {
+                    persistToDisk(emptyList())
+                }
                 triggerSyncIfNeeded(markMutation = false)
             }
         }
@@ -440,7 +563,7 @@ class PlayHistoryRepository private constructor(private val app: Context) {
 
                 val updated = current.filterNot { it.identityKey() in removalKeys }
                 _history.value = updated
-                persistToDisk(updated)
+                persistSnapshot(previous = current, next = updated)
                 triggerSyncIfNeeded(markMutation = false)
             }
         }
@@ -454,8 +577,9 @@ class PlayHistoryRepository private constructor(private val app: Context) {
                 .distinctBy { it.identityKey() }
                 .take(1000)
             NPLogger.d("PlayHistoryRepo", "updateHistory() setting history to ${clipped.size} entries, latest: ${clipped.firstOrNull()?.name}")
+            val previous = _history.value
             _history.value = clipped
-            persistToDisk(clipped)
+            persistSnapshot(previous = previous, next = clipped)
         }
     }
 
@@ -471,8 +595,9 @@ class PlayHistoryRepository private constructor(private val app: Context) {
                 .sortedByDescending { it.playedAt }
                 .distinctBy { it.identityKey() }
                 .take(1000)
+            val previous = _history.value
             _history.value = clipped
-            persistToDisk(clipped)
+            persistSnapshot(previous = previous, next = clipped)
             true
         }
     }
@@ -534,7 +659,13 @@ class PlayHistoryRepository private constructor(private val app: Context) {
 
         fun getInstance(context: Context): PlayHistoryRepository {
             return INSTANCE ?: synchronized(this) {
-                INSTANCE ?: PlayHistoryRepository(context.applicationContext).also { INSTANCE = it }
+                val appContext = context.applicationContext
+                INSTANCE ?: PlayHistoryRepository(
+                    app = appContext,
+                    roomStore = PlayHistoryRoomStore(
+                        database = NeriUserDataDatabase.getInstance(appContext)
+                    )
+                ).also { INSTANCE = it }
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.mergeRoomRecoverySnapshot
 import moe.ouom.neriplayer.data.local.database.store.PlayHistoryRoomImportStatus
 import moe.ouom.neriplayer.data.local.database.store.PlayHistoryRoomStore
 import moe.ouom.neriplayer.data.local.media.LocalSongSupport
@@ -163,6 +164,7 @@ class PlayHistoryRepository private constructor(
     private val file: File by lazy { File(app.filesDir, "play_history.json") }
     @Volatile
     private var roomStorageEnabled = roomStore != null
+    private var roomRecoveryBaseline: List<PlayedEntry>? = null
     private val initialHistory = loadInitialHistory()
     private val _history = MutableStateFlow(initialHistory)
     private var persistedHistory = initialHistory
@@ -175,6 +177,10 @@ class PlayHistoryRepository private constructor(
     private var retryJob: Job? = null
     private var pendingSyncUrgency: PlayHistorySyncUrgency? = null
     private val pendingRecentPlayDeletionRemovals = mutableSetOf<SongIdentity>()
+
+    init {
+        scheduleRoomRecovery()
+    }
 
     private fun loadInitialHistory(): List<PlayedEntry> {
         if (roomStorageEnabled && roomStore != null) {
@@ -198,6 +204,7 @@ class PlayHistoryRepository private constructor(
         }
 
         val legacyEntries = loadLegacyFromDisk()
+        var needsRoomRecovery = !roomStorageEnabled && roomStore != null
         if (roomStorageEnabled && roomStore != null) {
             val activeRoomStore = roomStore
             val imported = runCatching {
@@ -206,6 +213,7 @@ class PlayHistoryRepository private constructor(
                 }
             }.onFailure { error ->
                 roomStorageEnabled = false
+                needsRoomRecovery = true
                 NPLogger.e(
                     "PlayHistoryRepo",
                     "Failed to promote legacy history to Room",
@@ -214,6 +222,7 @@ class PlayHistoryRepository private constructor(
             }.getOrNull()
             if (imported?.status == PlayHistoryRoomImportStatus.SKIPPED_NOT_EQUIVALENT) {
                 roomStorageEnabled = false
+                needsRoomRecovery = false
                 NPLogger.w(
                     "PlayHistoryRepo",
                     "Room history mapper is not equivalent; keep legacy JSON"
@@ -221,6 +230,9 @@ class PlayHistoryRepository private constructor(
             } else if (imported?.status == PlayHistoryRoomImportStatus.IMPORTED) {
                 LegacyJsonCleanupScheduler.schedule(app, "play-history-import")
             }
+        }
+        if (needsRoomRecovery) {
+            roomRecoveryBaseline = legacyEntries
         }
         return legacyEntries
     }
@@ -248,6 +260,7 @@ class PlayHistoryRepository private constructor(
                 "PlayHistoryRepo",
                 "Play history update remains in memory until Room is available."
             )
+            scheduleRoomRecovery()
             return
         }
         val roomWriteSucceeded = runCatching {
@@ -276,6 +289,89 @@ class PlayHistoryRepository private constructor(
                 persistSnapshot(_history.value)
             }
         }
+    }
+
+    private fun scheduleRoomRecovery() {
+        if (roomStorageEnabled || roomRecoveryBaseline == null || retryJob?.isActive == true) {
+            return
+        }
+        retryJob = scope.launch {
+            delay(ROOM_RETRY_DELAY_MS)
+            historyMutex.withLock {
+                retryJob = null
+                recoverRoomStorage()
+            }
+        }
+    }
+
+    private suspend fun recoverRoomStorage() {
+        val activeRoomStore = roomStore ?: return
+        val baseline = roomRecoveryBaseline ?: return
+        val recovered = runCatching<List<PlayedEntry>?> {
+            val roomSnapshot = activeRoomStore.readIfRoomPrimary()
+            if (roomSnapshot == null) {
+                val imported = activeRoomStore.importLegacyAndPromote(_history.value)
+                when (imported.status) {
+                    PlayHistoryRoomImportStatus.IMPORTED -> _history.value
+                    PlayHistoryRoomImportStatus.SKIPPED_ALREADY_PRIMARY -> {
+                        val primarySnapshot = activeRoomStore.readIfRoomPrimary()
+                            ?: return@runCatching null
+                        mergeRecoveredRoomHistory(
+                            activeRoomStore = activeRoomStore,
+                            baseline = baseline,
+                            roomSnapshot = primarySnapshot,
+                            currentSnapshot = _history.value
+                        )
+                    }
+
+                    PlayHistoryRoomImportStatus.SKIPPED_NOT_EQUIVALENT -> null
+                }
+            } else {
+                mergeRecoveredRoomHistory(
+                    activeRoomStore = activeRoomStore,
+                    baseline = baseline,
+                    roomSnapshot = roomSnapshot,
+                    currentSnapshot = _history.value
+                )
+            }
+        }.onFailure { error ->
+            NPLogger.e(
+                "PlayHistoryRepo",
+                "Failed to recover Room history without replaying legacy JSON",
+                error
+            )
+        }.getOrNull()
+        if (recovered == null) {
+            scheduleRoomRecovery()
+            return
+        }
+
+        roomStorageEnabled = true
+        roomRecoveryBaseline = null
+        persistedHistory = recovered
+        _history.value = recovered
+        LegacyJsonCleanupScheduler.schedule(app, "play-history-room-recovery")
+        flushPostPersistenceActions(recovered)
+    }
+
+    private suspend fun mergeRecoveredRoomHistory(
+        activeRoomStore: PlayHistoryRoomStore,
+        baseline: List<PlayedEntry>,
+        roomSnapshot: List<PlayedEntry>,
+        currentSnapshot: List<PlayedEntry>
+    ): List<PlayedEntry> {
+        val merged = mergeRoomRecoverySnapshot(
+            roomSnapshot = roomSnapshot,
+            recoveryBaseline = baseline,
+            currentSnapshot = currentSnapshot,
+            keyOf = { entry -> entry.identityKey() },
+            mergeLocalChange = { _, local -> local }
+        )
+            .sortedByDescending { entry -> entry.playedAt }
+            .distinctBy { entry -> entry.identityKey() }
+            .take(1000)
+        activeRoomStore.writeIncremental(roomSnapshot, merged)
+        return merged
     }
 
     private fun requestSyncAfterPersistence(urgency: PlayHistorySyncUrgency) {

--- a/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
@@ -47,6 +47,7 @@ import moe.ouom.neriplayer.data.sync.PlayHistoryUpdateMode
 import moe.ouom.neriplayer.data.sync.SyncPreferences
 import moe.ouom.neriplayer.data.sync.github.GitHubSyncWorker
 import moe.ouom.neriplayer.data.sync.github.SecureTokenStorage
+import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.util.io.writeTextAtomically
 import moe.ouom.neriplayer.data.sync.model.SyncRecentPlayDeletion
 import moe.ouom.neriplayer.data.sync.webdav.WebDavSyncWorker
@@ -187,6 +188,7 @@ class PlayHistoryRepository private constructor(
                 )
             }.getOrNull()
             if (roomEntries != null) {
+                LegacyJsonCleanupScheduler.schedule(app, "play-history-room-load")
                 return roomEntries
             }
         }
@@ -212,6 +214,8 @@ class PlayHistoryRepository private constructor(
                     "PlayHistoryRepo",
                     "Room history mapper is not equivalent; keep legacy JSON"
                 )
+            } else if (imported?.status == PlayHistoryRoomImportStatus.IMPORTED) {
+                LegacyJsonCleanupScheduler.schedule(app, "play-history-import")
             }
         }
         return legacyEntries

--- a/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/history/PlayHistoryRepository.kt
@@ -173,6 +173,8 @@ class PlayHistoryRepository private constructor(
     private val historyMutex = Mutex()
     private var pendingSettledSyncJob: Job? = null
     private var retryJob: Job? = null
+    private var pendingSyncUrgency: PlayHistorySyncUrgency? = null
+    private val pendingRecentPlayDeletionRemovals = mutableSetOf<SongIdentity>()
 
     private fun loadInitialHistory(): List<PlayedEntry> {
         if (roomStorageEnabled && roomStore != null) {
@@ -259,6 +261,7 @@ class PlayHistoryRepository private constructor(
         }.isSuccess
         if (roomWriteSucceeded) {
             persistedHistory = next
+            flushPostPersistenceActions(next)
         } else {
             schedulePersistenceRetry()
         }
@@ -272,6 +275,42 @@ class PlayHistoryRepository private constructor(
                 retryJob = null
                 persistSnapshot(_history.value)
             }
+        }
+    }
+
+    private fun requestSyncAfterPersistence(urgency: PlayHistorySyncUrgency) {
+        pendingSyncUrgency = when {
+            pendingSyncUrgency == PlayHistorySyncUrgency.IMMEDIATE ||
+                urgency == PlayHistorySyncUrgency.IMMEDIATE -> PlayHistorySyncUrgency.IMMEDIATE
+            else -> PlayHistorySyncUrgency.SETTLED
+        }
+    }
+
+    private fun requestRecentPlayDeletionRemoval(song: SongItem) {
+        if (!LocalSongSupport.isLocalSong(song.album, song.mediaUri, song.albumId, app)) {
+            pendingRecentPlayDeletionRemovals += song.identityKey()
+        }
+    }
+
+    private fun flushPostPersistenceActions(persisted: List<PlayedEntry>) {
+        val persistedKeys = persisted.mapTo(mutableSetOf()) { entry -> entry.identityKey() }
+        pendingRecentPlayDeletionRemovals
+            .filter { identityKey -> identityKey in persistedKeys }
+            .also { clearedKeys -> pendingRecentPlayDeletionRemovals.removeAll(clearedKeys) }
+            .forEach { identityKey ->
+                runCatching {
+                    storage.removeRecentPlayDeletion(identityKey)
+                }.onFailure { error ->
+                    NPLogger.e(
+                        "PlayHistoryRepo",
+                        "Failed to clear superseded recent play deletion",
+                        error
+                    )
+                }
+            }
+        pendingSyncUrgency?.let { urgency ->
+            pendingSyncUrgency = null
+            triggerSyncIfNeeded(urgency = urgency, markMutation = false)
         }
     }
 
@@ -325,6 +364,7 @@ class PlayHistoryRepository private constructor(
         try {
             if (!storage.isAutoSyncEnabled()) {
                 NPLogger.d("PlayHistoryRepo", "Auto sync is disabled, skipping sync")
+                return
             }
             GitHubSyncWorker.scheduleDelayedSync(app, triggerByUserAction = false)
             WebDavSyncWorker.scheduleDelayedSync(app, triggerByUserAction = false)
@@ -364,17 +404,11 @@ class PlayHistoryRepository private constructor(
                     .take(1000)
 
                 markSyncMutation()
+                requestSyncAfterPersistence(PlayHistorySyncUrgency.SETTLED)
+                requestRecentPlayDeletionRemoval(song)
                 NPLogger.d("PlayHistoryRepo", "Updated history size: ${updated.size}, latest: ${updated.firstOrNull()?.name}")
                 _history.value = updated
                 persistSnapshot(next = updated)
-
-                if (!LocalSongSupport.isLocalSong(song.album, song.mediaUri, song.albumId, app)) {
-                    storage.removeRecentPlayDeletion(song.identityKey())
-                }
-                triggerSyncIfNeeded(
-                    urgency = PlayHistorySyncUrgency.SETTLED,
-                    markMutation = false
-                )
             }
         }
     }
@@ -428,15 +462,10 @@ class PlayHistoryRepository private constructor(
                     .take(1000)
 
                 markSyncMutation()
+                requestSyncAfterPersistence(PlayHistorySyncUrgency.SETTLED)
+                requestRecentPlayDeletionRemoval(song)
                 _history.value = updated
                 persistSnapshot(next = updated)
-                if (!LocalSongSupport.isLocalSong(song.album, song.mediaUri, song.albumId, app)) {
-                    storage.removeRecentPlayDeletion(song.identityKey())
-                }
-                triggerSyncIfNeeded(
-                    urgency = PlayHistorySyncUrgency.SETTLED,
-                    markMutation = false
-                )
             }
         }
     }
@@ -469,11 +498,12 @@ class PlayHistoryRepository private constructor(
                     .distinctBy { it.identityKey() }
                     .take(1000)
 
+                if (triggerSync) {
+                    markSyncMutation()
+                    requestSyncAfterPersistence(PlayHistorySyncUrgency.SETTLED)
+                }
                 _history.value = updated
                 persistSnapshot(next = updated)
-                if (triggerSync) {
-                    triggerSyncIfNeeded(PlayHistorySyncUrgency.SETTLED)
-                }
             }
         }
     }
@@ -497,9 +527,9 @@ class PlayHistoryRepository private constructor(
                     markSyncMutation()
                 }
 
+                requestSyncAfterPersistence(PlayHistorySyncUrgency.IMMEDIATE)
                 _history.value = emptyList()
                 persistSnapshot(next = emptyList())
-                triggerSyncIfNeeded(markMutation = false)
             }
         }
     }
@@ -530,9 +560,9 @@ class PlayHistoryRepository private constructor(
                 }
 
                 val updated = current.filterNot { it.identityKey() in removalKeys }
+                requestSyncAfterPersistence(PlayHistorySyncUrgency.IMMEDIATE)
                 _history.value = updated
                 persistSnapshot(next = updated)
-                triggerSyncIfNeeded(markMutation = false)
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -17,6 +17,7 @@ import moe.ouom.neriplayer.data.local.database.dao.TrafficStatsDao
 import moe.ouom.neriplayer.data.local.database.dao.SyncMetadataDao
 import moe.ouom.neriplayer.data.local.database.dao.PlaybackQueueDao
 import moe.ouom.neriplayer.data.local.database.dao.BiliVideoSkipDao
+import moe.ouom.neriplayer.data.local.database.dao.DownloadRecoveryDao
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
 import moe.ouom.neriplayer.data.local.database.entity.TrafficStatsBucketEntity
@@ -42,6 +43,8 @@ import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueStateEntity
 import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipDraftEntity
 import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipIntervalEntity
 import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipRuleEntity
+import moe.ouom.neriplayer.data.local.database.entity.DownloadCancelledKeyEntity
+import moe.ouom.neriplayer.data.local.database.entity.DownloadPendingQueueEntity
 
 @Database(
     entities = [
@@ -69,9 +72,11 @@ import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipRuleEntity
         PlaybackQueueSongEntity::class,
         BiliVideoSkipRuleEntity::class,
         BiliVideoSkipIntervalEntity::class,
-        BiliVideoSkipDraftEntity::class
+        BiliVideoSkipDraftEntity::class,
+        DownloadPendingQueueEntity::class,
+        DownloadCancelledKeyEntity::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -94,6 +99,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
     abstract fun playbackQueueDao(): PlaybackQueueDao
 
     abstract fun biliVideoSkipDao(): BiliVideoSkipDao
+
+    abstract fun downloadRecoveryDao(): DownloadRecoveryDao
 
     companion object {
         const val DATABASE_NAME = "neri_user_data.db"
@@ -123,7 +130,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 MIGRATION_5_6,
                 MIGRATION_6_7,
                 MIGRATION_7_8,
-                MIGRATION_8_9
+                MIGRATION_8_9,
+                MIGRATION_9_10
             ).build()
         }
 
@@ -675,6 +683,67 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                         `end_text` TEXT NOT NULL,
                         `modified_at` INTEGER NOT NULL,
                         PRIMARY KEY(`target_key`)
+                    )
+                    """.trimIndent()
+                )
+            }
+        }
+
+        val MIGRATION_9_10: Migration = object : Migration(9, 10) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `download_pending_queue` (
+                        `stable_key` TEXT NOT NULL,
+                        `queue_order` INTEGER NOT NULL,
+                        `queued_at_ms` INTEGER NOT NULL,
+                        `id` INTEGER NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `artist` TEXT NOT NULL,
+                        `album` TEXT NOT NULL,
+                        `album_id` INTEGER NOT NULL,
+                        `duration_ms` INTEGER NOT NULL,
+                        `cover_url` TEXT,
+                        `media_uri` TEXT,
+                        `matched_lyric` TEXT,
+                        `matched_translated_lyric` TEXT,
+                        `matched_lyric_source` TEXT,
+                        `matched_song_id` TEXT,
+                        `user_lyric_offset_ms` INTEGER NOT NULL,
+                        `custom_cover_url` TEXT,
+                        `custom_name` TEXT,
+                        `custom_artist` TEXT,
+                        `original_name` TEXT,
+                        `original_artist` TEXT,
+                        `original_cover_url` TEXT,
+                        `original_lyric` TEXT,
+                        `original_translated_lyric` TEXT,
+                        `local_file_name` TEXT,
+                        `local_file_path` TEXT,
+                        `channel_id` TEXT,
+                        `audio_id` TEXT,
+                        `sub_audio_id` TEXT,
+                        `playlist_context_id` TEXT,
+                        `source_stable_key` TEXT,
+                        `stream_url` TEXT,
+                        PRIMARY KEY(`stable_key`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_download_pending_queue_order`
+                    ON `download_pending_queue`
+                    (`queue_order` ASC)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `download_cancelled_key` (
+                        `stable_key` TEXT NOT NULL,
+                        `cancelled_at_ms` INTEGER NOT NULL,
+                        PRIMARY KEY(`stable_key`)
                     )
                     """.trimIndent()
                 )

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -13,9 +13,11 @@ import moe.ouom.neriplayer.data.local.database.dao.PlaylistUsageDao
 import moe.ouom.neriplayer.data.local.database.dao.LocalPlaylistPlaybackDao
 import moe.ouom.neriplayer.data.local.database.dao.PlaybackStatsDao
 import moe.ouom.neriplayer.data.local.database.dao.FavoritePlaylistDao
+import moe.ouom.neriplayer.data.local.database.dao.TrafficStatsDao
 import moe.ouom.neriplayer.data.local.database.dao.SyncMetadataDao
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
+import moe.ouom.neriplayer.data.local.database.entity.TrafficStatsBucketEntity
 import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlayHistoryEntity
@@ -54,9 +56,10 @@ import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
         PlaybackStatCounterShardEntity::class,
         PlaybackStatDailyCounterShardEntity::class,
         FavoritePlaylistEntity::class,
-        FavoritePlaylistSongEntity::class
+        FavoritePlaylistSongEntity::class,
+        TrafficStatsBucketEntity::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -71,6 +74,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
     abstract fun playbackStatsDao(): PlaybackStatsDao
 
     abstract fun favoritePlaylistDao(): FavoritePlaylistDao
+
+    abstract fun trafficStatsDao(): TrafficStatsDao
 
     abstract fun syncMetadataDao(): SyncMetadataDao
 
@@ -99,7 +104,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 MIGRATION_2_3,
                 MIGRATION_3_4,
                 MIGRATION_4_5,
-                MIGRATION_5_6
+                MIGRATION_5_6,
+                MIGRATION_6_7
             ).build()
         }
 
@@ -515,6 +521,34 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                     `index_favorite_playlist_song_order`
                     ON `favorite_playlist_song`
                     (`playlist_id` ASC, `source` ASC, `display_position` ASC)
+                    """.trimIndent()
+                )
+            }
+        }
+
+        val MIGRATION_6_7: Migration = object : Migration(6, 7) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `traffic_stats_bucket` (
+                        `day_start_at` INTEGER NOT NULL,
+                        `wifi_bytes` INTEGER NOT NULL,
+                        `mobile_bytes` INTEGER NOT NULL,
+                        `roaming_bytes` INTEGER NOT NULL,
+                        `playback_network_bytes` INTEGER NOT NULL,
+                        `download_network_bytes` INTEGER NOT NULL,
+                        `cache_hit_bytes` INTEGER NOT NULL,
+                        `request_count` INTEGER NOT NULL,
+                        `cache_hit_count` INTEGER NOT NULL,
+                        PRIMARY KEY(`day_start_at`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_traffic_stats_bucket_day`
+                    ON `traffic_stats_bucket` (`day_start_at` DESC)
                     """.trimIndent()
                 )
             }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -24,6 +24,7 @@ import moe.ouom.neriplayer.data.local.database.dao.DownloadSnapshotDao
 import moe.ouom.neriplayer.data.local.database.dao.PlatformPlaylistCacheDao
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
+import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongNeteaseArtistEntity
 import moe.ouom.neriplayer.data.local.database.entity.TrafficStatsBucketEntity
 import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
@@ -38,6 +39,7 @@ import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatCounterShardEn
 import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatDailyCounterShardEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberNeteaseArtistEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberTokenEntity
 import moe.ouom.neriplayer.data.local.database.entity.SyncOutboxEntity
 import moe.ouom.neriplayer.data.local.database.entity.SyncReplicaCheckpointEntity
@@ -62,6 +64,7 @@ import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheTrack
         LocalPlaylistEntity::class,
         TrackEntity::class,
         PlaylistMemberEntity::class,
+        PlaylistMemberNeteaseArtistEntity::class,
         PlaylistMemberTokenEntity::class,
         SyncOutboxEntity::class,
         SyncReplicaCheckpointEntity::class,
@@ -78,6 +81,7 @@ import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheTrack
         PlaybackStatDailyCounterShardEntity::class,
         FavoritePlaylistEntity::class,
         FavoritePlaylistSongEntity::class,
+        FavoritePlaylistSongNeteaseArtistEntity::class,
         TrafficStatsBucketEntity::class,
         PlaybackQueueStateEntity::class,
         PlaybackQueueSongEntity::class,
@@ -94,7 +98,7 @@ import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheTrack
         PlatformPlaylistCacheTrackEntity::class,
         PlatformPlaylistCacheTrackArtistEntity::class
     ],
-    version = 14,
+    version = 15,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -161,7 +165,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
-                MIGRATION_13_14
+                MIGRATION_13_14,
+                MIGRATION_14_15
             ).build()
         }
 
@@ -995,6 +1000,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 createPlatformPlaylistCacheTables(db)
             }
         }
+
+        val MIGRATION_14_15: Migration = StructuredSongRoomMigration
 
         private fun createPlatformPlaylistCacheTables(db: SupportSQLiteDatabase) {
             db.execSQL(

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -15,6 +15,7 @@ import moe.ouom.neriplayer.data.local.database.dao.PlaybackStatsDao
 import moe.ouom.neriplayer.data.local.database.dao.FavoritePlaylistDao
 import moe.ouom.neriplayer.data.local.database.dao.TrafficStatsDao
 import moe.ouom.neriplayer.data.local.database.dao.SyncMetadataDao
+import moe.ouom.neriplayer.data.local.database.dao.PlaybackQueueDao
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
 import moe.ouom.neriplayer.data.local.database.entity.TrafficStatsBucketEntity
@@ -35,6 +36,8 @@ import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberTokenEntity
 import moe.ouom.neriplayer.data.local.database.entity.SyncOutboxEntity
 import moe.ouom.neriplayer.data.local.database.entity.SyncReplicaCheckpointEntity
 import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueSongEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueStateEntity
 
 @Database(
     entities = [
@@ -57,9 +60,11 @@ import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
         PlaybackStatDailyCounterShardEntity::class,
         FavoritePlaylistEntity::class,
         FavoritePlaylistSongEntity::class,
-        TrafficStatsBucketEntity::class
+        TrafficStatsBucketEntity::class,
+        PlaybackQueueStateEntity::class,
+        PlaybackQueueSongEntity::class
     ],
-    version = 7,
+    version = 8,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -78,6 +83,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
     abstract fun trafficStatsDao(): TrafficStatsDao
 
     abstract fun syncMetadataDao(): SyncMetadataDao
+
+    abstract fun playbackQueueDao(): PlaybackQueueDao
 
     companion object {
         const val DATABASE_NAME = "neri_user_data.db"
@@ -105,7 +112,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 MIGRATION_3_4,
                 MIGRATION_4_5,
                 MIGRATION_5_6,
-                MIGRATION_6_7
+                MIGRATION_6_7,
+                MIGRATION_7_8
             ).build()
         }
 
@@ -549,6 +557,64 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                     CREATE INDEX IF NOT EXISTS
                     `index_traffic_stats_bucket_day`
                     ON `traffic_stats_bucket` (`day_start_at` DESC)
+                    """.trimIndent()
+                )
+            }
+        }
+
+        val MIGRATION_7_8: Migration = object : Migration(7, 8) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `playback_queue_state` (
+                        `id` INTEGER NOT NULL,
+                        `current_index` INTEGER NOT NULL,
+                        `media_url` TEXT,
+                        `position_ms` INTEGER NOT NULL,
+                        `should_resume_playback` INTEGER NOT NULL,
+                        `repeat_mode` INTEGER,
+                        `shuffle_enabled` INTEGER,
+                        `shuffle_restore_index` INTEGER,
+                        `updated_at` INTEGER NOT NULL,
+                        PRIMARY KEY(`id`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `playback_queue_song` (
+                        `queue_id` TEXT NOT NULL,
+                        `position` INTEGER NOT NULL,
+                        `id` INTEGER NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `artist` TEXT NOT NULL,
+                        `album` TEXT NOT NULL,
+                        `album_id` INTEGER NOT NULL,
+                        `duration_ms` INTEGER NOT NULL,
+                        `cover_url` TEXT,
+                        `media_uri` TEXT,
+                        `matched_lyric` TEXT,
+                        `matched_translated_lyric` TEXT,
+                        `matched_lyric_source` TEXT,
+                        `matched_song_id` TEXT,
+                        `user_lyric_offset_ms` INTEGER NOT NULL,
+                        `custom_cover_url` TEXT,
+                        `custom_name` TEXT,
+                        `custom_artist` TEXT,
+                        `original_name` TEXT,
+                        `original_artist` TEXT,
+                        `original_cover_url` TEXT,
+                        `original_lyric` TEXT,
+                        `original_translated_lyric` TEXT,
+                        `local_file_name` TEXT,
+                        `local_file_path` TEXT,
+                        `channel_id` TEXT,
+                        `audio_id` TEXT,
+                        `sub_audio_id` TEXT,
+                        `playlist_context_id` TEXT,
+                        `stream_url` TEXT,
+                        PRIMARY KEY(`queue_id`, `position`)
+                    )
                     """.trimIndent()
                 )
             }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -21,6 +21,7 @@ import moe.ouom.neriplayer.data.local.database.dao.CoverUrlMappingDao
 import moe.ouom.neriplayer.data.local.database.dao.DownloadRecoveryDao
 import moe.ouom.neriplayer.data.local.database.dao.DownloadedSongCatalogDao
 import moe.ouom.neriplayer.data.local.database.dao.DownloadSnapshotDao
+import moe.ouom.neriplayer.data.local.database.dao.PlatformPlaylistCacheDao
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
 import moe.ouom.neriplayer.data.local.database.entity.TrafficStatsBucketEntity
@@ -52,6 +53,9 @@ import moe.ouom.neriplayer.data.local.database.entity.DownloadPendingQueueEntity
 import moe.ouom.neriplayer.data.local.database.entity.DownloadedSongCatalogEntity
 import moe.ouom.neriplayer.data.local.database.entity.DownloadSnapshotEntryEntity
 import moe.ouom.neriplayer.data.local.database.entity.DownloadSnapshotMetadataEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheTrackArtistEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheTrackEntity
 
 @Database(
     entities = [
@@ -85,9 +89,12 @@ import moe.ouom.neriplayer.data.local.database.entity.DownloadSnapshotMetadataEn
         DownloadedSongCatalogEntity::class,
         CoverUrlMappingEntity::class,
         DownloadSnapshotEntryEntity::class,
-        DownloadSnapshotMetadataEntity::class
+        DownloadSnapshotMetadataEntity::class,
+        PlatformPlaylistCacheEntity::class,
+        PlatformPlaylistCacheTrackEntity::class,
+        PlatformPlaylistCacheTrackArtistEntity::class
     ],
-    version = 13,
+    version = 14,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -118,6 +125,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
     abstract fun coverUrlMappingDao(): CoverUrlMappingDao
 
     abstract fun downloadSnapshotDao(): DownloadSnapshotDao
+
+    abstract fun platformPlaylistCacheDao(): PlatformPlaylistCacheDao
 
     companion object {
         const val DATABASE_NAME = "neri_user_data.db"
@@ -151,7 +160,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 MIGRATION_9_10,
                 MIGRATION_10_11,
                 MIGRATION_11_12,
-                MIGRATION_12_13
+                MIGRATION_12_13,
+                MIGRATION_13_14
             ).build()
         }
 
@@ -978,6 +988,125 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                     """.trimIndent()
                 )
             }
+        }
+
+        val MIGRATION_13_14: Migration = object : Migration(13, 14) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                createPlatformPlaylistCacheTables(db)
+            }
+        }
+
+        private fun createPlatformPlaylistCacheTables(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `platform_playlist_cache` (
+                    `platform` TEXT NOT NULL,
+                    `cache_key` TEXT NOT NULL,
+                    `source_id` INTEGER,
+                    `alternate_key` TEXT,
+                    `kind` TEXT,
+                    `title` TEXT,
+                    `subtitle` TEXT,
+                    `creator_name` TEXT,
+                    `cover_url` TEXT,
+                    `play_count` INTEGER,
+                    `track_count` INTEGER NOT NULL,
+                    `total_count` INTEGER NOT NULL,
+                    `signature_primary` TEXT,
+                    `signature_secondary` TEXT,
+                    `has_more` INTEGER,
+                    `saved_at_ms` INTEGER NOT NULL,
+                    PRIMARY KEY(`platform`, `cache_key`)
+                )
+                """.trimIndent()
+            )
+            db.execSQL(
+                """
+                CREATE INDEX IF NOT EXISTS
+                `index_platform_playlist_cache_source_id`
+                ON `platform_playlist_cache` (`platform`, `source_id`)
+                """.trimIndent()
+            )
+            db.execSQL(
+                """
+                CREATE INDEX IF NOT EXISTS
+                `index_platform_playlist_cache_saved_at`
+                ON `platform_playlist_cache` (`platform`, `saved_at_ms`)
+                """.trimIndent()
+            )
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `platform_playlist_cache_track` (
+                    `platform` TEXT NOT NULL,
+                    `cache_key` TEXT NOT NULL,
+                    `position` INTEGER NOT NULL,
+                    `item_id` INTEGER,
+                    `item_key` TEXT,
+                    `name` TEXT NOT NULL,
+                    `artist` TEXT NOT NULL,
+                    `album` TEXT NOT NULL,
+                    `album_id` INTEGER,
+                    `duration_ms` INTEGER NOT NULL,
+                    `cover_url` TEXT,
+                    `audio_id` TEXT,
+                    `uploader_mid` INTEGER,
+                    `added_at` INTEGER NOT NULL,
+                    PRIMARY KEY(`platform`, `cache_key`, `position`),
+                    FOREIGN KEY(`platform`, `cache_key`)
+                    REFERENCES `platform_playlist_cache`(`platform`, `cache_key`)
+                    ON UPDATE NO ACTION ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+            db.execSQL(
+                """
+                CREATE INDEX IF NOT EXISTS
+                `index_platform_playlist_cache_track_item_id`
+                ON `platform_playlist_cache_track`
+                (`platform`, `cache_key`, `item_id`)
+                """.trimIndent()
+            )
+            db.execSQL(
+                """
+                CREATE INDEX IF NOT EXISTS
+                `index_platform_playlist_cache_track_item_key`
+                ON `platform_playlist_cache_track`
+                (`platform`, `cache_key`, `item_key`)
+                """.trimIndent()
+            )
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `platform_playlist_cache_track_artist` (
+                    `platform` TEXT NOT NULL,
+                    `cache_key` TEXT NOT NULL,
+                    `track_position` INTEGER NOT NULL,
+                    `artist_position` INTEGER NOT NULL,
+                    `artist_id` INTEGER NOT NULL,
+                    `name` TEXT NOT NULL,
+                    PRIMARY KEY(
+                        `platform`,
+                        `cache_key`,
+                        `track_position`,
+                        `artist_position`
+                    ),
+                    FOREIGN KEY(`platform`, `cache_key`, `track_position`)
+                    REFERENCES `platform_playlist_cache_track`(
+                        `platform`,
+                        `cache_key`,
+                        `position`
+                    )
+                    ON UPDATE NO ACTION ON DELETE CASCADE
+                )
+                """.trimIndent()
+            )
+            db.execSQL(
+                """
+                CREATE INDEX IF NOT EXISTS
+                `index_platform_playlist_cache_artist_track`
+                ON `platform_playlist_cache_track_artist`
+                (`platform`, `cache_key`, `track_position`)
+                """.trimIndent()
+            )
         }
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -5,10 +5,17 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import moe.ouom.neriplayer.data.local.database.dao.LocalPlaylistDao
+import moe.ouom.neriplayer.data.local.database.dao.PlayHistoryDao
+import moe.ouom.neriplayer.data.local.database.dao.PlaylistUsageDao
 import moe.ouom.neriplayer.data.local.database.dao.SyncMetadataDao
 import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlayHistoryEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistUsageCounterShardEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistUsageEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberTokenEntity
 import moe.ouom.neriplayer.data.local.database.entity.SyncOutboxEntity
@@ -23,13 +30,20 @@ import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
         PlaylistMemberTokenEntity::class,
         SyncOutboxEntity::class,
         SyncReplicaCheckpointEntity::class,
-        MigrationMetadataEntity::class
+        MigrationMetadataEntity::class,
+        PlayHistoryEntity::class,
+        PlaylistUsageEntity::class,
+        PlaylistUsageCounterShardEntity::class
     ],
-    version = 1,
+    version = 3,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
     abstract fun localPlaylistDao(): LocalPlaylistDao
+
+    abstract fun playHistoryDao(): PlayHistoryDao
+
+    abstract fun playlistUsageDao(): PlaylistUsageDao
 
     abstract fun syncMetadataDao(): SyncMetadataDao
 
@@ -53,7 +67,7 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 context.applicationContext,
                 NeriUserDataDatabase::class.java,
                 DATABASE_NAME
-            ).build()
+            ).addMigrations(MIGRATION_1_2, MIGRATION_2_3).build()
         }
 
         private fun checkMainProcess(context: Context) {
@@ -62,6 +76,127 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
             check(currentProcess == expectedProcess) {
                 "Neri user database may only be opened in the main process: " +
                     "current=$currentProcess expected=$expectedProcess"
+            }
+        }
+
+        val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `play_history` (
+                        `identity_key` TEXT NOT NULL,
+                        `identity_id` INTEGER NOT NULL,
+                        `identity_album` TEXT NOT NULL,
+                        `identity_media_uri` TEXT,
+                        `id` INTEGER NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `artist` TEXT NOT NULL,
+                        `album` TEXT NOT NULL,
+                        `album_id` INTEGER NOT NULL,
+                        `duration_ms` INTEGER NOT NULL,
+                        `resume_position_ms` INTEGER NOT NULL,
+                        `cover_url` TEXT,
+                        `media_uri` TEXT,
+                        `matched_lyric` TEXT,
+                        `matched_translated_lyric` TEXT,
+                        `custom_cover_url` TEXT,
+                        `custom_name` TEXT,
+                        `custom_artist` TEXT,
+                        `original_name` TEXT,
+                        `original_artist` TEXT,
+                        `original_cover_url` TEXT,
+                        `original_lyric` TEXT,
+                        `original_translated_lyric` TEXT,
+                        `local_file_name` TEXT,
+                        `local_file_path` TEXT,
+                        `channel_id` TEXT,
+                        `audio_id` TEXT,
+                        `sub_audio_id` TEXT,
+                        `source_stable_key` TEXT,
+                        `played_at` INTEGER NOT NULL,
+                        PRIMARY KEY(`identity_key`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_play_history_played_at`
+                    ON `play_history` (`played_at` DESC)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_play_history_identity_parts`
+                    ON `play_history`
+                    (`identity_id`, `identity_album`, `identity_media_uri`)
+                    """.trimIndent()
+                )
+            }
+        }
+
+        val MIGRATION_2_3: Migration = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `playlist_usage` (
+                        `usage_key` TEXT NOT NULL,
+                        `id` INTEGER NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `pic_url` TEXT,
+                        `track_count` INTEGER NOT NULL,
+                        `source` TEXT NOT NULL,
+                        `last_opened` INTEGER NOT NULL,
+                        `open_count` INTEGER NOT NULL,
+                        `first_opened` INTEGER NOT NULL,
+                        `counter_base_open_count` INTEGER NOT NULL,
+                        `fid` INTEGER,
+                        `mid` INTEGER,
+                        `browse_id` TEXT,
+                        `playlist_id` TEXT,
+                        `subtype` TEXT,
+                        `subtitle` TEXT,
+                        PRIMARY KEY(`usage_key`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_playlist_usage_last_opened`
+                    ON `playlist_usage` (`last_opened` DESC)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_playlist_usage_source_id`
+                    ON `playlist_usage` (`source`, `playlist_id`)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `playlist_usage_counter_shard` (
+                        `usage_key` TEXT NOT NULL,
+                        `device_id` TEXT NOT NULL,
+                        `epoch_started_at` INTEGER NOT NULL,
+                        `play_count` INTEGER NOT NULL,
+                        `first_played_at` INTEGER NOT NULL,
+                        `last_played_at` INTEGER NOT NULL,
+                        PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`),
+                        FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`)
+                            ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_playlist_usage_counter_usage_key`
+                    ON `playlist_usage_counter_shard` (`usage_key`)
+                    """.trimIndent()
+                )
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -20,6 +20,7 @@ import moe.ouom.neriplayer.data.local.database.dao.BiliVideoSkipDao
 import moe.ouom.neriplayer.data.local.database.dao.CoverUrlMappingDao
 import moe.ouom.neriplayer.data.local.database.dao.DownloadRecoveryDao
 import moe.ouom.neriplayer.data.local.database.dao.DownloadedSongCatalogDao
+import moe.ouom.neriplayer.data.local.database.dao.DownloadSnapshotDao
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
 import moe.ouom.neriplayer.data.local.database.entity.TrafficStatsBucketEntity
@@ -49,6 +50,8 @@ import moe.ouom.neriplayer.data.local.database.entity.CoverUrlMappingEntity
 import moe.ouom.neriplayer.data.local.database.entity.DownloadCancelledKeyEntity
 import moe.ouom.neriplayer.data.local.database.entity.DownloadPendingQueueEntity
 import moe.ouom.neriplayer.data.local.database.entity.DownloadedSongCatalogEntity
+import moe.ouom.neriplayer.data.local.database.entity.DownloadSnapshotEntryEntity
+import moe.ouom.neriplayer.data.local.database.entity.DownloadSnapshotMetadataEntity
 
 @Database(
     entities = [
@@ -80,9 +83,11 @@ import moe.ouom.neriplayer.data.local.database.entity.DownloadedSongCatalogEntit
         DownloadPendingQueueEntity::class,
         DownloadCancelledKeyEntity::class,
         DownloadedSongCatalogEntity::class,
-        CoverUrlMappingEntity::class
+        CoverUrlMappingEntity::class,
+        DownloadSnapshotEntryEntity::class,
+        DownloadSnapshotMetadataEntity::class
     ],
-    version = 12,
+    version = 13,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -111,6 +116,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
     abstract fun downloadedSongCatalogDao(): DownloadedSongCatalogDao
 
     abstract fun coverUrlMappingDao(): CoverUrlMappingDao
+
+    abstract fun downloadSnapshotDao(): DownloadSnapshotDao
 
     companion object {
         const val DATABASE_NAME = "neri_user_data.db"
@@ -143,7 +150,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 MIGRATION_8_9,
                 MIGRATION_9_10,
                 MIGRATION_10_11,
-                MIGRATION_11_12
+                MIGRATION_11_12,
+                MIGRATION_12_13
             ).build()
         }
 
@@ -854,6 +862,119 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                     CREATE INDEX IF NOT EXISTS
                     `index_cover_url_mapping_updated_at`
                     ON `cover_url_mapping` (`updated_at` DESC)
+                    """.trimIndent()
+                )
+            }
+        }
+
+        val MIGRATION_12_13: Migration = object : Migration(12, 13) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `download_snapshot_entry` (
+                        `root_key` TEXT NOT NULL,
+                        `bucket` TEXT NOT NULL,
+                        `entry_key` TEXT NOT NULL,
+                        `display_position` INTEGER NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `reference` TEXT NOT NULL,
+                        `media_uri` TEXT NOT NULL,
+                        `local_file_path` TEXT,
+                        `size_bytes` INTEGER NOT NULL,
+                        `last_modified_ms` INTEGER NOT NULL,
+                        `is_directory` INTEGER NOT NULL,
+                        PRIMARY KEY(`root_key`, `bucket`, `entry_key`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_download_snapshot_entry_root_bucket_position`
+                    ON `download_snapshot_entry`
+                    (`root_key` ASC, `bucket` ASC, `display_position` ASC)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_download_snapshot_entry_root_bucket_name`
+                    ON `download_snapshot_entry`
+                    (`root_key`, `bucket`, `name`)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_download_snapshot_entry_root_reference`
+                    ON `download_snapshot_entry` (`root_key`, `reference`)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `download_snapshot_metadata` (
+                        `root_key` TEXT NOT NULL,
+                        `audio_name` TEXT NOT NULL,
+                        `stable_key` TEXT,
+                        `song_id` INTEGER,
+                        `identity_album` TEXT,
+                        `name` TEXT,
+                        `artist` TEXT,
+                        `cover_url` TEXT,
+                        `matched_lyric` TEXT,
+                        `matched_translated_lyric` TEXT,
+                        `matched_lyric_source` TEXT,
+                        `matched_song_id` TEXT,
+                        `user_lyric_offset_ms` INTEGER NOT NULL,
+                        `custom_cover_url` TEXT,
+                        `custom_name` TEXT,
+                        `custom_artist` TEXT,
+                        `original_name` TEXT,
+                        `original_artist` TEXT,
+                        `original_cover_url` TEXT,
+                        `original_lyric` TEXT,
+                        `original_translated_lyric` TEXT,
+                        `media_uri` TEXT,
+                        `channel_id` TEXT,
+                        `audio_id` TEXT,
+                        `sub_audio_id` TEXT,
+                        `playlist_context_id` TEXT,
+                        `cover_path` TEXT,
+                        `lyric_path` TEXT,
+                        `translated_lyric_path` TEXT,
+                        `duration_ms` INTEGER NOT NULL,
+                        `download_finalized` INTEGER,
+                        PRIMARY KEY(`root_key`, `audio_name`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_download_snapshot_metadata_root_stable_key`
+                    ON `download_snapshot_metadata` (`root_key`, `stable_key`)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_download_snapshot_metadata_root_song_id`
+                    ON `download_snapshot_metadata` (`root_key`, `song_id`)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_download_snapshot_metadata_root_media_uri`
+                    ON `download_snapshot_metadata` (`root_key`, `media_uri`)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_download_snapshot_metadata_root_remote_track`
+                    ON `download_snapshot_metadata`
+                    (`root_key`, `channel_id`, `audio_id`, `sub_audio_id`)
                     """.trimIndent()
                 )
             }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -12,7 +12,10 @@ import moe.ouom.neriplayer.data.local.database.dao.PlayHistoryDao
 import moe.ouom.neriplayer.data.local.database.dao.PlaylistUsageDao
 import moe.ouom.neriplayer.data.local.database.dao.LocalPlaylistPlaybackDao
 import moe.ouom.neriplayer.data.local.database.dao.PlaybackStatsDao
+import moe.ouom.neriplayer.data.local.database.dao.FavoritePlaylistDao
 import moe.ouom.neriplayer.data.local.database.dao.SyncMetadataDao
+import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
+import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
 import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlayHistoryEntity
@@ -49,9 +52,11 @@ import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
         PlaybackStatEntity::class,
         PlaybackStatBucketEntity::class,
         PlaybackStatCounterShardEntity::class,
-        PlaybackStatDailyCounterShardEntity::class
+        PlaybackStatDailyCounterShardEntity::class,
+        FavoritePlaylistEntity::class,
+        FavoritePlaylistSongEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -64,6 +69,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
     abstract fun localPlaylistPlaybackDao(): LocalPlaylistPlaybackDao
 
     abstract fun playbackStatsDao(): PlaybackStatsDao
+
+    abstract fun favoritePlaylistDao(): FavoritePlaylistDao
 
     abstract fun syncMetadataDao(): SyncMetadataDao
 
@@ -91,7 +98,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 MIGRATION_1_2,
                 MIGRATION_2_3,
                 MIGRATION_3_4,
-                MIGRATION_4_5
+                MIGRATION_4_5,
+                MIGRATION_5_6
             ).build()
         }
 
@@ -447,6 +455,66 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                     `index_playback_stat_daily_counter_scope`
                     ON `playback_stat_daily_counter_shard`
                     (`day_start_at`, `identity_key`)
+                    """.trimIndent()
+                )
+            }
+        }
+
+        val MIGRATION_5_6: Migration = object : Migration(5, 6) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `favorite_playlist` (
+                        `playlist_id` INTEGER NOT NULL,
+                        `source` TEXT NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `cover_url` TEXT,
+                        `track_count` INTEGER NOT NULL,
+                        `browse_id` TEXT,
+                        `remote_playlist_id` TEXT,
+                        `subtitle` TEXT,
+                        `added_time` INTEGER NOT NULL,
+                        `sort_order` INTEGER NOT NULL,
+                        `modified_at` INTEGER NOT NULL,
+                        `is_deleted` INTEGER NOT NULL,
+                        PRIMARY KEY(`playlist_id`, `source`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_favorite_playlist_sort`
+                    ON `favorite_playlist` (`sort_order` DESC, `modified_at` DESC)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_favorite_playlist_visibility`
+                    ON `favorite_playlist` (`is_deleted` ASC, `sort_order` DESC)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `favorite_playlist_song` (
+                        `playlist_id` INTEGER NOT NULL,
+                        `source` TEXT NOT NULL,
+                        `display_position` INTEGER NOT NULL,
+                        `song_payload_json` TEXT NOT NULL,
+                        PRIMARY KEY(`playlist_id`, `source`, `display_position`),
+                        FOREIGN KEY(`playlist_id`, `source`)
+                            REFERENCES `favorite_playlist`(`playlist_id`, `source`)
+                            ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_favorite_playlist_song_order`
+                    ON `favorite_playlist_song`
+                    (`playlist_id` ASC, `source` ASC, `display_position` ASC)
                     """.trimIndent()
                 )
             }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -10,12 +10,16 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import moe.ouom.neriplayer.data.local.database.dao.LocalPlaylistDao
 import moe.ouom.neriplayer.data.local.database.dao.PlayHistoryDao
 import moe.ouom.neriplayer.data.local.database.dao.PlaylistUsageDao
+import moe.ouom.neriplayer.data.local.database.dao.LocalPlaylistPlaybackDao
 import moe.ouom.neriplayer.data.local.database.dao.SyncMetadataDao
 import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlayHistoryEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistUsageCounterShardEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistUsageEntity
+import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistPlaybackBucketEntity
+import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistPlaybackCounterShardEntity
+import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistPlaybackStatEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberTokenEntity
 import moe.ouom.neriplayer.data.local.database.entity.SyncOutboxEntity
@@ -33,9 +37,12 @@ import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
         MigrationMetadataEntity::class,
         PlayHistoryEntity::class,
         PlaylistUsageEntity::class,
-        PlaylistUsageCounterShardEntity::class
+        PlaylistUsageCounterShardEntity::class,
+        LocalPlaylistPlaybackStatEntity::class,
+        LocalPlaylistPlaybackBucketEntity::class,
+        LocalPlaylistPlaybackCounterShardEntity::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -44,6 +51,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
     abstract fun playHistoryDao(): PlayHistoryDao
 
     abstract fun playlistUsageDao(): PlaylistUsageDao
+
+    abstract fun localPlaylistPlaybackDao(): LocalPlaylistPlaybackDao
 
     abstract fun syncMetadataDao(): SyncMetadataDao
 
@@ -67,7 +76,7 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 context.applicationContext,
                 NeriUserDataDatabase::class.java,
                 DATABASE_NAME
-            ).addMigrations(MIGRATION_1_2, MIGRATION_2_3).build()
+            ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4).build()
         }
 
         private fun checkMainProcess(context: Context) {
@@ -195,6 +204,84 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                     CREATE INDEX IF NOT EXISTS
                     `index_playlist_usage_counter_usage_key`
                     ON `playlist_usage_counter_shard` (`usage_key`)
+                    """.trimIndent()
+                )
+            }
+        }
+
+        val MIGRATION_3_4: Migration = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `local_playlist_playback_stat` (
+                        `playlist_id` INTEGER NOT NULL,
+                        `total_play_count` INTEGER NOT NULL,
+                        `first_played_at` INTEGER NOT NULL,
+                        `last_played_at` INTEGER NOT NULL,
+                        `counter_base_play_count` INTEGER NOT NULL,
+                        PRIMARY KEY(`playlist_id`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_local_playlist_playback_stat_last_played`
+                    ON `local_playlist_playback_stat` (`last_played_at` DESC)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `local_playlist_playback_bucket` (
+                        `playlist_id` INTEGER NOT NULL,
+                        `day_start_at` INTEGER NOT NULL,
+                        `play_count` INTEGER NOT NULL,
+                        `first_played_at` INTEGER NOT NULL,
+                        `last_played_at` INTEGER NOT NULL,
+                        `counter_base_play_count` INTEGER NOT NULL,
+                        PRIMARY KEY(`playlist_id`, `day_start_at`),
+                        FOREIGN KEY(`playlist_id`) REFERENCES
+                            `local_playlist_playback_stat`(`playlist_id`)
+                            ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_local_playlist_playback_bucket_day`
+                    ON `local_playlist_playback_bucket`
+                    (`playlist_id` ASC, `day_start_at` ASC)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `local_playlist_playback_counter_shard` (
+                        `playlist_id` INTEGER NOT NULL,
+                        `day_start_at` INTEGER NOT NULL,
+                        `device_id` TEXT NOT NULL,
+                        `epoch_started_at` INTEGER NOT NULL,
+                        `play_count` INTEGER NOT NULL,
+                        `first_played_at` INTEGER NOT NULL,
+                        `last_played_at` INTEGER NOT NULL,
+                        PRIMARY KEY(
+                            `playlist_id`,
+                            `day_start_at`,
+                            `device_id`,
+                            `epoch_started_at`
+                        ),
+                        FOREIGN KEY(`playlist_id`) REFERENCES
+                            `local_playlist_playback_stat`(`playlist_id`)
+                            ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_local_playlist_playback_counter_scope`
+                    ON `local_playlist_playback_counter_shard`
+                    (`playlist_id`, `day_start_at`)
                     """.trimIndent()
                 )
             }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -11,6 +11,7 @@ import moe.ouom.neriplayer.data.local.database.dao.LocalPlaylistDao
 import moe.ouom.neriplayer.data.local.database.dao.PlayHistoryDao
 import moe.ouom.neriplayer.data.local.database.dao.PlaylistUsageDao
 import moe.ouom.neriplayer.data.local.database.dao.LocalPlaylistPlaybackDao
+import moe.ouom.neriplayer.data.local.database.dao.PlaybackStatsDao
 import moe.ouom.neriplayer.data.local.database.dao.SyncMetadataDao
 import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
@@ -20,6 +21,10 @@ import moe.ouom.neriplayer.data.local.database.entity.PlaylistUsageEntity
 import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistPlaybackBucketEntity
 import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistPlaybackCounterShardEntity
 import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistPlaybackStatEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatBucketEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatCounterShardEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatDailyCounterShardEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberTokenEntity
 import moe.ouom.neriplayer.data.local.database.entity.SyncOutboxEntity
@@ -40,9 +45,13 @@ import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
         PlaylistUsageCounterShardEntity::class,
         LocalPlaylistPlaybackStatEntity::class,
         LocalPlaylistPlaybackBucketEntity::class,
-        LocalPlaylistPlaybackCounterShardEntity::class
+        LocalPlaylistPlaybackCounterShardEntity::class,
+        PlaybackStatEntity::class,
+        PlaybackStatBucketEntity::class,
+        PlaybackStatCounterShardEntity::class,
+        PlaybackStatDailyCounterShardEntity::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -53,6 +62,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
     abstract fun playlistUsageDao(): PlaylistUsageDao
 
     abstract fun localPlaylistPlaybackDao(): LocalPlaylistPlaybackDao
+
+    abstract fun playbackStatsDao(): PlaybackStatsDao
 
     abstract fun syncMetadataDao(): SyncMetadataDao
 
@@ -76,7 +87,12 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 context.applicationContext,
                 NeriUserDataDatabase::class.java,
                 DATABASE_NAME
-            ).addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4).build()
+            ).addMigrations(
+                MIGRATION_1_2,
+                MIGRATION_2_3,
+                MIGRATION_3_4,
+                MIGRATION_4_5
+            ).build()
         }
 
         private fun checkMainProcess(context: Context) {
@@ -282,6 +298,155 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                     `index_local_playlist_playback_counter_scope`
                     ON `local_playlist_playback_counter_shard`
                     (`playlist_id`, `day_start_at`)
+                    """.trimIndent()
+                )
+            }
+        }
+
+        val MIGRATION_4_5: Migration = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `playback_stat` (
+                        `identity_key` TEXT NOT NULL,
+                        `id` INTEGER NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `artist` TEXT NOT NULL,
+                        `album` TEXT NOT NULL,
+                        `album_id` INTEGER NOT NULL,
+                        `cover_url` TEXT,
+                        `duration_ms` INTEGER NOT NULL,
+                        `total_listen_ms` INTEGER NOT NULL,
+                        `play_count` INTEGER NOT NULL,
+                        `last_played_at` INTEGER NOT NULL,
+                        `first_played_at` INTEGER NOT NULL,
+                        `media_uri` TEXT,
+                        `local_file_path` TEXT,
+                        `local_file_name` TEXT,
+                        `custom_name` TEXT,
+                        `custom_artist` TEXT,
+                        `custom_cover_url` TEXT,
+                        PRIMARY KEY(`identity_key`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_playback_stat_last_played`
+                    ON `playback_stat` (`last_played_at` DESC)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_playback_stat_media_uri`
+                    ON `playback_stat` (`media_uri`)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `playback_stat_bucket` (
+                        `day_start_at` INTEGER NOT NULL,
+                        `identity_key` TEXT NOT NULL,
+                        `id` INTEGER NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `artist` TEXT NOT NULL,
+                        `album` TEXT NOT NULL,
+                        `album_id` INTEGER NOT NULL,
+                        `cover_url` TEXT,
+                        `duration_ms` INTEGER NOT NULL,
+                        `total_listen_ms` INTEGER NOT NULL,
+                        `play_count` INTEGER NOT NULL,
+                        `last_played_at` INTEGER NOT NULL,
+                        `first_played_at` INTEGER NOT NULL,
+                        `media_uri` TEXT,
+                        `local_file_path` TEXT,
+                        `local_file_name` TEXT,
+                        `custom_name` TEXT,
+                        `custom_artist` TEXT,
+                        `custom_cover_url` TEXT,
+                        PRIMARY KEY(`day_start_at`, `identity_key`),
+                        FOREIGN KEY(`identity_key`) REFERENCES
+                            `playback_stat`(`identity_key`)
+                            ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_playback_stat_bucket_day`
+                    ON `playback_stat_bucket`
+                    (`day_start_at` DESC, `identity_key` ASC)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_playback_stat_bucket_identity`
+                    ON `playback_stat_bucket` (`identity_key`)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `playback_stat_counter_shard` (
+                        `identity_key` TEXT NOT NULL,
+                        `device_id` TEXT NOT NULL,
+                        `epoch_started_at` INTEGER NOT NULL,
+                        `total_listen_ms` INTEGER NOT NULL,
+                        `play_count` INTEGER NOT NULL,
+                        `first_played_at` INTEGER NOT NULL,
+                        `last_played_at` INTEGER NOT NULL,
+                        PRIMARY KEY(
+                            `identity_key`,
+                            `device_id`,
+                            `epoch_started_at`
+                        ),
+                        FOREIGN KEY(`identity_key`) REFERENCES
+                            `playback_stat`(`identity_key`)
+                            ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_playback_stat_counter_identity`
+                    ON `playback_stat_counter_shard` (`identity_key`)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS
+                    `playback_stat_daily_counter_shard` (
+                        `day_start_at` INTEGER NOT NULL,
+                        `identity_key` TEXT NOT NULL,
+                        `device_id` TEXT NOT NULL,
+                        `epoch_started_at` INTEGER NOT NULL,
+                        `total_listen_ms` INTEGER NOT NULL,
+                        `play_count` INTEGER NOT NULL,
+                        `first_played_at` INTEGER NOT NULL,
+                        `last_played_at` INTEGER NOT NULL,
+                        PRIMARY KEY(
+                            `day_start_at`,
+                            `identity_key`,
+                            `device_id`,
+                            `epoch_started_at`
+                        ),
+                        FOREIGN KEY(`day_start_at`, `identity_key`)
+                            REFERENCES `playback_stat_bucket`
+                            (`day_start_at`, `identity_key`)
+                            ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_playback_stat_daily_counter_scope`
+                    ON `playback_stat_daily_counter_shard`
+                    (`day_start_at`, `identity_key`)
                     """.trimIndent()
                 )
             }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -18,6 +18,7 @@ import moe.ouom.neriplayer.data.local.database.dao.SyncMetadataDao
 import moe.ouom.neriplayer.data.local.database.dao.PlaybackQueueDao
 import moe.ouom.neriplayer.data.local.database.dao.BiliVideoSkipDao
 import moe.ouom.neriplayer.data.local.database.dao.DownloadRecoveryDao
+import moe.ouom.neriplayer.data.local.database.dao.DownloadedSongCatalogDao
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
 import moe.ouom.neriplayer.data.local.database.entity.TrafficStatsBucketEntity
@@ -45,6 +46,7 @@ import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipIntervalEntit
 import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipRuleEntity
 import moe.ouom.neriplayer.data.local.database.entity.DownloadCancelledKeyEntity
 import moe.ouom.neriplayer.data.local.database.entity.DownloadPendingQueueEntity
+import moe.ouom.neriplayer.data.local.database.entity.DownloadedSongCatalogEntity
 
 @Database(
     entities = [
@@ -74,9 +76,10 @@ import moe.ouom.neriplayer.data.local.database.entity.DownloadPendingQueueEntity
         BiliVideoSkipIntervalEntity::class,
         BiliVideoSkipDraftEntity::class,
         DownloadPendingQueueEntity::class,
-        DownloadCancelledKeyEntity::class
+        DownloadCancelledKeyEntity::class,
+        DownloadedSongCatalogEntity::class
     ],
-    version = 10,
+    version = 11,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -101,6 +104,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
     abstract fun biliVideoSkipDao(): BiliVideoSkipDao
 
     abstract fun downloadRecoveryDao(): DownloadRecoveryDao
+
+    abstract fun downloadedSongCatalogDao(): DownloadedSongCatalogDao
 
     companion object {
         const val DATABASE_NAME = "neri_user_data.db"
@@ -131,7 +136,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 MIGRATION_6_7,
                 MIGRATION_7_8,
                 MIGRATION_8_9,
-                MIGRATION_9_10
+                MIGRATION_9_10,
+                MIGRATION_10_11
             ).build()
         }
 
@@ -745,6 +751,81 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                         `cancelled_at_ms` INTEGER NOT NULL,
                         PRIMARY KEY(`stable_key`)
                     )
+                    """.trimIndent()
+                )
+            }
+        }
+
+        val MIGRATION_10_11: Migration = object : Migration(10, 11) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `downloaded_song_catalog` (
+                        `catalog_key` TEXT NOT NULL,
+                        `root_key` TEXT NOT NULL,
+                        `display_position` INTEGER NOT NULL,
+                        `id` INTEGER NOT NULL,
+                        `name` TEXT NOT NULL,
+                        `artist` TEXT NOT NULL,
+                        `album` TEXT NOT NULL,
+                        `file_path` TEXT NOT NULL,
+                        `file_size` INTEGER NOT NULL,
+                        `download_time` INTEGER NOT NULL,
+                        `cover_path` TEXT,
+                        `cover_url` TEXT,
+                        `matched_lyric` TEXT,
+                        `matched_translated_lyric` TEXT,
+                        `matched_lyric_source` TEXT,
+                        `matched_song_id` TEXT,
+                        `user_lyric_offset_ms` INTEGER NOT NULL,
+                        `custom_cover_url` TEXT,
+                        `custom_name` TEXT,
+                        `custom_artist` TEXT,
+                        `original_name` TEXT,
+                        `original_artist` TEXT,
+                        `original_cover_url` TEXT,
+                        `original_lyric` TEXT,
+                        `original_translated_lyric` TEXT,
+                        `media_uri` TEXT,
+                        `duration_ms` INTEGER NOT NULL,
+                        `stable_key` TEXT,
+                        `source_identity_album` TEXT,
+                        `source_media_uri` TEXT,
+                        `source_channel_id` TEXT,
+                        `source_audio_id` TEXT,
+                        `source_sub_audio_id` TEXT,
+                        `source_playlist_context_id` TEXT,
+                        PRIMARY KEY(`catalog_key`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_downloaded_song_catalog_root_position`
+                    ON `downloaded_song_catalog`
+                    (`root_key` ASC, `display_position` ASC)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_downloaded_song_catalog_file_path`
+                    ON `downloaded_song_catalog` (`file_path`)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_downloaded_song_catalog_media_uri`
+                    ON `downloaded_song_catalog` (`media_uri`)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_downloaded_song_catalog_stable_key`
+                    ON `downloaded_song_catalog` (`stable_key`)
                     """.trimIndent()
                 )
             }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -1,0 +1,68 @@
+package moe.ouom.neriplayer.data.local.database
+
+import android.app.Application
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import moe.ouom.neriplayer.data.local.database.dao.LocalPlaylistDao
+import moe.ouom.neriplayer.data.local.database.dao.SyncMetadataDao
+import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistEntity
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberTokenEntity
+import moe.ouom.neriplayer.data.local.database.entity.SyncOutboxEntity
+import moe.ouom.neriplayer.data.local.database.entity.SyncReplicaCheckpointEntity
+import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
+
+@Database(
+    entities = [
+        LocalPlaylistEntity::class,
+        TrackEntity::class,
+        PlaylistMemberEntity::class,
+        PlaylistMemberTokenEntity::class,
+        SyncOutboxEntity::class,
+        SyncReplicaCheckpointEntity::class,
+        MigrationMetadataEntity::class
+    ],
+    version = 1,
+    exportSchema = true
+)
+internal abstract class NeriUserDataDatabase : RoomDatabase() {
+    abstract fun localPlaylistDao(): LocalPlaylistDao
+
+    abstract fun syncMetadataDao(): SyncMetadataDao
+
+    companion object {
+        const val DATABASE_NAME = "neri_user_data.db"
+
+        @Volatile
+        private var instance: NeriUserDataDatabase? = null
+
+        fun getInstance(context: Context): NeriUserDataDatabase {
+            return instance ?: synchronized(this) {
+                instance ?: create(context.applicationContext).also { database ->
+                    instance = database
+                }
+            }
+        }
+
+        internal fun create(context: Context): NeriUserDataDatabase {
+            checkMainProcess(context)
+            return Room.databaseBuilder(
+                context.applicationContext,
+                NeriUserDataDatabase::class.java,
+                DATABASE_NAME
+            ).build()
+        }
+
+        private fun checkMainProcess(context: Context) {
+            val expectedProcess = context.applicationInfo.processName
+            val currentProcess = Application.getProcessName()
+            check(currentProcess == expectedProcess) {
+                "Neri user database may only be opened in the main process: " +
+                    "current=$currentProcess expected=$expectedProcess"
+            }
+        }
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -17,6 +17,7 @@ import moe.ouom.neriplayer.data.local.database.dao.TrafficStatsDao
 import moe.ouom.neriplayer.data.local.database.dao.SyncMetadataDao
 import moe.ouom.neriplayer.data.local.database.dao.PlaybackQueueDao
 import moe.ouom.neriplayer.data.local.database.dao.BiliVideoSkipDao
+import moe.ouom.neriplayer.data.local.database.dao.CoverUrlMappingDao
 import moe.ouom.neriplayer.data.local.database.dao.DownloadRecoveryDao
 import moe.ouom.neriplayer.data.local.database.dao.DownloadedSongCatalogDao
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
@@ -44,6 +45,7 @@ import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueStateEntity
 import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipDraftEntity
 import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipIntervalEntity
 import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipRuleEntity
+import moe.ouom.neriplayer.data.local.database.entity.CoverUrlMappingEntity
 import moe.ouom.neriplayer.data.local.database.entity.DownloadCancelledKeyEntity
 import moe.ouom.neriplayer.data.local.database.entity.DownloadPendingQueueEntity
 import moe.ouom.neriplayer.data.local.database.entity.DownloadedSongCatalogEntity
@@ -77,9 +79,10 @@ import moe.ouom.neriplayer.data.local.database.entity.DownloadedSongCatalogEntit
         BiliVideoSkipDraftEntity::class,
         DownloadPendingQueueEntity::class,
         DownloadCancelledKeyEntity::class,
-        DownloadedSongCatalogEntity::class
+        DownloadedSongCatalogEntity::class,
+        CoverUrlMappingEntity::class
     ],
-    version = 11,
+    version = 12,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -106,6 +109,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
     abstract fun downloadRecoveryDao(): DownloadRecoveryDao
 
     abstract fun downloadedSongCatalogDao(): DownloadedSongCatalogDao
+
+    abstract fun coverUrlMappingDao(): CoverUrlMappingDao
 
     companion object {
         const val DATABASE_NAME = "neri_user_data.db"
@@ -137,7 +142,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 MIGRATION_7_8,
                 MIGRATION_8_9,
                 MIGRATION_9_10,
-                MIGRATION_10_11
+                MIGRATION_10_11,
+                MIGRATION_11_12
             ).build()
         }
 
@@ -826,6 +832,28 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                     CREATE INDEX IF NOT EXISTS
                     `index_downloaded_song_catalog_stable_key`
                     ON `downloaded_song_catalog` (`stable_key`)
+                    """.trimIndent()
+                )
+            }
+        }
+
+        val MIGRATION_11_12: Migration = object : Migration(11, 12) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `cover_url_mapping` (
+                        `local_url` TEXT NOT NULL,
+                        `network_url` TEXT NOT NULL,
+                        `updated_at` INTEGER NOT NULL,
+                        PRIMARY KEY(`local_url`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_cover_url_mapping_updated_at`
+                    ON `cover_url_mapping` (`updated_at` DESC)
                     """.trimIndent()
                 )
             }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -16,6 +16,7 @@ import moe.ouom.neriplayer.data.local.database.dao.FavoritePlaylistDao
 import moe.ouom.neriplayer.data.local.database.dao.TrafficStatsDao
 import moe.ouom.neriplayer.data.local.database.dao.SyncMetadataDao
 import moe.ouom.neriplayer.data.local.database.dao.PlaybackQueueDao
+import moe.ouom.neriplayer.data.local.database.dao.BiliVideoSkipDao
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
 import moe.ouom.neriplayer.data.local.database.entity.TrafficStatsBucketEntity
@@ -38,6 +39,9 @@ import moe.ouom.neriplayer.data.local.database.entity.SyncReplicaCheckpointEntit
 import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueSongEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueStateEntity
+import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipDraftEntity
+import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipIntervalEntity
+import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipRuleEntity
 
 @Database(
     entities = [
@@ -62,9 +66,12 @@ import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueStateEntity
         FavoritePlaylistSongEntity::class,
         TrafficStatsBucketEntity::class,
         PlaybackQueueStateEntity::class,
-        PlaybackQueueSongEntity::class
+        PlaybackQueueSongEntity::class,
+        BiliVideoSkipRuleEntity::class,
+        BiliVideoSkipIntervalEntity::class,
+        BiliVideoSkipDraftEntity::class
     ],
-    version = 8,
+    version = 9,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -85,6 +92,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
     abstract fun syncMetadataDao(): SyncMetadataDao
 
     abstract fun playbackQueueDao(): PlaybackQueueDao
+
+    abstract fun biliVideoSkipDao(): BiliVideoSkipDao
 
     companion object {
         const val DATABASE_NAME = "neri_user_data.db"
@@ -113,7 +122,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 MIGRATION_4_5,
                 MIGRATION_5_6,
                 MIGRATION_6_7,
-                MIGRATION_7_8
+                MIGRATION_7_8,
+                MIGRATION_8_9
             ).build()
         }
 
@@ -614,6 +624,57 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                         `playlist_context_id` TEXT,
                         `stream_url` TEXT,
                         PRIMARY KEY(`queue_id`, `position`)
+                    )
+                    """.trimIndent()
+                )
+            }
+        }
+
+        val MIGRATION_8_9: Migration = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `bili_video_skip_rule` (
+                        `bvid` TEXT NOT NULL,
+                        `cid` INTEGER NOT NULL,
+                        `modified_at` INTEGER NOT NULL,
+                        `is_deleted` INTEGER NOT NULL,
+                        PRIMARY KEY(`bvid`, `cid`)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS
+                    `index_bili_video_skip_rule_modified_at`
+                    ON `bili_video_skip_rule` (`modified_at` DESC)
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `bili_video_skip_interval` (
+                        `bvid` TEXT NOT NULL,
+                        `cid` INTEGER NOT NULL,
+                        `position` INTEGER NOT NULL,
+                        `start_ms` INTEGER NOT NULL,
+                        `end_ms` INTEGER NOT NULL,
+                        PRIMARY KEY(`bvid`, `cid`, `position`),
+                        FOREIGN KEY(`bvid`, `cid`)
+                            REFERENCES `bili_video_skip_rule`(`bvid`, `cid`)
+                            ON UPDATE NO ACTION ON DELETE CASCADE
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `bili_video_skip_draft` (
+                        `target_key` TEXT NOT NULL,
+                        `bvid` TEXT NOT NULL,
+                        `cid` INTEGER NOT NULL,
+                        `start_text` TEXT NOT NULL,
+                        `end_text` TEXT NOT NULL,
+                        `modified_at` INTEGER NOT NULL,
+                        PRIMARY KEY(`target_key`)
                     )
                     """.trimIndent()
                 )

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/RoomRecoveryMerge.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/RoomRecoveryMerge.kt
@@ -1,0 +1,27 @@
+package moe.ouom.neriplayer.data.local.database
+
+internal fun <Key, Value> mergeRoomRecoverySnapshot(
+    roomSnapshot: List<Value>,
+    recoveryBaseline: List<Value>,
+    currentSnapshot: List<Value>,
+    keyOf: (Value) -> Key,
+    mergeLocalChange: (roomValue: Value?, currentValue: Value) -> Value
+): List<Value> {
+    val recovered = LinkedHashMap<Key, Value>()
+    roomSnapshot.forEach { value ->
+        recovered[keyOf(value)] = value
+    }
+    val baselineByKey = recoveryBaseline.associateBy(keyOf)
+    val currentByKey = currentSnapshot.associateBy(keyOf)
+    (baselineByKey.keys + currentByKey.keys).forEach { key ->
+        val baselineValue = baselineByKey[key]
+        val currentValue = currentByKey[key]
+        when {
+            currentValue == null && baselineValue != null -> recovered.remove(key)
+            currentValue != null && currentValue != baselineValue -> {
+                recovered[key] = mergeLocalChange(recovered[key], currentValue)
+            }
+        }
+    }
+    return recovered.values.toList()
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/StructuredSongRoomMigration.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/StructuredSongRoomMigration.kt
@@ -1,0 +1,643 @@
+package moe.ouom.neriplayer.data.local.database
+
+import android.content.ContentValues
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.google.gson.Gson
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import moe.ouom.neriplayer.data.local.database.entity.LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION
+
+internal object StructuredSongRoomMigration : Migration(14, 15) {
+    private val gson = Gson()
+
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("PRAGMA foreign_keys=OFF")
+        migrateTrackTable(db)
+        val trackData = loadTrackData(db)
+        val memberArtists = migratePlaylistMemberTable(db, trackData)
+        createPlaylistMemberArtistTable(db)
+        memberArtists.forEach { artist ->
+            db.insert(
+                "playlist_member_netease_artist",
+                0,
+                artist.toContentValues()
+            )
+        }
+        val favoriteArtists = migrateFavoritePlaylistSongTable(db)
+        createFavoritePlaylistSongArtistTable(db)
+        favoriteArtists.forEach { artist ->
+            db.insert(
+                "favorite_playlist_song_netease_artist",
+                0,
+                artist.toContentValues()
+            )
+        }
+        db.execSQL("PRAGMA foreign_keys=ON")
+    }
+
+    private fun migrateTrackTable(db: SupportSQLiteDatabase) {
+        db.execSQL("DROP TABLE IF EXISTS track_new")
+        db.execSQL(
+            """
+            CREATE TABLE track_new (
+                identity_key TEXT NOT NULL,
+                identity_id INTEGER NOT NULL,
+                identity_album TEXT NOT NULL,
+                identity_media_uri TEXT,
+                song_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                artist TEXT NOT NULL,
+                album TEXT NOT NULL,
+                album_id INTEGER NOT NULL,
+                duration_ms INTEGER NOT NULL,
+                cover_url TEXT,
+                media_uri TEXT,
+                matched_lyric TEXT,
+                matched_translated_lyric TEXT,
+                matched_lyric_source TEXT,
+                matched_song_id TEXT,
+                user_lyric_offset_ms INTEGER NOT NULL,
+                custom_cover_url TEXT,
+                custom_name TEXT,
+                custom_artist TEXT,
+                original_name TEXT,
+                original_artist TEXT,
+                original_cover_url TEXT,
+                original_lyric TEXT,
+                original_translated_lyric TEXT,
+                channel_id TEXT,
+                audio_id TEXT,
+                sub_audio_id TEXT,
+                source_stable_key TEXT,
+                local_file_name TEXT,
+                local_file_path TEXT,
+                structured_schema_version INTEGER NOT NULL,
+                PRIMARY KEY(identity_key)
+            )
+            """.trimIndent()
+        )
+        db.query(
+            "SELECT * FROM track"
+        ).use { cursor ->
+            while (cursor.moveToNext()) {
+                val fallback = StructuredSongData(
+                    id = cursor.long("song_id"),
+                    name = cursor.string("name").orEmpty(),
+                    artist = cursor.string("artist").orEmpty(),
+                    album = cursor.string("album").orEmpty(),
+                    albumId = cursor.long("album_id"),
+                    durationMs = cursor.long("duration_ms"),
+                    coverUrl = cursor.string("cover_url"),
+                    mediaUri = cursor.string("media_uri"),
+                    channelId = cursor.string("channel_id"),
+                    audioId = cursor.string("audio_id"),
+                    subAudioId = cursor.string("sub_audio_id"),
+                    sourceStableKey = cursor.string("source_stable_key"),
+                    localFileName = cursor.string("local_file_name"),
+                    localFilePath = cursor.string("local_file_path")
+                )
+                val song = parseSong(cursor.string("durable_payload_json"), fallback)
+                val values = song.toTrackContentValues(
+                    identityKey = cursor.string("identity_key").orEmpty(),
+                    identityId = cursor.long("identity_id"),
+                    identityAlbum = cursor.string("identity_album").orEmpty(),
+                    identityMediaUri = cursor.string("identity_media_uri")
+                )
+                db.insert("track_new", 0, values)
+            }
+        }
+        db.execSQL("DROP TABLE track")
+        db.execSQL("ALTER TABLE track_new RENAME TO track")
+        db.execSQL(
+            "CREATE INDEX index_track_identity_parts ON track " +
+                "(identity_id, identity_album, identity_media_uri)"
+        )
+        db.execSQL("CREATE INDEX index_track_name ON track (name)")
+        db.execSQL("CREATE INDEX index_track_artist ON track (artist)")
+    }
+
+    private fun loadTrackData(db: SupportSQLiteDatabase): Map<String, StructuredSongData> {
+        val result = LinkedHashMap<String, StructuredSongData>()
+        db.query("SELECT * FROM track").use { cursor ->
+            while (cursor.moveToNext()) {
+                result[cursor.string("identity_key").orEmpty()] = StructuredSongData(
+                    id = cursor.long("song_id"),
+                    name = cursor.string("name").orEmpty(),
+                    artist = cursor.string("artist").orEmpty(),
+                    album = cursor.string("album").orEmpty(),
+                    albumId = cursor.long("album_id"),
+                    durationMs = cursor.long("duration_ms"),
+                    coverUrl = cursor.string("cover_url"),
+                    mediaUri = cursor.string("media_uri"),
+                    matchedLyric = cursor.string("matched_lyric"),
+                    matchedTranslatedLyric = cursor.string("matched_translated_lyric"),
+                    matchedLyricSource = cursor.string("matched_lyric_source"),
+                    matchedSongId = cursor.string("matched_song_id"),
+                    userLyricOffsetMs = cursor.long("user_lyric_offset_ms"),
+                    customCoverUrl = cursor.string("custom_cover_url"),
+                    customName = cursor.string("custom_name"),
+                    customArtist = cursor.string("custom_artist"),
+                    originalName = cursor.string("original_name"),
+                    originalArtist = cursor.string("original_artist"),
+                    originalCoverUrl = cursor.string("original_cover_url"),
+                    originalLyric = cursor.string("original_lyric"),
+                    originalTranslatedLyric = cursor.string("original_translated_lyric"),
+                    localFileName = cursor.string("local_file_name"),
+                    localFilePath = cursor.string("local_file_path"),
+                    channelId = cursor.string("channel_id"),
+                    audioId = cursor.string("audio_id"),
+                    subAudioId = cursor.string("sub_audio_id"),
+                    sourceStableKey = cursor.string("source_stable_key")
+                )
+            }
+        }
+        return result
+    }
+
+    private fun migratePlaylistMemberTable(
+        db: SupportSQLiteDatabase,
+        trackData: Map<String, StructuredSongData>
+    ): List<ArtistRow> {
+        db.execSQL("DROP TABLE IF EXISTS playlist_member_new")
+        db.execSQL(
+            """
+            CREATE TABLE playlist_member_new (
+                playlist_id INTEGER NOT NULL,
+                identity_key TEXT NOT NULL,
+                display_position INTEGER NOT NULL,
+                added_at INTEGER NOT NULL,
+                order_tie_break INTEGER NOT NULL,
+                playlist_context_id TEXT,
+                song_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                artist TEXT NOT NULL,
+                album TEXT NOT NULL,
+                album_id INTEGER NOT NULL,
+                duration_ms INTEGER NOT NULL,
+                cover_url TEXT,
+                media_uri TEXT,
+                matched_lyric TEXT,
+                matched_translated_lyric TEXT,
+                matched_lyric_source TEXT,
+                matched_song_id TEXT,
+                user_lyric_offset_ms INTEGER NOT NULL,
+                custom_cover_url TEXT,
+                custom_name TEXT,
+                custom_artist TEXT,
+                original_name TEXT,
+                original_artist TEXT,
+                original_cover_url TEXT,
+                original_lyric TEXT,
+                original_translated_lyric TEXT,
+                local_file_name TEXT,
+                local_file_path TEXT,
+                channel_id TEXT,
+                audio_id TEXT,
+                sub_audio_id TEXT,
+                source_stable_key TEXT,
+                structured_schema_version INTEGER NOT NULL,
+                PRIMARY KEY(playlist_id, identity_key),
+                FOREIGN KEY(playlist_id) REFERENCES local_playlist(playlist_id)
+                    ON UPDATE NO ACTION ON DELETE CASCADE,
+                FOREIGN KEY(identity_key) REFERENCES track(identity_key)
+                    ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent()
+        )
+        val artists = ArrayList<ArtistRow>()
+        db.query("SELECT * FROM playlist_member").use { cursor ->
+            while (cursor.moveToNext()) {
+                val identityKey = cursor.string("identity_key").orEmpty()
+                val fallback = trackData[identityKey] ?: StructuredSongData()
+                val song = parseSong(cursor.string("member_payload_json"), fallback)
+                val playlistId = cursor.long("playlist_id")
+                val values = song.toMemberContentValues(
+                    playlistId = playlistId,
+                    identityKey = identityKey,
+                    displayPosition = cursor.int("display_position"),
+                    addedAt = cursor.long("added_at"),
+                    orderTieBreak = cursor.int("order_tie_break"),
+                    playlistContextId = cursor.string("playlist_context_id")
+                )
+                db.insert("playlist_member_new", 0, values)
+                song.neteaseArtists.forEachIndexed { position, artist ->
+                    artists += ArtistRow(
+                        playlistId = playlistId,
+                        identityKey = identityKey,
+                        artistPosition = position,
+                        artistId = artist.id,
+                        artistName = artist.name
+                    )
+                }
+            }
+        }
+        db.execSQL("DROP TABLE playlist_member")
+        db.execSQL("ALTER TABLE playlist_member_new RENAME TO playlist_member")
+        db.execSQL(
+            "CREATE INDEX index_playlist_member_display_order ON playlist_member " +
+                "(playlist_id, display_position ASC)"
+        )
+        db.execSQL(
+            "CREATE INDEX index_playlist_member_added_order ON playlist_member " +
+                "(playlist_id, added_at DESC, order_tie_break ASC)"
+        )
+        db.execSQL(
+            "CREATE INDEX index_playlist_member_identity_key ON playlist_member " +
+                "(identity_key)"
+        )
+        return artists
+    }
+
+    private fun createPlaylistMemberArtistTable(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE playlist_member_netease_artist (
+                playlist_id INTEGER NOT NULL,
+                identity_key TEXT NOT NULL,
+                artist_position INTEGER NOT NULL,
+                artist_id INTEGER NOT NULL,
+                artist_name TEXT NOT NULL,
+                PRIMARY KEY(playlist_id, identity_key, artist_position),
+                FOREIGN KEY(playlist_id, identity_key)
+                    REFERENCES playlist_member(playlist_id, identity_key)
+                    ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            "CREATE INDEX index_playlist_member_artist_member " +
+                "ON playlist_member_netease_artist (playlist_id, identity_key)"
+        )
+    }
+
+    private fun migrateFavoritePlaylistSongTable(db: SupportSQLiteDatabase): List<ArtistRow> {
+        db.execSQL("DROP TABLE IF EXISTS favorite_playlist_song_new")
+        db.execSQL(
+            """
+            CREATE TABLE favorite_playlist_song_new (
+                playlist_id INTEGER NOT NULL,
+                source TEXT NOT NULL,
+                display_position INTEGER NOT NULL,
+                id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                artist TEXT NOT NULL,
+                album TEXT NOT NULL,
+                album_id INTEGER NOT NULL,
+                duration_ms INTEGER NOT NULL,
+                cover_url TEXT,
+                media_uri TEXT,
+                matched_lyric TEXT,
+                matched_translated_lyric TEXT,
+                matched_lyric_source TEXT,
+                matched_song_id TEXT,
+                user_lyric_offset_ms INTEGER NOT NULL,
+                custom_cover_url TEXT,
+                custom_name TEXT,
+                custom_artist TEXT,
+                original_name TEXT,
+                original_artist TEXT,
+                original_cover_url TEXT,
+                original_lyric TEXT,
+                original_translated_lyric TEXT,
+                local_file_name TEXT,
+                local_file_path TEXT,
+                channel_id TEXT,
+                audio_id TEXT,
+                sub_audio_id TEXT,
+                playlist_context_id TEXT,
+                source_stable_key TEXT,
+                added_at INTEGER NOT NULL,
+                structured_schema_version INTEGER NOT NULL,
+                PRIMARY KEY(playlist_id, source, display_position),
+                FOREIGN KEY(playlist_id, source)
+                    REFERENCES favorite_playlist(playlist_id, source)
+                    ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent()
+        )
+        val artists = ArrayList<ArtistRow>()
+        db.query("SELECT * FROM favorite_playlist_song").use { cursor ->
+            while (cursor.moveToNext()) {
+                val song = parseSong(cursor.string("song_payload_json"), StructuredSongData())
+                val playlistId = cursor.long("playlist_id")
+                val source = cursor.string("source").orEmpty()
+                val displayPosition = cursor.int("display_position")
+                db.insert(
+                    "favorite_playlist_song_new",
+                    0,
+                    song.toFavoriteContentValues(
+                        playlistId = playlistId,
+                        source = source,
+                        displayPosition = displayPosition
+                    )
+                )
+                song.neteaseArtists.forEachIndexed { position, artist ->
+                    artists += ArtistRow(
+                        playlistId = playlistId,
+                        source = source,
+                        displayPosition = displayPosition,
+                        artistPosition = position,
+                        artistId = artist.id,
+                        artistName = artist.name
+                    )
+                }
+            }
+        }
+        db.execSQL("DROP TABLE favorite_playlist_song")
+        db.execSQL("ALTER TABLE favorite_playlist_song_new RENAME TO favorite_playlist_song")
+        db.execSQL(
+            "CREATE INDEX index_favorite_playlist_song_order ON favorite_playlist_song " +
+                "(playlist_id ASC, source ASC, display_position ASC)"
+        )
+        return artists
+    }
+
+    private fun createFavoritePlaylistSongArtistTable(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE favorite_playlist_song_netease_artist (
+                playlist_id INTEGER NOT NULL,
+                source TEXT NOT NULL,
+                display_position INTEGER NOT NULL,
+                artist_position INTEGER NOT NULL,
+                artist_id INTEGER NOT NULL,
+                artist_name TEXT NOT NULL,
+                PRIMARY KEY(playlist_id, source, display_position, artist_position),
+                FOREIGN KEY(playlist_id, source, display_position)
+                    REFERENCES favorite_playlist_song(
+                        playlist_id, source, display_position
+                    ) ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            "CREATE INDEX index_favorite_playlist_song_artist_song " +
+                "ON favorite_playlist_song_netease_artist " +
+                "(playlist_id, source, display_position)"
+        )
+    }
+
+    private fun parseSong(raw: String?, fallback: StructuredSongData): StructuredSongData {
+        val objectValue = runCatching {
+            gson.fromJson(raw.orEmpty(), JsonObject::class.java)
+        }.getOrNull() ?: return fallback
+        return fallback.copy(
+            id = objectValue.long("id", fallback.id),
+            name = objectValue.requiredString("name", fallback.name),
+            artist = objectValue.requiredString("artist", fallback.artist),
+            album = objectValue.requiredString("album", fallback.album),
+            albumId = objectValue.long("albumId", fallback.albumId),
+            durationMs = objectValue.long("durationMs", fallback.durationMs),
+            coverUrl = objectValue.optionalString("coverUrl", fallback.coverUrl),
+            mediaUri = objectValue.optionalString("mediaUri", fallback.mediaUri),
+            matchedLyric = objectValue.optionalString("matchedLyric", fallback.matchedLyric),
+            matchedTranslatedLyric = objectValue.optionalString(
+                "matchedTranslatedLyric",
+                fallback.matchedTranslatedLyric
+            ),
+            matchedLyricSource = objectValue.optionalString(
+                "matchedLyricSource",
+                fallback.matchedLyricSource
+            ),
+            matchedSongId = objectValue.optionalString("matchedSongId", fallback.matchedSongId),
+            userLyricOffsetMs = objectValue.long(
+                "userLyricOffsetMs",
+                fallback.userLyricOffsetMs
+            ),
+            customCoverUrl = objectValue.optionalString(
+                "customCoverUrl",
+                fallback.customCoverUrl
+            ),
+            customName = objectValue.optionalString("customName", fallback.customName),
+            customArtist = objectValue.optionalString("customArtist", fallback.customArtist),
+            originalName = objectValue.optionalString("originalName", fallback.originalName),
+            originalArtist = objectValue.optionalString("originalArtist", fallback.originalArtist),
+            originalCoverUrl = objectValue.optionalString(
+                "originalCoverUrl",
+                fallback.originalCoverUrl
+            ),
+            originalLyric = objectValue.optionalString("originalLyric", fallback.originalLyric),
+            originalTranslatedLyric = objectValue.optionalString(
+                "originalTranslatedLyric",
+                fallback.originalTranslatedLyric
+            ),
+            localFileName = objectValue.optionalString("localFileName", fallback.localFileName),
+            localFilePath = objectValue.optionalString("localFilePath", fallback.localFilePath),
+            channelId = objectValue.optionalString("channelId", fallback.channelId),
+            audioId = objectValue.optionalString("audioId", fallback.audioId),
+            subAudioId = objectValue.optionalString("subAudioId", fallback.subAudioId),
+            playlistContextId = objectValue.optionalString(
+                "playlistContextId",
+                fallback.playlistContextId
+            ),
+            sourceStableKey = objectValue.optionalString(
+                "sourceStableKey",
+                fallback.sourceStableKey
+            ),
+            addedAt = objectValue.long("addedAt", fallback.addedAt),
+            neteaseArtists = objectValue.artists(fallback.neteaseArtists)
+        )
+    }
+
+    private fun JsonObject.requiredString(key: String, fallback: String): String {
+        return optionalString(key, fallback).orEmpty()
+    }
+
+    private fun JsonObject.optionalString(key: String, fallback: String?): String? {
+        if (!has(key)) return fallback
+        val value = get(key) ?: return fallback
+        return runCatching {
+            if (value.isJsonNull) null else value.asString
+        }.getOrNull()
+    }
+
+    private fun JsonObject.long(key: String, fallback: Long): Long {
+        if (!has(key)) return fallback
+        val value = get(key) ?: return fallback
+        return runCatching {
+            if (value.isJsonNull) fallback else value.asLong
+        }.getOrDefault(fallback)
+    }
+
+    private fun JsonObject.artists(fallback: List<ArtistData>): List<ArtistData> {
+        if (!has("neteaseArtists")) return fallback
+        val array = get("neteaseArtists")
+        if (array == null || array.isJsonNull) return emptyList()
+        if (!array.isJsonArray) return fallback
+        return array.asJsonArray.toArtistData()
+    }
+
+    private fun JsonArray.toArtistData(): List<ArtistData> {
+        return mapNotNull { value ->
+            runCatching {
+                val objectValue = value.asJsonObject
+                ArtistData(
+                    id = objectValue.long("id", 0L),
+                    name = objectValue.requiredString("name", "")
+                )
+            }.getOrNull()
+        }
+    }
+
+    private fun StructuredSongData.toTrackContentValues(
+        identityKey: String,
+        identityId: Long,
+        identityAlbum: String,
+        identityMediaUri: String?
+    ): ContentValues {
+        return ContentValues().apply {
+            put("identity_key", identityKey)
+            put("identity_id", identityId)
+            put("identity_album", identityAlbum)
+            putText("identity_media_uri", identityMediaUri)
+            putSongFields(this, includePlaylistContextId = false)
+            put("structured_schema_version", LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION)
+        }
+    }
+
+    private fun StructuredSongData.toMemberContentValues(
+        playlistId: Long,
+        identityKey: String,
+        displayPosition: Int,
+        addedAt: Long,
+        orderTieBreak: Int,
+        playlistContextId: String?
+    ): ContentValues {
+        return ContentValues().apply {
+            put("playlist_id", playlistId)
+            put("identity_key", identityKey)
+            put("display_position", displayPosition)
+            put("added_at", addedAt)
+            put("order_tie_break", orderTieBreak)
+            putText("playlist_context_id", playlistContextId)
+            putSongFields(this, includePlaylistContextId = true)
+            put("structured_schema_version", LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION)
+        }
+    }
+
+    private fun StructuredSongData.toFavoriteContentValues(
+        playlistId: Long,
+        source: String,
+        displayPosition: Int
+    ): ContentValues {
+        return ContentValues().apply {
+            put("playlist_id", playlistId)
+            put("source", source)
+            put("display_position", displayPosition)
+            putSongFields(this, includePlaylistContextId = true, idColumn = "id")
+            put("added_at", addedAt)
+            put("structured_schema_version", LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION)
+        }
+    }
+
+    private fun StructuredSongData.putSongFields(
+        values: ContentValues,
+        includePlaylistContextId: Boolean,
+        idColumn: String = "song_id"
+    ) {
+        values.put(idColumn, id)
+        values.put("name", name)
+        values.put("artist", artist)
+        values.put("album", album)
+        values.put("album_id", albumId)
+        values.put("duration_ms", durationMs)
+        values.putText("cover_url", coverUrl)
+        values.putText("media_uri", mediaUri)
+        values.putText("matched_lyric", matchedLyric)
+        values.putText("matched_translated_lyric", matchedTranslatedLyric)
+        values.putText("matched_lyric_source", matchedLyricSource)
+        values.putText("matched_song_id", matchedSongId)
+        values.put("user_lyric_offset_ms", userLyricOffsetMs)
+        values.putText("custom_cover_url", customCoverUrl)
+        values.putText("custom_name", customName)
+        values.putText("custom_artist", customArtist)
+        values.putText("original_name", originalName)
+        values.putText("original_artist", originalArtist)
+        values.putText("original_cover_url", originalCoverUrl)
+        values.putText("original_lyric", originalLyric)
+        values.putText("original_translated_lyric", originalTranslatedLyric)
+        values.putText("local_file_name", localFileName)
+        values.putText("local_file_path", localFilePath)
+        values.putText("channel_id", channelId)
+        values.putText("audio_id", audioId)
+        values.putText("sub_audio_id", subAudioId)
+        if (includePlaylistContextId) {
+            values.putText("playlist_context_id", playlistContextId)
+        }
+        values.putText("source_stable_key", sourceStableKey)
+    }
+
+    private fun ContentValues.putText(key: String, value: String?) {
+        if (value == null) putNull(key) else put(key, value)
+    }
+
+    private data class StructuredSongData(
+        val id: Long = 0L,
+        val name: String = "",
+        val artist: String = "",
+        val album: String = "",
+        val albumId: Long = 0L,
+        val durationMs: Long = 0L,
+        val coverUrl: String? = null,
+        val mediaUri: String? = null,
+        val matchedLyric: String? = null,
+        val matchedTranslatedLyric: String? = null,
+        val matchedLyricSource: String? = null,
+        val matchedSongId: String? = null,
+        val userLyricOffsetMs: Long = 0L,
+        val customCoverUrl: String? = null,
+        val customName: String? = null,
+        val customArtist: String? = null,
+        val originalName: String? = null,
+        val originalArtist: String? = null,
+        val originalCoverUrl: String? = null,
+        val originalLyric: String? = null,
+        val originalTranslatedLyric: String? = null,
+        val localFileName: String? = null,
+        val localFilePath: String? = null,
+        val channelId: String? = null,
+        val audioId: String? = null,
+        val subAudioId: String? = null,
+        val playlistContextId: String? = null,
+        val sourceStableKey: String? = null,
+        val addedAt: Long = 0L,
+        val neteaseArtists: List<ArtistData> = emptyList()
+    )
+
+    private data class ArtistData(
+        val id: Long,
+        val name: String
+    )
+
+    private data class ArtistRow(
+        val playlistId: Long,
+        val identityKey: String? = null,
+        val source: String? = null,
+        val displayPosition: Int? = null,
+        val artistPosition: Int,
+        val artistId: Long,
+        val artistName: String
+    ) {
+        fun toContentValues(): ContentValues {
+            return ContentValues().apply {
+                put("playlist_id", playlistId)
+                identityKey?.let { put("identity_key", it) }
+                source?.let { put("source", it) }
+                displayPosition?.let { put("display_position", it) }
+                put("artist_position", artistPosition)
+                put("artist_id", artistId)
+                put("artist_name", artistName)
+            }
+        }
+    }
+
+    private fun android.database.Cursor.string(name: String): String? =
+        getString(getColumnIndexOrThrow(name))
+
+    private fun android.database.Cursor.long(name: String): Long =
+        getLong(getColumnIndexOrThrow(name))
+
+    private fun android.database.Cursor.int(name: String): Int =
+        getInt(getColumnIndexOrThrow(name))
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/StructuredSongRoomMigration.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/StructuredSongRoomMigration.kt
@@ -12,6 +12,15 @@ internal object StructuredSongRoomMigration : Migration(14, 15) {
     private val gson = Gson()
 
     override fun migrate(db: SupportSQLiteDatabase) {
+        // copy child rows before rebuilding the parent table because Room enforces
+        // the foreign key cascade while the migration transaction is active
+        db.execSQL("DROP TABLE IF EXISTS playlist_member_backup")
+        db.execSQL("CREATE TEMP TABLE playlist_member_backup AS SELECT * FROM playlist_member")
+        db.execSQL("DROP TABLE IF EXISTS favorite_playlist_song_backup")
+        db.execSQL(
+            "CREATE TEMP TABLE favorite_playlist_song_backup AS " +
+                "SELECT * FROM favorite_playlist_song"
+        )
         db.execSQL("PRAGMA foreign_keys=OFF")
         migrateTrackTable(db)
         val trackData = loadTrackData(db)
@@ -206,7 +215,7 @@ internal object StructuredSongRoomMigration : Migration(14, 15) {
             """.trimIndent()
         )
         val artists = ArrayList<ArtistRow>()
-        db.query("SELECT * FROM playlist_member").use { cursor ->
+        db.query("SELECT * FROM playlist_member_backup").use { cursor ->
             while (cursor.moveToNext()) {
                 val identityKey = cursor.string("identity_key").orEmpty()
                 val fallback = trackData[identityKey] ?: StructuredSongData()
@@ -317,7 +326,7 @@ internal object StructuredSongRoomMigration : Migration(14, 15) {
             """.trimIndent()
         )
         val artists = ArrayList<ArtistRow>()
-        db.query("SELECT * FROM favorite_playlist_song").use { cursor ->
+        db.query("SELECT * FROM favorite_playlist_song_backup").use { cursor ->
             while (cursor.moveToNext()) {
                 val song = parseSong(cursor.string("song_payload_json"), StructuredSongData())
                 val playlistId = cursor.long("playlist_id")

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/BiliVideoSkipDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/BiliVideoSkipDao.kt
@@ -1,0 +1,48 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipDraftEntity
+import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipIntervalEntity
+import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipRuleEntity
+
+@Dao
+internal interface BiliVideoSkipDao {
+    @Query(
+        "SELECT * FROM bili_video_skip_rule " +
+            "ORDER BY bvid ASC, cid ASC"
+    )
+    suspend fun getRules(): List<BiliVideoSkipRuleEntity>
+
+    @Query(
+        "SELECT * FROM bili_video_skip_interval " +
+            "ORDER BY bvid ASC, cid ASC, position ASC"
+    )
+    suspend fun getIntervals(): List<BiliVideoSkipIntervalEntity>
+
+    @Query(
+        "SELECT * FROM bili_video_skip_draft " +
+            "ORDER BY bvid ASC, cid ASC"
+    )
+    suspend fun getDrafts(): List<BiliVideoSkipDraftEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertRules(rules: List<BiliVideoSkipRuleEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertIntervals(intervals: List<BiliVideoSkipIntervalEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertDrafts(drafts: List<BiliVideoSkipDraftEntity>)
+
+    @Query("DELETE FROM bili_video_skip_interval")
+    suspend fun deleteIntervals()
+
+    @Query("DELETE FROM bili_video_skip_rule")
+    suspend fun deleteRules()
+
+    @Query("DELETE FROM bili_video_skip_draft")
+    suspend fun deleteDrafts()
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/CoverUrlMappingDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/CoverUrlMappingDao.kt
@@ -1,0 +1,24 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import moe.ouom.neriplayer.data.local.database.entity.CoverUrlMappingEntity
+
+@Dao
+internal interface CoverUrlMappingDao {
+    @Query("SELECT * FROM cover_url_mapping")
+    suspend fun getAll(): List<CoverUrlMappingEntity>
+
+    @Upsert
+    suspend fun upsert(entity: CoverUrlMappingEntity)
+
+    @Upsert
+    suspend fun upsert(entities: List<CoverUrlMappingEntity>)
+
+    @Query("DELETE FROM cover_url_mapping WHERE local_url IN (:localUrls)")
+    suspend fun delete(localUrls: List<String>)
+
+    @Query("DELETE FROM cover_url_mapping")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/DownloadRecoveryDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/DownloadRecoveryDao.kt
@@ -1,0 +1,38 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import moe.ouom.neriplayer.data.local.database.entity.DownloadCancelledKeyEntity
+import moe.ouom.neriplayer.data.local.database.entity.DownloadPendingQueueEntity
+
+@Dao
+internal interface DownloadRecoveryDao {
+    @Query(
+        "SELECT * FROM download_pending_queue " +
+            "ORDER BY queue_order ASC, stable_key ASC"
+    )
+    suspend fun getPendingQueue(): List<DownloadPendingQueueEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertPendingQueue(entries: List<DownloadPendingQueueEntity>)
+
+    @Query("DELETE FROM download_pending_queue WHERE stable_key IN (:stableKeys)")
+    suspend fun deletePendingQueue(stableKeys: List<String>)
+
+    @Query("DELETE FROM download_pending_queue")
+    suspend fun clearPendingQueue()
+
+    @Query("SELECT stable_key FROM download_cancelled_key")
+    suspend fun getCancelledKeys(): List<String>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertCancelledKeys(entries: List<DownloadCancelledKeyEntity>)
+
+    @Query("DELETE FROM download_cancelled_key WHERE stable_key IN (:stableKeys)")
+    suspend fun deleteCancelledKeys(stableKeys: List<String>)
+
+    @Query("DELETE FROM download_cancelled_key")
+    suspend fun clearCancelledKeys()
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/DownloadSnapshotDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/DownloadSnapshotDao.kt
@@ -29,9 +29,9 @@ internal interface DownloadSnapshotDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertMetadata(metadata: List<DownloadSnapshotMetadataEntity>)
 
-    @Query("DELETE FROM download_snapshot_entry")
-    suspend fun clearEntries()
+    @Query("DELETE FROM download_snapshot_entry WHERE root_key = :rootKey")
+    suspend fun clearEntries(rootKey: String)
 
-    @Query("DELETE FROM download_snapshot_metadata")
-    suspend fun clearMetadata()
+    @Query("DELETE FROM download_snapshot_metadata WHERE root_key = :rootKey")
+    suspend fun clearMetadata(rootKey: String)
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/DownloadSnapshotDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/DownloadSnapshotDao.kt
@@ -1,0 +1,37 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import moe.ouom.neriplayer.data.local.database.entity.DownloadSnapshotEntryEntity
+import moe.ouom.neriplayer.data.local.database.entity.DownloadSnapshotMetadataEntity
+
+@Dao
+internal interface DownloadSnapshotDao {
+    @Query(
+        "SELECT * FROM download_snapshot_entry " +
+            "WHERE root_key = :rootKey AND bucket = :bucket " +
+            "ORDER BY display_position ASC, entry_key ASC"
+    )
+    suspend fun getEntries(rootKey: String, bucket: String): List<DownloadSnapshotEntryEntity>
+
+    @Query(
+        "SELECT * FROM download_snapshot_metadata " +
+            "WHERE root_key = :rootKey " +
+            "ORDER BY audio_name ASC"
+    )
+    suspend fun getMetadata(rootKey: String): List<DownloadSnapshotMetadataEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertEntries(entries: List<DownloadSnapshotEntryEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertMetadata(metadata: List<DownloadSnapshotMetadataEntity>)
+
+    @Query("DELETE FROM download_snapshot_entry")
+    suspend fun clearEntries()
+
+    @Query("DELETE FROM download_snapshot_metadata")
+    suspend fun clearMetadata()
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/DownloadedSongCatalogDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/DownloadedSongCatalogDao.kt
@@ -18,6 +18,6 @@ internal interface DownloadedSongCatalogDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertSongs(songs: List<DownloadedSongCatalogEntity>)
 
-    @Query("DELETE FROM downloaded_song_catalog")
-    suspend fun clearSongs()
+    @Query("DELETE FROM downloaded_song_catalog WHERE root_key = :rootKey")
+    suspend fun clearSongs(rootKey: String)
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/DownloadedSongCatalogDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/DownloadedSongCatalogDao.kt
@@ -1,0 +1,23 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import moe.ouom.neriplayer.data.local.database.entity.DownloadedSongCatalogEntity
+
+@Dao
+internal interface DownloadedSongCatalogDao {
+    @Query(
+        "SELECT * FROM downloaded_song_catalog " +
+            "WHERE root_key = :rootKey " +
+            "ORDER BY display_position ASC, catalog_key ASC"
+    )
+    suspend fun getSongs(rootKey: String): List<DownloadedSongCatalogEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertSongs(songs: List<DownloadedSongCatalogEntity>)
+
+    @Query("DELETE FROM downloaded_song_catalog")
+    suspend fun clearSongs()
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/FavoritePlaylistDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/FavoritePlaylistDao.kt
@@ -1,0 +1,34 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
+import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
+
+@Dao
+internal interface FavoritePlaylistDao {
+    @Query(
+        "SELECT * FROM favorite_playlist " +
+            "ORDER BY sort_order DESC, modified_at DESC, source ASC, playlist_id ASC"
+    )
+    suspend fun getPlaylists(): List<FavoritePlaylistEntity>
+
+    @Query(
+        "SELECT * FROM favorite_playlist_song " +
+            "ORDER BY playlist_id ASC, source ASC, display_position ASC"
+    )
+    suspend fun getSongs(): List<FavoritePlaylistSongEntity>
+
+    @Upsert
+    suspend fun upsertPlaylists(playlists: List<FavoritePlaylistEntity>)
+
+    @Upsert
+    suspend fun upsertSongs(songs: List<FavoritePlaylistSongEntity>)
+
+    @Query("DELETE FROM favorite_playlist_song")
+    suspend fun deleteAllSongs()
+
+    @Query("DELETE FROM favorite_playlist")
+    suspend fun deleteAllPlaylists()
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/FavoritePlaylistDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/FavoritePlaylistDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Query
 import androidx.room.Upsert
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
+import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongNeteaseArtistEntity
 
 @Dao
 internal interface FavoritePlaylistDao {
@@ -20,14 +21,28 @@ internal interface FavoritePlaylistDao {
     )
     suspend fun getSongs(): List<FavoritePlaylistSongEntity>
 
+    @Query(
+        "SELECT * FROM favorite_playlist_song_netease_artist ORDER BY playlist_id ASC, " +
+            "source ASC, display_position ASC, artist_position ASC"
+    )
+    suspend fun getSongNeteaseArtists(): List<FavoritePlaylistSongNeteaseArtistEntity>
+
     @Upsert
     suspend fun upsertPlaylists(playlists: List<FavoritePlaylistEntity>)
 
     @Upsert
     suspend fun upsertSongs(songs: List<FavoritePlaylistSongEntity>)
 
+    @Upsert
+    suspend fun upsertSongNeteaseArtists(
+        artists: List<FavoritePlaylistSongNeteaseArtistEntity>
+    )
+
     @Query("DELETE FROM favorite_playlist_song")
     suspend fun deleteAllSongs()
+
+    @Query("DELETE FROM favorite_playlist_song_netease_artist")
+    suspend fun deleteAllSongNeteaseArtists()
 
     @Query("DELETE FROM favorite_playlist")
     suspend fun deleteAllPlaylists()
@@ -37,6 +52,12 @@ internal interface FavoritePlaylistDao {
             "WHERE playlist_id = :playlistId AND source = :source"
     )
     suspend fun deleteSongs(playlistId: Long, source: String)
+
+    @Query(
+        "DELETE FROM favorite_playlist_song_netease_artist " +
+            "WHERE playlist_id = :playlistId AND source = :source"
+    )
+    suspend fun deleteSongNeteaseArtists(playlistId: Long, source: String)
 
     @Query(
         "DELETE FROM favorite_playlist " +

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/FavoritePlaylistDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/FavoritePlaylistDao.kt
@@ -31,4 +31,16 @@ internal interface FavoritePlaylistDao {
 
     @Query("DELETE FROM favorite_playlist")
     suspend fun deleteAllPlaylists()
+
+    @Query(
+        "DELETE FROM favorite_playlist_song " +
+            "WHERE playlist_id = :playlistId AND source = :source"
+    )
+    suspend fun deleteSongs(playlistId: Long, source: String)
+
+    @Query(
+        "DELETE FROM favorite_playlist " +
+            "WHERE playlist_id = :playlistId AND source = :source"
+    )
+    suspend fun deletePlaylist(playlistId: Long, source: String)
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/LocalPlaylistDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/LocalPlaylistDao.kt
@@ -1,0 +1,118 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistEntity
+import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistSummaryProjection
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberTokenEntity
+import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
+
+@Dao
+internal interface LocalPlaylistDao {
+    @Query(
+        """
+        SELECT
+            playlist.playlist_id AS playlist_id,
+            playlist.name AS name,
+            playlist.custom_cover_url AS custom_cover_url,
+            COUNT(member.identity_key) AS song_count,
+            playlist.modified_at AS modified_at,
+            playlist.song_order_version AS song_order_version
+        FROM local_playlist AS playlist
+        LEFT JOIN playlist_member AS member
+            ON member.playlist_id = playlist.playlist_id
+        GROUP BY
+            playlist.playlist_id,
+            playlist.name,
+            playlist.custom_cover_url,
+            playlist.modified_at,
+            playlist.song_order_version,
+            playlist.display_position
+        ORDER BY playlist.display_position ASC, playlist.playlist_id ASC
+        """
+    )
+    fun observePlaylistSummaries(): Flow<List<LocalPlaylistSummaryProjection>>
+
+    @Query("SELECT COUNT(*) FROM local_playlist")
+    suspend fun countPlaylists(): Int
+
+    @Query(
+        "SELECT * FROM local_playlist ORDER BY display_position ASC, playlist_id ASC"
+    )
+    suspend fun getPlaylists(): List<LocalPlaylistEntity>
+
+    @Query(
+        "SELECT * FROM playlist_member ORDER BY playlist_id ASC, display_position ASC, " +
+            "identity_key ASC"
+    )
+    suspend fun getMembers(): List<PlaylistMemberEntity>
+
+    @Query(
+        "SELECT * FROM playlist_member_token ORDER BY playlist_id ASC, identity_key ASC, " +
+            "token_index ASC, device_id ASC, counter ASC"
+    )
+    suspend fun getMemberTokens(): List<PlaylistMemberTokenEntity>
+
+    @Query("SELECT * FROM track ORDER BY identity_key ASC")
+    suspend fun getTracks(): List<TrackEntity>
+
+    @Upsert
+    suspend fun insertPlaylists(playlists: List<LocalPlaylistEntity>)
+
+    @Upsert
+    suspend fun insertTracks(tracks: List<TrackEntity>)
+
+    @Upsert
+    suspend fun insertMembers(members: List<PlaylistMemberEntity>)
+
+    @Upsert
+    suspend fun insertMemberTokens(tokens: List<PlaylistMemberTokenEntity>)
+
+    @Query("DELETE FROM playlist_member_token")
+    suspend fun deleteMemberTokens()
+
+    @Query("DELETE FROM playlist_member_token WHERE playlist_id = :playlistId")
+    suspend fun deleteMemberTokensForPlaylist(playlistId: Long)
+
+    @Query("DELETE FROM playlist_member")
+    suspend fun deleteMembers()
+
+    @Query("DELETE FROM playlist_member WHERE playlist_id = :playlistId")
+    suspend fun deleteMembersForPlaylist(playlistId: Long)
+
+    @Query("DELETE FROM local_playlist")
+    suspend fun deletePlaylists()
+
+    @Query("DELETE FROM local_playlist WHERE playlist_id = :playlistId")
+    suspend fun deletePlaylist(playlistId: Long)
+
+    @Query("DELETE FROM track")
+    suspend fun deleteTracks()
+
+    @Query(
+        "DELETE FROM track WHERE identity_key NOT IN " +
+            "(SELECT DISTINCT identity_key FROM playlist_member)"
+    )
+    suspend fun deleteOrphanTracks()
+
+    @Transaction
+    suspend fun replaceSnapshot(
+        playlists: List<LocalPlaylistEntity>,
+        tracks: List<TrackEntity>,
+        members: List<PlaylistMemberEntity>,
+        memberTokens: List<PlaylistMemberTokenEntity>
+    ) {
+        deleteMemberTokens()
+        deleteMembers()
+        deletePlaylists()
+        deleteTracks()
+        insertTracks(tracks)
+        insertPlaylists(playlists)
+        insertMembers(members)
+        insertMemberTokens(memberTokens)
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/LocalPlaylistDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/LocalPlaylistDao.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.Flow
 import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistSummaryProjection
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberNeteaseArtistEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberTokenEntity
 import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
 
@@ -52,6 +53,12 @@ internal interface LocalPlaylistDao {
     suspend fun getMembers(): List<PlaylistMemberEntity>
 
     @Query(
+        "SELECT * FROM playlist_member_netease_artist ORDER BY playlist_id ASC, " +
+            "identity_key ASC, artist_position ASC"
+    )
+    suspend fun getMemberNeteaseArtists(): List<PlaylistMemberNeteaseArtistEntity>
+
+    @Query(
         "SELECT * FROM playlist_member_token ORDER BY playlist_id ASC, identity_key ASC, " +
             "token_index ASC, device_id ASC, counter ASC"
     )
@@ -70,6 +77,9 @@ internal interface LocalPlaylistDao {
     suspend fun insertMembers(members: List<PlaylistMemberEntity>)
 
     @Upsert
+    suspend fun insertMemberNeteaseArtists(artists: List<PlaylistMemberNeteaseArtistEntity>)
+
+    @Upsert
     suspend fun insertMemberTokens(tokens: List<PlaylistMemberTokenEntity>)
 
     @Query("DELETE FROM playlist_member_token")
@@ -83,6 +93,14 @@ internal interface LocalPlaylistDao {
 
     @Query("DELETE FROM playlist_member WHERE playlist_id = :playlistId")
     suspend fun deleteMembersForPlaylist(playlistId: Long)
+
+    @Query("DELETE FROM playlist_member_netease_artist")
+    suspend fun deleteMemberNeteaseArtists()
+
+    @Query(
+        "DELETE FROM playlist_member_netease_artist WHERE playlist_id = :playlistId"
+    )
+    suspend fun deleteMemberNeteaseArtistsForPlaylist(playlistId: Long)
 
     @Query("DELETE FROM local_playlist")
     suspend fun deletePlaylists()
@@ -104,15 +122,18 @@ internal interface LocalPlaylistDao {
         playlists: List<LocalPlaylistEntity>,
         tracks: List<TrackEntity>,
         members: List<PlaylistMemberEntity>,
+        memberNeteaseArtists: List<PlaylistMemberNeteaseArtistEntity>,
         memberTokens: List<PlaylistMemberTokenEntity>
     ) {
         deleteMemberTokens()
+        deleteMemberNeteaseArtists()
         deleteMembers()
         deletePlaylists()
         deleteTracks()
         insertTracks(tracks)
         insertPlaylists(playlists)
         insertMembers(members)
+        insertMemberNeteaseArtists(memberNeteaseArtists)
         insertMemberTokens(memberTokens)
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/LocalPlaylistPlaybackDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/LocalPlaylistPlaybackDao.kt
@@ -1,0 +1,65 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistPlaybackBucketEntity
+import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistPlaybackCounterShardEntity
+import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistPlaybackStatEntity
+
+@Dao
+internal interface LocalPlaylistPlaybackDao {
+    @Query(
+        "SELECT * FROM local_playlist_playback_stat " +
+            "ORDER BY playlist_id ASC"
+    )
+    suspend fun getStats(): List<LocalPlaylistPlaybackStatEntity>
+
+    @Query(
+        "SELECT * FROM local_playlist_playback_bucket " +
+            "ORDER BY playlist_id ASC, day_start_at ASC"
+    )
+    suspend fun getBuckets(): List<LocalPlaylistPlaybackBucketEntity>
+
+    @Query(
+        "SELECT * FROM local_playlist_playback_counter_shard " +
+            "ORDER BY playlist_id ASC, day_start_at ASC, device_id ASC"
+    )
+    suspend fun getCounterShards(): List<LocalPlaylistPlaybackCounterShardEntity>
+
+    @Upsert
+    suspend fun upsertStats(stats: List<LocalPlaylistPlaybackStatEntity>)
+
+    @Upsert
+    suspend fun upsertBuckets(buckets: List<LocalPlaylistPlaybackBucketEntity>)
+
+    @Upsert
+    suspend fun upsertCounterShards(
+        shards: List<LocalPlaylistPlaybackCounterShardEntity>
+    )
+
+    @Query(
+        "DELETE FROM local_playlist_playback_counter_shard " +
+            "WHERE playlist_id IN (:playlistIds)"
+    )
+    suspend fun deleteCounterShards(playlistIds: List<Long>)
+
+    @Query(
+        "DELETE FROM local_playlist_playback_bucket WHERE playlist_id IN (:playlistIds)"
+    )
+    suspend fun deleteBuckets(playlistIds: List<Long>)
+
+    @Query(
+        "DELETE FROM local_playlist_playback_stat WHERE playlist_id IN (:playlistIds)"
+    )
+    suspend fun deleteStats(playlistIds: List<Long>)
+
+    @Query("DELETE FROM local_playlist_playback_counter_shard")
+    suspend fun deleteAllCounterShards()
+
+    @Query("DELETE FROM local_playlist_playback_bucket")
+    suspend fun deleteAllBuckets()
+
+    @Query("DELETE FROM local_playlist_playback_stat")
+    suspend fun deleteAllStats()
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/PlatformPlaylistCacheDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/PlatformPlaylistCacheDao.kt
@@ -1,0 +1,77 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheTrackArtistEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheTrackEntity
+
+@Dao
+internal interface PlatformPlaylistCacheDao {
+    @Query(
+        "SELECT * FROM platform_playlist_cache " +
+            "WHERE platform = :platform AND cache_key = :cacheKey"
+    )
+    suspend fun getCache(
+        platform: String,
+        cacheKey: String
+    ): PlatformPlaylistCacheEntity?
+
+    @Query(
+        "SELECT * FROM platform_playlist_cache_track " +
+            "WHERE platform = :platform AND cache_key = :cacheKey " +
+            "ORDER BY position ASC"
+    )
+    suspend fun getTracks(
+        platform: String,
+        cacheKey: String
+    ): List<PlatformPlaylistCacheTrackEntity>
+
+    @Query(
+        "SELECT * FROM platform_playlist_cache_track_artist " +
+            "WHERE platform = :platform AND cache_key = :cacheKey " +
+            "ORDER BY track_position ASC, artist_position ASC"
+    )
+    suspend fun getArtists(
+        platform: String,
+        cacheKey: String
+    ): List<PlatformPlaylistCacheTrackArtistEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertCache(cache: PlatformPlaylistCacheEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertTracks(tracks: List<PlatformPlaylistCacheTrackEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertArtists(artists: List<PlatformPlaylistCacheTrackArtistEntity>)
+
+    @Query(
+        "DELETE FROM platform_playlist_cache_track_artist " +
+            "WHERE platform = :platform AND cache_key = :cacheKey"
+    )
+    suspend fun deleteArtists(
+        platform: String,
+        cacheKey: String
+    )
+
+    @Query(
+        "DELETE FROM platform_playlist_cache_track " +
+            "WHERE platform = :platform AND cache_key = :cacheKey"
+    )
+    suspend fun deleteTracks(
+        platform: String,
+        cacheKey: String
+    )
+
+    @Query(
+        "DELETE FROM platform_playlist_cache " +
+            "WHERE platform = :platform AND cache_key = :cacheKey"
+    )
+    suspend fun deleteCache(
+        platform: String,
+        cacheKey: String
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/PlayHistoryDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/PlayHistoryDao.kt
@@ -1,0 +1,21 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import moe.ouom.neriplayer.data.local.database.entity.PlayHistoryEntity
+
+@Dao
+internal interface PlayHistoryDao {
+    @Query("SELECT * FROM play_history ORDER BY played_at DESC, identity_key ASC")
+    suspend fun getAll(): List<PlayHistoryEntity>
+
+    @Upsert
+    suspend fun upsert(entries: List<PlayHistoryEntity>)
+
+    @Query("DELETE FROM play_history WHERE identity_key IN (:identityKeys)")
+    suspend fun deleteByIdentityKeys(identityKeys: List<String>)
+
+    @Query("DELETE FROM play_history")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/PlaybackQueueDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/PlaybackQueueDao.kt
@@ -1,0 +1,35 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueSongEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueStateEntity
+
+@Dao
+internal interface PlaybackQueueDao {
+    @Query("SELECT * FROM playback_queue_state WHERE id = 1")
+    suspend fun getState(): PlaybackQueueStateEntity?
+
+    @Query(
+        "SELECT * FROM playback_queue_song WHERE queue_id = :queueId " +
+            "ORDER BY position ASC"
+    )
+    suspend fun getSongs(queueId: String): List<PlaybackQueueSongEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertState(state: PlaybackQueueStateEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertSongs(songs: List<PlaybackQueueSongEntity>)
+
+    @Query("DELETE FROM playback_queue_state")
+    suspend fun deleteState()
+
+    @Query("DELETE FROM playback_queue_song")
+    suspend fun deleteSongs()
+
+    @Query("DELETE FROM playback_queue_song WHERE queue_id = :queueId")
+    suspend fun deleteSongs(queueId: String)
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/PlaybackStatsDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/PlaybackStatsDao.kt
@@ -1,0 +1,83 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatBucketEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatCounterShardEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatDailyCounterShardEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatEntity
+
+@Dao
+internal interface PlaybackStatsDao {
+    @Query(
+        "SELECT * FROM playback_stat " +
+            "ORDER BY last_played_at DESC, identity_key ASC"
+    )
+    suspend fun getStats(): List<PlaybackStatEntity>
+
+    @Query(
+        "SELECT * FROM playback_stat_bucket " +
+            "ORDER BY day_start_at ASC, identity_key ASC"
+    )
+    suspend fun getBuckets(): List<PlaybackStatBucketEntity>
+
+    @Query(
+        "SELECT * FROM playback_stat_counter_shard " +
+            "ORDER BY identity_key ASC, device_id ASC, epoch_started_at ASC"
+    )
+    suspend fun getCounterShards(): List<PlaybackStatCounterShardEntity>
+
+    @Query(
+        "SELECT * FROM playback_stat_daily_counter_shard " +
+            "ORDER BY day_start_at ASC, identity_key ASC, device_id ASC, " +
+            "epoch_started_at ASC"
+    )
+    suspend fun getDailyCounterShards(): List<PlaybackStatDailyCounterShardEntity>
+
+    @Upsert
+    suspend fun upsertStats(stats: List<PlaybackStatEntity>)
+
+    @Upsert
+    suspend fun upsertBuckets(buckets: List<PlaybackStatBucketEntity>)
+
+    @Upsert
+    suspend fun upsertCounterShards(shards: List<PlaybackStatCounterShardEntity>)
+
+    @Upsert
+    suspend fun upsertDailyCounterShards(
+        shards: List<PlaybackStatDailyCounterShardEntity>
+    )
+
+    @Query(
+        "DELETE FROM playback_stat_counter_shard " +
+            "WHERE identity_key IN (:identityKeys)"
+    )
+    suspend fun deleteCounterShards(identityKeys: List<String>)
+
+    @Query(
+        "DELETE FROM playback_stat_daily_counter_shard " +
+            "WHERE identity_key IN (:identityKeys)"
+    )
+    suspend fun deleteDailyCounterShards(identityKeys: List<String>)
+
+    @Query(
+        "DELETE FROM playback_stat_bucket WHERE identity_key IN (:identityKeys)"
+    )
+    suspend fun deleteBuckets(identityKeys: List<String>)
+
+    @Query("DELETE FROM playback_stat WHERE identity_key IN (:identityKeys)")
+    suspend fun deleteStats(identityKeys: List<String>)
+
+    @Query("DELETE FROM playback_stat_daily_counter_shard")
+    suspend fun deleteAllDailyCounterShards()
+
+    @Query("DELETE FROM playback_stat_counter_shard")
+    suspend fun deleteAllCounterShards()
+
+    @Query("DELETE FROM playback_stat_bucket")
+    suspend fun deleteAllBuckets()
+
+    @Query("DELETE FROM playback_stat")
+    suspend fun deleteAllStats()
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/PlaylistUsageDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/PlaylistUsageDao.kt
@@ -1,0 +1,34 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistUsageCounterShardEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistUsageEntity
+
+@Dao
+internal interface PlaylistUsageDao {
+    @Query("SELECT * FROM playlist_usage ORDER BY last_opened DESC, usage_key ASC")
+    suspend fun getEntries(): List<PlaylistUsageEntity>
+
+    @Query("SELECT * FROM playlist_usage_counter_shard ORDER BY usage_key ASC, device_id ASC")
+    suspend fun getCounterShards(): List<PlaylistUsageCounterShardEntity>
+
+    @Upsert
+    suspend fun upsertEntries(entries: List<PlaylistUsageEntity>)
+
+    @Upsert
+    suspend fun upsertCounterShards(shards: List<PlaylistUsageCounterShardEntity>)
+
+    @Query("DELETE FROM playlist_usage WHERE usage_key IN (:usageKeys)")
+    suspend fun deleteEntries(usageKeys: List<String>)
+
+    @Query("DELETE FROM playlist_usage_counter_shard WHERE usage_key IN (:usageKeys)")
+    suspend fun deleteCounterShards(usageKeys: List<String>)
+
+    @Query("DELETE FROM playlist_usage_counter_shard")
+    suspend fun deleteAllCounterShards()
+
+    @Query("DELETE FROM playlist_usage")
+    suspend fun deleteAllEntries()
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/SyncMetadataDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/SyncMetadataDao.kt
@@ -1,0 +1,51 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+import moe.ouom.neriplayer.data.local.database.entity.SyncOutboxEntity
+import moe.ouom.neriplayer.data.local.database.entity.SyncReplicaCheckpointEntity
+
+@Dao
+internal interface SyncMetadataDao {
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insertOutbox(entry: SyncOutboxEntity): Long
+
+    @Query(
+        "SELECT * FROM sync_outbox WHERE status IN (:statuses) " +
+            "ORDER BY sequence ASC LIMIT :limit"
+    )
+    suspend fun getOutbox(statuses: List<String>, limit: Int): List<SyncOutboxEntity>
+
+    @Query("DELETE FROM sync_outbox WHERE status = :status")
+    suspend fun deleteOutboxByStatus(status: String)
+
+    @Query(
+        "UPDATE sync_outbox SET status = :status, attempt_count = :attemptCount, " +
+            "last_error_type = :lastErrorType, updated_at = :updatedAt " +
+            "WHERE sequence = :sequence"
+    )
+    suspend fun updateOutbox(
+        sequence: Long,
+        status: String,
+        attemptCount: Int,
+        lastErrorType: String?,
+        updatedAt: Long
+    )
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertCheckpoint(checkpoint: SyncReplicaCheckpointEntity)
+
+    @Query(
+        "SELECT * FROM sync_replica_checkpoint WHERE transport_id = :transportId"
+    )
+    suspend fun getCheckpoint(transportId: String): SyncReplicaCheckpointEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertMigrationMetadata(metadata: MigrationMetadataEntity)
+
+    @Query("SELECT * FROM migration_metadata WHERE key = :key")
+    suspend fun getMigrationMetadata(key: String): MigrationMetadataEntity?
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/SyncMetadataDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/SyncMetadataDao.kt
@@ -48,4 +48,7 @@ internal interface SyncMetadataDao {
 
     @Query("SELECT * FROM migration_metadata WHERE key = :key")
     suspend fun getMigrationMetadata(key: String): MigrationMetadataEntity?
+
+    @Query("DELETE FROM migration_metadata WHERE key IN (:keys)")
+    suspend fun deleteMigrationMetadata(keys: List<String>)
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/TrafficStatsDao.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/dao/TrafficStatsDao.kt
@@ -1,0 +1,26 @@
+package moe.ouom.neriplayer.data.local.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import moe.ouom.neriplayer.data.local.database.entity.TrafficStatsBucketEntity
+
+@Dao
+internal interface TrafficStatsDao {
+    @Query(
+        "SELECT * FROM traffic_stats_bucket " +
+            "ORDER BY day_start_at ASC"
+    )
+    suspend fun getAll(): List<TrafficStatsBucketEntity>
+
+    @Upsert
+    suspend fun upsert(buckets: List<TrafficStatsBucketEntity>)
+
+    @Query(
+        "DELETE FROM traffic_stats_bucket WHERE day_start_at IN (:dayStartAt)"
+    )
+    suspend fun delete(dayStartAt: List<Long>)
+
+    @Query("DELETE FROM traffic_stats_bucket")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/BiliVideoSkipEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/BiliVideoSkipEntities.kt
@@ -1,0 +1,64 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "bili_video_skip_rule",
+    primaryKeys = ["bvid", "cid"],
+    indices = [
+        Index(
+            value = ["modified_at"],
+            orders = [Index.Order.DESC],
+            name = "index_bili_video_skip_rule_modified_at"
+        )
+    ]
+)
+internal data class BiliVideoSkipRuleEntity(
+    val bvid: String,
+    val cid: Long,
+    @ColumnInfo(name = "modified_at")
+    val modifiedAt: Long,
+    @ColumnInfo(name = "is_deleted")
+    val isDeleted: Boolean
+)
+
+@Entity(
+    tableName = "bili_video_skip_interval",
+    primaryKeys = ["bvid", "cid", "position"],
+    foreignKeys = [
+        ForeignKey(
+            entity = BiliVideoSkipRuleEntity::class,
+            parentColumns = ["bvid", "cid"],
+            childColumns = ["bvid", "cid"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ]
+)
+internal data class BiliVideoSkipIntervalEntity(
+    val bvid: String,
+    val cid: Long,
+    val position: Int,
+    @ColumnInfo(name = "start_ms")
+    val startMs: Long,
+    @ColumnInfo(name = "end_ms")
+    val endMs: Long
+)
+
+@Entity(tableName = "bili_video_skip_draft")
+internal data class BiliVideoSkipDraftEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "target_key")
+    val targetKey: String,
+    val bvid: String,
+    val cid: Long,
+    @ColumnInfo(name = "start_text")
+    val startText: String,
+    @ColumnInfo(name = "end_text")
+    val endText: String,
+    @ColumnInfo(name = "modified_at")
+    val modifiedAt: Long
+)

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/CoverUrlMappingEntity.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/CoverUrlMappingEntity.kt
@@ -1,0 +1,26 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "cover_url_mapping",
+    indices = [
+        Index(
+            value = ["updated_at"],
+            orders = [Index.Order.DESC],
+            name = "index_cover_url_mapping_updated_at"
+        )
+    ]
+)
+internal data class CoverUrlMappingEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "local_url")
+    val localUrl: String,
+    @ColumnInfo(name = "network_url")
+    val networkUrl: String,
+    @ColumnInfo(name = "updated_at")
+    val updatedAt: Long
+)

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/DownloadRecoveryEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/DownloadRecoveryEntities.kt
@@ -1,0 +1,89 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "download_pending_queue",
+    indices = [
+        Index(
+            value = ["queue_order"],
+            orders = [Index.Order.ASC],
+            name = "index_download_pending_queue_order"
+        )
+    ]
+)
+internal data class DownloadPendingQueueEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "stable_key")
+    val stableKey: String,
+    @ColumnInfo(name = "queue_order")
+    val queueOrder: Int,
+    @ColumnInfo(name = "queued_at_ms")
+    val queuedAtMs: Long,
+    val id: Long,
+    val name: String,
+    val artist: String,
+    val album: String,
+    @ColumnInfo(name = "album_id")
+    val albumId: Long,
+    @ColumnInfo(name = "duration_ms")
+    val durationMs: Long,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "media_uri")
+    val mediaUri: String?,
+    @ColumnInfo(name = "matched_lyric")
+    val matchedLyric: String?,
+    @ColumnInfo(name = "matched_translated_lyric")
+    val matchedTranslatedLyric: String?,
+    @ColumnInfo(name = "matched_lyric_source")
+    val matchedLyricSource: String?,
+    @ColumnInfo(name = "matched_song_id")
+    val matchedSongId: String?,
+    @ColumnInfo(name = "user_lyric_offset_ms")
+    val userLyricOffsetMs: Long,
+    @ColumnInfo(name = "custom_cover_url")
+    val customCoverUrl: String?,
+    @ColumnInfo(name = "custom_name")
+    val customName: String?,
+    @ColumnInfo(name = "custom_artist")
+    val customArtist: String?,
+    @ColumnInfo(name = "original_name")
+    val originalName: String?,
+    @ColumnInfo(name = "original_artist")
+    val originalArtist: String?,
+    @ColumnInfo(name = "original_cover_url")
+    val originalCoverUrl: String?,
+    @ColumnInfo(name = "original_lyric")
+    val originalLyric: String?,
+    @ColumnInfo(name = "original_translated_lyric")
+    val originalTranslatedLyric: String?,
+    @ColumnInfo(name = "local_file_name")
+    val localFileName: String?,
+    @ColumnInfo(name = "local_file_path")
+    val localFilePath: String?,
+    @ColumnInfo(name = "channel_id")
+    val channelId: String?,
+    @ColumnInfo(name = "audio_id")
+    val audioId: String?,
+    @ColumnInfo(name = "sub_audio_id")
+    val subAudioId: String?,
+    @ColumnInfo(name = "playlist_context_id")
+    val playlistContextId: String?,
+    @ColumnInfo(name = "source_stable_key")
+    val sourceStableKey: String?,
+    @ColumnInfo(name = "stream_url")
+    val streamUrl: String?
+)
+
+@Entity(tableName = "download_cancelled_key")
+internal data class DownloadCancelledKeyEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "stable_key")
+    val stableKey: String,
+    @ColumnInfo(name = "cancelled_at_ms")
+    val cancelledAtMs: Long
+)

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/DownloadSnapshotEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/DownloadSnapshotEntities.kt
@@ -1,0 +1,131 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+
+@Entity(
+    tableName = "download_snapshot_entry",
+    primaryKeys = ["root_key", "bucket", "entry_key"],
+    indices = [
+        Index(
+            value = ["root_key", "bucket", "display_position"],
+            orders = [Index.Order.ASC, Index.Order.ASC, Index.Order.ASC],
+            name = "index_download_snapshot_entry_root_bucket_position"
+        ),
+        Index(
+            value = ["root_key", "bucket", "name"],
+            name = "index_download_snapshot_entry_root_bucket_name"
+        ),
+        Index(
+            value = ["root_key", "reference"],
+            name = "index_download_snapshot_entry_root_reference"
+        )
+    ]
+)
+internal data class DownloadSnapshotEntryEntity(
+    @ColumnInfo(name = "root_key")
+    val rootKey: String,
+    val bucket: String,
+    @ColumnInfo(name = "entry_key")
+    val entryKey: String,
+    @ColumnInfo(name = "display_position")
+    val displayPosition: Int,
+    val name: String,
+    val reference: String,
+    @ColumnInfo(name = "media_uri")
+    val mediaUri: String,
+    @ColumnInfo(name = "local_file_path")
+    val localFilePath: String?,
+    @ColumnInfo(name = "size_bytes")
+    val sizeBytes: Long,
+    @ColumnInfo(name = "last_modified_ms")
+    val lastModifiedMs: Long,
+    @ColumnInfo(name = "is_directory")
+    val isDirectory: Boolean
+)
+
+@Entity(
+    tableName = "download_snapshot_metadata",
+    primaryKeys = ["root_key", "audio_name"],
+    indices = [
+        Index(
+            value = ["root_key", "stable_key"],
+            name = "index_download_snapshot_metadata_root_stable_key"
+        ),
+        Index(
+            value = ["root_key", "song_id"],
+            name = "index_download_snapshot_metadata_root_song_id"
+        ),
+        Index(
+            value = ["root_key", "media_uri"],
+            name = "index_download_snapshot_metadata_root_media_uri"
+        ),
+        Index(
+            value = ["root_key", "channel_id", "audio_id", "sub_audio_id"],
+            name = "index_download_snapshot_metadata_root_remote_track"
+        )
+    ]
+)
+internal data class DownloadSnapshotMetadataEntity(
+    @ColumnInfo(name = "root_key")
+    val rootKey: String,
+    @ColumnInfo(name = "audio_name")
+    val audioName: String,
+    @ColumnInfo(name = "stable_key")
+    val stableKey: String?,
+    @ColumnInfo(name = "song_id")
+    val songId: Long?,
+    @ColumnInfo(name = "identity_album")
+    val identityAlbum: String?,
+    val name: String?,
+    val artist: String?,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "matched_lyric")
+    val matchedLyric: String?,
+    @ColumnInfo(name = "matched_translated_lyric")
+    val matchedTranslatedLyric: String?,
+    @ColumnInfo(name = "matched_lyric_source")
+    val matchedLyricSource: String?,
+    @ColumnInfo(name = "matched_song_id")
+    val matchedSongId: String?,
+    @ColumnInfo(name = "user_lyric_offset_ms")
+    val userLyricOffsetMs: Long,
+    @ColumnInfo(name = "custom_cover_url")
+    val customCoverUrl: String?,
+    @ColumnInfo(name = "custom_name")
+    val customName: String?,
+    @ColumnInfo(name = "custom_artist")
+    val customArtist: String?,
+    @ColumnInfo(name = "original_name")
+    val originalName: String?,
+    @ColumnInfo(name = "original_artist")
+    val originalArtist: String?,
+    @ColumnInfo(name = "original_cover_url")
+    val originalCoverUrl: String?,
+    @ColumnInfo(name = "original_lyric")
+    val originalLyric: String?,
+    @ColumnInfo(name = "original_translated_lyric")
+    val originalTranslatedLyric: String?,
+    @ColumnInfo(name = "media_uri")
+    val mediaUri: String?,
+    @ColumnInfo(name = "channel_id")
+    val channelId: String?,
+    @ColumnInfo(name = "audio_id")
+    val audioId: String?,
+    @ColumnInfo(name = "sub_audio_id")
+    val subAudioId: String?,
+    @ColumnInfo(name = "playlist_context_id")
+    val playlistContextId: String?,
+    @ColumnInfo(name = "cover_path")
+    val coverPath: String?,
+    @ColumnInfo(name = "lyric_path")
+    val lyricPath: String?,
+    @ColumnInfo(name = "translated_lyric_path")
+    val translatedLyricPath: String?,
+    @ColumnInfo(name = "duration_ms")
+    val durationMs: Long,
+    @ColumnInfo(name = "download_finalized")
+    val downloadFinalized: Boolean?
+)

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/DownloadedSongCatalogEntity.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/DownloadedSongCatalogEntity.kt
@@ -1,0 +1,96 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "downloaded_song_catalog",
+    indices = [
+        Index(
+            value = ["root_key", "display_position"],
+            orders = [Index.Order.ASC, Index.Order.ASC],
+            name = "index_downloaded_song_catalog_root_position"
+        ),
+        Index(
+            value = ["file_path"],
+            name = "index_downloaded_song_catalog_file_path"
+        ),
+        Index(
+            value = ["media_uri"],
+            name = "index_downloaded_song_catalog_media_uri"
+        ),
+        Index(
+            value = ["stable_key"],
+            name = "index_downloaded_song_catalog_stable_key"
+        )
+    ]
+)
+internal data class DownloadedSongCatalogEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "catalog_key")
+    val catalogKey: String,
+    @ColumnInfo(name = "root_key")
+    val rootKey: String,
+    @ColumnInfo(name = "display_position")
+    val displayPosition: Int,
+    val id: Long,
+    val name: String,
+    val artist: String,
+    val album: String,
+    @ColumnInfo(name = "file_path")
+    val filePath: String,
+    @ColumnInfo(name = "file_size")
+    val fileSize: Long,
+    @ColumnInfo(name = "download_time")
+    val downloadTime: Long,
+    @ColumnInfo(name = "cover_path")
+    val coverPath: String?,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "matched_lyric")
+    val matchedLyric: String?,
+    @ColumnInfo(name = "matched_translated_lyric")
+    val matchedTranslatedLyric: String?,
+    @ColumnInfo(name = "matched_lyric_source")
+    val matchedLyricSource: String?,
+    @ColumnInfo(name = "matched_song_id")
+    val matchedSongId: String?,
+    @ColumnInfo(name = "user_lyric_offset_ms")
+    val userLyricOffsetMs: Long,
+    @ColumnInfo(name = "custom_cover_url")
+    val customCoverUrl: String?,
+    @ColumnInfo(name = "custom_name")
+    val customName: String?,
+    @ColumnInfo(name = "custom_artist")
+    val customArtist: String?,
+    @ColumnInfo(name = "original_name")
+    val originalName: String?,
+    @ColumnInfo(name = "original_artist")
+    val originalArtist: String?,
+    @ColumnInfo(name = "original_cover_url")
+    val originalCoverUrl: String?,
+    @ColumnInfo(name = "original_lyric")
+    val originalLyric: String?,
+    @ColumnInfo(name = "original_translated_lyric")
+    val originalTranslatedLyric: String?,
+    @ColumnInfo(name = "media_uri")
+    val mediaUri: String?,
+    @ColumnInfo(name = "duration_ms")
+    val durationMs: Long,
+    @ColumnInfo(name = "stable_key")
+    val stableKey: String?,
+    @ColumnInfo(name = "source_identity_album")
+    val sourceIdentityAlbum: String?,
+    @ColumnInfo(name = "source_media_uri")
+    val sourceMediaUri: String?,
+    @ColumnInfo(name = "source_channel_id")
+    val sourceChannelId: String?,
+    @ColumnInfo(name = "source_audio_id")
+    val sourceAudioId: String?,
+    @ColumnInfo(name = "source_sub_audio_id")
+    val sourceSubAudioId: String?,
+    @ColumnInfo(name = "source_playlist_context_id")
+    val sourcePlaylistContextId: String?
+)

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/FavoritePlaylistEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/FavoritePlaylistEntities.kt
@@ -70,6 +70,92 @@ internal data class FavoritePlaylistSongEntity(
     val source: String,
     @ColumnInfo(name = "display_position")
     val displayPosition: Int,
-    @ColumnInfo(name = "song_payload_json")
-    val songPayloadJson: String
+    val id: Long,
+    val name: String,
+    val artist: String,
+    val album: String,
+    @ColumnInfo(name = "album_id")
+    val albumId: Long,
+    @ColumnInfo(name = "duration_ms")
+    val durationMs: Long,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "media_uri")
+    val mediaUri: String?,
+    @ColumnInfo(name = "matched_lyric")
+    val matchedLyric: String?,
+    @ColumnInfo(name = "matched_translated_lyric")
+    val matchedTranslatedLyric: String?,
+    @ColumnInfo(name = "matched_lyric_source")
+    val matchedLyricSource: String?,
+    @ColumnInfo(name = "matched_song_id")
+    val matchedSongId: String?,
+    @ColumnInfo(name = "user_lyric_offset_ms")
+    val userLyricOffsetMs: Long,
+    @ColumnInfo(name = "custom_cover_url")
+    val customCoverUrl: String?,
+    @ColumnInfo(name = "custom_name")
+    val customName: String?,
+    @ColumnInfo(name = "custom_artist")
+    val customArtist: String?,
+    @ColumnInfo(name = "original_name")
+    val originalName: String?,
+    @ColumnInfo(name = "original_artist")
+    val originalArtist: String?,
+    @ColumnInfo(name = "original_cover_url")
+    val originalCoverUrl: String?,
+    @ColumnInfo(name = "original_lyric")
+    val originalLyric: String?,
+    @ColumnInfo(name = "original_translated_lyric")
+    val originalTranslatedLyric: String?,
+    @ColumnInfo(name = "local_file_name")
+    val localFileName: String?,
+    @ColumnInfo(name = "local_file_path")
+    val localFilePath: String?,
+    @ColumnInfo(name = "channel_id")
+    val channelId: String?,
+    @ColumnInfo(name = "audio_id")
+    val audioId: String?,
+    @ColumnInfo(name = "sub_audio_id")
+    val subAudioId: String?,
+    @ColumnInfo(name = "playlist_context_id")
+    val playlistContextId: String?,
+    @ColumnInfo(name = "source_stable_key")
+    val sourceStableKey: String?,
+    @ColumnInfo(name = "added_at")
+    val addedAt: Long,
+    @ColumnInfo(name = "structured_schema_version")
+    val structuredSchemaVersion: Int
+)
+
+@Entity(
+    tableName = "favorite_playlist_song_netease_artist",
+    primaryKeys = ["playlist_id", "source", "display_position", "artist_position"],
+    foreignKeys = [
+        ForeignKey(
+            entity = FavoritePlaylistSongEntity::class,
+            parentColumns = ["playlist_id", "source", "display_position"],
+            childColumns = ["playlist_id", "source", "display_position"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(
+            value = ["playlist_id", "source", "display_position"],
+            name = "index_favorite_playlist_song_artist_song"
+        )
+    ]
+)
+internal data class FavoritePlaylistSongNeteaseArtistEntity(
+    @ColumnInfo(name = "playlist_id")
+    val playlistId: Long,
+    val source: String,
+    @ColumnInfo(name = "display_position")
+    val displayPosition: Int,
+    @ColumnInfo(name = "artist_position")
+    val artistPosition: Int,
+    @ColumnInfo(name = "artist_id")
+    val artistId: Long,
+    @ColumnInfo(name = "artist_name")
+    val artistName: String
 )

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/FavoritePlaylistEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/FavoritePlaylistEntities.kt
@@ -1,0 +1,75 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+@Entity(
+    tableName = "favorite_playlist",
+    primaryKeys = ["playlist_id", "source"],
+    indices = [
+        Index(
+            value = ["sort_order", "modified_at"],
+            orders = [Index.Order.DESC, Index.Order.DESC],
+            name = "index_favorite_playlist_sort"
+        ),
+        Index(
+            value = ["is_deleted", "sort_order"],
+            orders = [Index.Order.ASC, Index.Order.DESC],
+            name = "index_favorite_playlist_visibility"
+        )
+    ]
+)
+internal data class FavoritePlaylistEntity(
+    @ColumnInfo(name = "playlist_id")
+    val playlistId: Long,
+    val source: String,
+    val name: String,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "track_count")
+    val trackCount: Int,
+    @ColumnInfo(name = "browse_id")
+    val browseId: String?,
+    @ColumnInfo(name = "remote_playlist_id")
+    val remotePlaylistId: String?,
+    val subtitle: String?,
+    @ColumnInfo(name = "added_time")
+    val addedTime: Long,
+    @ColumnInfo(name = "sort_order")
+    val sortOrder: Long,
+    @ColumnInfo(name = "modified_at")
+    val modifiedAt: Long,
+    @ColumnInfo(name = "is_deleted")
+    val isDeleted: Boolean
+)
+
+@Entity(
+    tableName = "favorite_playlist_song",
+    primaryKeys = ["playlist_id", "source", "display_position"],
+    foreignKeys = [
+        ForeignKey(
+            entity = FavoritePlaylistEntity::class,
+            parentColumns = ["playlist_id", "source"],
+            childColumns = ["playlist_id", "source"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(
+            value = ["playlist_id", "source", "display_position"],
+            orders = [Index.Order.ASC, Index.Order.ASC, Index.Order.ASC],
+            name = "index_favorite_playlist_song_order"
+        )
+    ]
+)
+internal data class FavoritePlaylistSongEntity(
+    @ColumnInfo(name = "playlist_id")
+    val playlistId: Long,
+    val source: String,
+    @ColumnInfo(name = "display_position")
+    val displayPosition: Int,
+    @ColumnInfo(name = "song_payload_json")
+    val songPayloadJson: String
+)

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/LocalPlaylistEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/LocalPlaylistEntities.kt
@@ -1,0 +1,187 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+internal const val LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION = 1
+
+@Entity(
+    tableName = "local_playlist",
+    indices = [
+        Index(
+            value = ["display_position"],
+            orders = [Index.Order.ASC],
+            name = "index_local_playlist_display_position"
+        ),
+        Index(
+            value = ["modified_at"],
+            orders = [Index.Order.DESC],
+            name = "index_local_playlist_modified_at"
+        )
+    ]
+)
+internal data class LocalPlaylistEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "playlist_id")
+    val playlistId: Long,
+    val name: String,
+    @ColumnInfo(name = "display_position")
+    val displayPosition: Int,
+    @ColumnInfo(name = "custom_cover_url")
+    val customCoverUrl: String?,
+    @ColumnInfo(name = "modified_at")
+    val modifiedAt: Long,
+    @ColumnInfo(name = "song_order_version")
+    val songOrderVersion: Int,
+    @ColumnInfo(name = "is_system")
+    val isSystem: Boolean
+)
+
+@Entity(
+    tableName = "track",
+    indices = [
+        Index(
+            value = ["identity_id", "identity_album", "identity_media_uri"],
+            name = "index_track_identity_parts"
+        ),
+        Index(value = ["name"], name = "index_track_name"),
+        Index(value = ["artist"], name = "index_track_artist")
+    ]
+)
+internal data class TrackEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "identity_key")
+    val identityKey: String,
+    @ColumnInfo(name = "identity_id")
+    val identityId: Long,
+    @ColumnInfo(name = "identity_album")
+    val identityAlbum: String,
+    @ColumnInfo(name = "identity_media_uri")
+    val identityMediaUri: String?,
+    @ColumnInfo(name = "song_id")
+    val songId: Long,
+    val name: String,
+    val artist: String,
+    val album: String,
+    @ColumnInfo(name = "album_id")
+    val albumId: Long,
+    @ColumnInfo(name = "duration_ms")
+    val durationMs: Long,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "media_uri")
+    val mediaUri: String?,
+    @ColumnInfo(name = "channel_id")
+    val channelId: String?,
+    @ColumnInfo(name = "audio_id")
+    val audioId: String?,
+    @ColumnInfo(name = "sub_audio_id")
+    val subAudioId: String?,
+    @ColumnInfo(name = "source_stable_key")
+    val sourceStableKey: String?,
+    @ColumnInfo(name = "local_file_name")
+    val localFileName: String?,
+    @ColumnInfo(name = "local_file_path")
+    val localFilePath: String?,
+    @ColumnInfo(name = "payload_schema_version")
+    val payloadSchemaVersion: Int,
+    @ColumnInfo(name = "durable_payload_json")
+    val durablePayloadJson: String
+)
+
+@Entity(
+    tableName = "playlist_member",
+    primaryKeys = ["playlist_id", "identity_key"],
+    foreignKeys = [
+        ForeignKey(
+            entity = LocalPlaylistEntity::class,
+            parentColumns = ["playlist_id"],
+            childColumns = ["playlist_id"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = TrackEntity::class,
+            parentColumns = ["identity_key"],
+            childColumns = ["identity_key"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(
+            value = ["playlist_id", "display_position"],
+            orders = [Index.Order.ASC, Index.Order.ASC],
+            name = "index_playlist_member_display_order"
+        ),
+        Index(
+            value = ["playlist_id", "added_at", "order_tie_break"],
+            orders = [Index.Order.ASC, Index.Order.DESC, Index.Order.ASC],
+            name = "index_playlist_member_added_order"
+        ),
+        Index(value = ["identity_key"], name = "index_playlist_member_identity_key")
+    ]
+)
+internal data class PlaylistMemberEntity(
+    @ColumnInfo(name = "playlist_id")
+    val playlistId: Long,
+    @ColumnInfo(name = "identity_key")
+    val identityKey: String,
+    @ColumnInfo(name = "display_position")
+    val displayPosition: Int,
+    @ColumnInfo(name = "added_at")
+    val addedAt: Long,
+    @ColumnInfo(name = "order_tie_break")
+    val orderTieBreak: Int,
+    @ColumnInfo(name = "playlist_context_id")
+    val playlistContextId: String?,
+    @ColumnInfo(name = "member_payload_schema_version")
+    val memberPayloadSchemaVersion: Int,
+    @ColumnInfo(name = "member_payload_json")
+    val memberPayloadJson: String
+)
+
+@Entity(
+    tableName = "playlist_member_token",
+    primaryKeys = ["playlist_id", "identity_key", "device_id", "counter"],
+    foreignKeys = [
+        ForeignKey(
+            entity = PlaylistMemberEntity::class,
+            parentColumns = ["playlist_id", "identity_key"],
+            childColumns = ["playlist_id", "identity_key"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(
+            value = ["playlist_id", "identity_key"],
+            name = "index_playlist_member_token_member"
+        )
+    ]
+)
+internal data class PlaylistMemberTokenEntity(
+    @ColumnInfo(name = "playlist_id")
+    val playlistId: Long,
+    @ColumnInfo(name = "identity_key")
+    val identityKey: String,
+    @ColumnInfo(name = "device_id")
+    val deviceId: String,
+    val counter: Long,
+    @ColumnInfo(name = "token_index")
+    val tokenIndex: Int
+)
+
+internal data class LocalPlaylistSummaryProjection(
+    @ColumnInfo(name = "playlist_id")
+    val playlistId: Long,
+    val name: String,
+    @ColumnInfo(name = "custom_cover_url")
+    val customCoverUrl: String?,
+    @ColumnInfo(name = "song_count")
+    val songCount: Int,
+    @ColumnInfo(name = "modified_at")
+    val modifiedAt: Long,
+    @ColumnInfo(name = "song_order_version")
+    val songOrderVersion: Int
+)

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/LocalPlaylistEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/LocalPlaylistEntities.kt
@@ -6,7 +6,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
-internal const val LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION = 1
+internal const val LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION = 2
 
 @Entity(
     tableName = "local_playlist",
@@ -74,6 +74,32 @@ internal data class TrackEntity(
     val coverUrl: String?,
     @ColumnInfo(name = "media_uri")
     val mediaUri: String?,
+    @ColumnInfo(name = "matched_lyric")
+    val matchedLyric: String?,
+    @ColumnInfo(name = "matched_translated_lyric")
+    val matchedTranslatedLyric: String?,
+    @ColumnInfo(name = "matched_lyric_source")
+    val matchedLyricSource: String?,
+    @ColumnInfo(name = "matched_song_id")
+    val matchedSongId: String?,
+    @ColumnInfo(name = "user_lyric_offset_ms")
+    val userLyricOffsetMs: Long,
+    @ColumnInfo(name = "custom_cover_url")
+    val customCoverUrl: String?,
+    @ColumnInfo(name = "custom_name")
+    val customName: String?,
+    @ColumnInfo(name = "custom_artist")
+    val customArtist: String?,
+    @ColumnInfo(name = "original_name")
+    val originalName: String?,
+    @ColumnInfo(name = "original_artist")
+    val originalArtist: String?,
+    @ColumnInfo(name = "original_cover_url")
+    val originalCoverUrl: String?,
+    @ColumnInfo(name = "original_lyric")
+    val originalLyric: String?,
+    @ColumnInfo(name = "original_translated_lyric")
+    val originalTranslatedLyric: String?,
     @ColumnInfo(name = "channel_id")
     val channelId: String?,
     @ColumnInfo(name = "audio_id")
@@ -86,10 +112,8 @@ internal data class TrackEntity(
     val localFileName: String?,
     @ColumnInfo(name = "local_file_path")
     val localFilePath: String?,
-    @ColumnInfo(name = "payload_schema_version")
-    val payloadSchemaVersion: Int,
-    @ColumnInfo(name = "durable_payload_json")
-    val durablePayloadJson: String
+    @ColumnInfo(name = "structured_schema_version")
+    val structuredSchemaVersion: Int
 )
 
 @Entity(
@@ -136,10 +160,59 @@ internal data class PlaylistMemberEntity(
     val orderTieBreak: Int,
     @ColumnInfo(name = "playlist_context_id")
     val playlistContextId: String?,
-    @ColumnInfo(name = "member_payload_schema_version")
-    val memberPayloadSchemaVersion: Int,
-    @ColumnInfo(name = "member_payload_json")
-    val memberPayloadJson: String
+    @ColumnInfo(name = "song_id")
+    val songId: Long,
+    val name: String,
+    val artist: String,
+    val album: String,
+    @ColumnInfo(name = "album_id")
+    val albumId: Long,
+    @ColumnInfo(name = "duration_ms")
+    val durationMs: Long,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "media_uri")
+    val mediaUri: String?,
+    @ColumnInfo(name = "matched_lyric")
+    val matchedLyric: String?,
+    @ColumnInfo(name = "matched_translated_lyric")
+    val matchedTranslatedLyric: String?,
+    @ColumnInfo(name = "matched_lyric_source")
+    val matchedLyricSource: String?,
+    @ColumnInfo(name = "matched_song_id")
+    val matchedSongId: String?,
+    @ColumnInfo(name = "user_lyric_offset_ms")
+    val userLyricOffsetMs: Long,
+    @ColumnInfo(name = "custom_cover_url")
+    val customCoverUrl: String?,
+    @ColumnInfo(name = "custom_name")
+    val customName: String?,
+    @ColumnInfo(name = "custom_artist")
+    val customArtist: String?,
+    @ColumnInfo(name = "original_name")
+    val originalName: String?,
+    @ColumnInfo(name = "original_artist")
+    val originalArtist: String?,
+    @ColumnInfo(name = "original_cover_url")
+    val originalCoverUrl: String?,
+    @ColumnInfo(name = "original_lyric")
+    val originalLyric: String?,
+    @ColumnInfo(name = "original_translated_lyric")
+    val originalTranslatedLyric: String?,
+    @ColumnInfo(name = "local_file_name")
+    val localFileName: String?,
+    @ColumnInfo(name = "local_file_path")
+    val localFilePath: String?,
+    @ColumnInfo(name = "channel_id")
+    val channelId: String?,
+    @ColumnInfo(name = "audio_id")
+    val audioId: String?,
+    @ColumnInfo(name = "sub_audio_id")
+    val subAudioId: String?,
+    @ColumnInfo(name = "source_stable_key")
+    val sourceStableKey: String?,
+    @ColumnInfo(name = "structured_schema_version")
+    val structuredSchemaVersion: Int
 )
 
 @Entity(

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/LocalPlaylistPlaybackEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/LocalPlaylistPlaybackEntities.kt
@@ -1,0 +1,140 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import moe.ouom.neriplayer.data.playlist.usage.LocalPlaylistPlayBucket
+import moe.ouom.neriplayer.data.playlist.usage.LocalPlaylistPlaybackStat
+import moe.ouom.neriplayer.data.sync.model.SyncPlaybackCounterShard
+
+@Entity(
+    tableName = "local_playlist_playback_stat",
+    indices = [
+        Index(
+            value = ["last_played_at"],
+            orders = [Index.Order.DESC],
+            name = "index_local_playlist_playback_stat_last_played"
+        )
+    ]
+)
+internal data class LocalPlaylistPlaybackStatEntity(
+    @androidx.room.PrimaryKey
+    @ColumnInfo(name = "playlist_id")
+    val playlistId: Long,
+    @ColumnInfo(name = "total_play_count")
+    val totalPlayCount: Long,
+    @ColumnInfo(name = "first_played_at")
+    val firstPlayedAt: Long,
+    @ColumnInfo(name = "last_played_at")
+    val lastPlayedAt: Long,
+    @ColumnInfo(name = "counter_base_play_count")
+    val counterBasePlayCount: Long
+)
+
+@Entity(
+    tableName = "local_playlist_playback_bucket",
+    primaryKeys = ["playlist_id", "day_start_at"],
+    foreignKeys = [
+        ForeignKey(
+            entity = LocalPlaylistPlaybackStatEntity::class,
+            parentColumns = ["playlist_id"],
+            childColumns = ["playlist_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(
+            value = ["playlist_id", "day_start_at"],
+            orders = [Index.Order.ASC, Index.Order.ASC],
+            name = "index_local_playlist_playback_bucket_day"
+        )
+    ]
+)
+internal data class LocalPlaylistPlaybackBucketEntity(
+    @ColumnInfo(name = "playlist_id")
+    val playlistId: Long,
+    @ColumnInfo(name = "day_start_at")
+    val dayStartAt: Long,
+    @ColumnInfo(name = "play_count")
+    val playCount: Long,
+    @ColumnInfo(name = "first_played_at")
+    val firstPlayedAt: Long,
+    @ColumnInfo(name = "last_played_at")
+    val lastPlayedAt: Long,
+    @ColumnInfo(name = "counter_base_play_count")
+    val counterBasePlayCount: Long
+)
+
+@Entity(
+    tableName = "local_playlist_playback_counter_shard",
+    primaryKeys = ["playlist_id", "day_start_at", "device_id", "epoch_started_at"],
+    foreignKeys = [
+        ForeignKey(
+            entity = LocalPlaylistPlaybackStatEntity::class,
+            parentColumns = ["playlist_id"],
+            childColumns = ["playlist_id"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(
+            value = ["playlist_id", "day_start_at"],
+            name = "index_local_playlist_playback_counter_scope"
+        )
+    ]
+)
+internal data class LocalPlaylistPlaybackCounterShardEntity(
+    @ColumnInfo(name = "playlist_id")
+    val playlistId: Long,
+    @ColumnInfo(name = "day_start_at")
+    val dayStartAt: Long,
+    @ColumnInfo(name = "device_id")
+    val deviceId: String,
+    @ColumnInfo(name = "epoch_started_at")
+    val epochStartedAt: Long,
+    @ColumnInfo(name = "play_count")
+    val playCount: Int,
+    @ColumnInfo(name = "first_played_at")
+    val firstPlayedAt: Long,
+    @ColumnInfo(name = "last_played_at")
+    val lastPlayedAt: Long
+)
+
+internal fun LocalPlaylistPlaybackStat.toEntity(): LocalPlaylistPlaybackStatEntity {
+    return LocalPlaylistPlaybackStatEntity(
+        playlistId = playlistId,
+        totalPlayCount = totalPlayCount,
+        firstPlayedAt = firstPlayedAt,
+        lastPlayedAt = lastPlayedAt,
+        counterBasePlayCount = counterBasePlayCount
+    )
+}
+
+internal fun LocalPlaylistPlayBucket.toEntity(
+    playlistId: Long
+): LocalPlaylistPlaybackBucketEntity {
+    return LocalPlaylistPlaybackBucketEntity(
+        playlistId = playlistId,
+        dayStartAt = dayStartAt,
+        playCount = playCount,
+        firstPlayedAt = firstPlayedAt,
+        lastPlayedAt = lastPlayedAt,
+        counterBasePlayCount = counterBasePlayCount
+    )
+}
+
+internal fun SyncPlaybackCounterShard.toEntity(
+    playlistId: Long,
+    dayStartAt: Long
+): LocalPlaylistPlaybackCounterShardEntity {
+    return LocalPlaylistPlaybackCounterShardEntity(
+        playlistId = playlistId,
+        dayStartAt = dayStartAt,
+        deviceId = deviceId,
+        epochStartedAt = epochStartedAt,
+        playCount = playCount,
+        firstPlayedAt = firstPlayedAt,
+        lastPlayedAt = lastPlayedAt
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/LocalPlaylistSongArtistEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/LocalPlaylistSongArtistEntities.kt
@@ -1,0 +1,36 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+@Entity(
+    tableName = "playlist_member_netease_artist",
+    primaryKeys = ["playlist_id", "identity_key", "artist_position"],
+    foreignKeys = [
+        ForeignKey(
+            entity = PlaylistMemberEntity::class,
+            parentColumns = ["playlist_id", "identity_key"],
+            childColumns = ["playlist_id", "identity_key"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(
+            value = ["playlist_id", "identity_key"],
+            name = "index_playlist_member_artist_member"
+        )
+    ]
+)
+internal data class PlaylistMemberNeteaseArtistEntity(
+    @androidx.room.ColumnInfo(name = "playlist_id")
+    val playlistId: Long,
+    @androidx.room.ColumnInfo(name = "identity_key")
+    val identityKey: String,
+    @androidx.room.ColumnInfo(name = "artist_position")
+    val artistPosition: Int,
+    @androidx.room.ColumnInfo(name = "artist_id")
+    val artistId: Long,
+    @androidx.room.ColumnInfo(name = "artist_name")
+    val artistName: String
+)

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/PlatformPlaylistCacheEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/PlatformPlaylistCacheEntities.kt
@@ -1,0 +1,130 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+@Entity(
+    tableName = "platform_playlist_cache",
+    primaryKeys = ["platform", "cache_key"],
+    indices = [
+        Index(
+            value = ["platform", "source_id"],
+            name = "index_platform_playlist_cache_source_id"
+        ),
+        Index(
+            value = ["platform", "saved_at_ms"],
+            name = "index_platform_playlist_cache_saved_at"
+        )
+    ]
+)
+internal data class PlatformPlaylistCacheEntity(
+    val platform: String,
+    @ColumnInfo(name = "cache_key")
+    val cacheKey: String,
+    @ColumnInfo(name = "source_id")
+    val sourceId: Long?,
+    @ColumnInfo(name = "alternate_key")
+    val alternateKey: String?,
+    val kind: String?,
+    val title: String?,
+    val subtitle: String?,
+    @ColumnInfo(name = "creator_name")
+    val creatorName: String?,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "play_count")
+    val playCount: Long?,
+    @ColumnInfo(name = "track_count")
+    val trackCount: Int,
+    @ColumnInfo(name = "total_count")
+    val totalCount: Int,
+    @ColumnInfo(name = "signature_primary")
+    val signaturePrimary: String?,
+    @ColumnInfo(name = "signature_secondary")
+    val signatureSecondary: String?,
+    @ColumnInfo(name = "has_more")
+    val hasMore: Boolean?,
+    @ColumnInfo(name = "saved_at_ms")
+    val savedAtMs: Long
+)
+
+@Entity(
+    tableName = "platform_playlist_cache_track",
+    primaryKeys = ["platform", "cache_key", "position"],
+    foreignKeys = [
+        ForeignKey(
+            entity = PlatformPlaylistCacheEntity::class,
+            parentColumns = ["platform", "cache_key"],
+            childColumns = ["platform", "cache_key"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(
+            value = ["platform", "cache_key", "item_id"],
+            name = "index_platform_playlist_cache_track_item_id"
+        ),
+        Index(
+            value = ["platform", "cache_key", "item_key"],
+            name = "index_platform_playlist_cache_track_item_key"
+        )
+    ]
+)
+internal data class PlatformPlaylistCacheTrackEntity(
+    val platform: String,
+    @ColumnInfo(name = "cache_key")
+    val cacheKey: String,
+    val position: Int,
+    @ColumnInfo(name = "item_id")
+    val itemId: Long?,
+    @ColumnInfo(name = "item_key")
+    val itemKey: String?,
+    val name: String,
+    val artist: String,
+    val album: String,
+    @ColumnInfo(name = "album_id")
+    val albumId: Long?,
+    @ColumnInfo(name = "duration_ms")
+    val durationMs: Long,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "audio_id")
+    val audioId: String?,
+    @ColumnInfo(name = "uploader_mid")
+    val uploaderMid: Long?,
+    @ColumnInfo(name = "added_at")
+    val addedAt: Long
+)
+
+@Entity(
+    tableName = "platform_playlist_cache_track_artist",
+    primaryKeys = ["platform", "cache_key", "track_position", "artist_position"],
+    foreignKeys = [
+        ForeignKey(
+            entity = PlatformPlaylistCacheTrackEntity::class,
+            parentColumns = ["platform", "cache_key", "position"],
+            childColumns = ["platform", "cache_key", "track_position"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(
+            value = ["platform", "cache_key", "track_position"],
+            name = "index_platform_playlist_cache_artist_track"
+        )
+    ]
+)
+internal data class PlatformPlaylistCacheTrackArtistEntity(
+    val platform: String,
+    @ColumnInfo(name = "cache_key")
+    val cacheKey: String,
+    @ColumnInfo(name = "track_position")
+    val trackPosition: Int,
+    @ColumnInfo(name = "artist_position")
+    val artistPosition: Int,
+    @ColumnInfo(name = "artist_id")
+    val artistId: Long,
+    val name: String
+)

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/PlayHistoryEntity.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/PlayHistoryEntity.kt
@@ -1,0 +1,123 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import moe.ouom.neriplayer.data.history.PlayedEntry
+import moe.ouom.neriplayer.data.model.SongIdentity
+import moe.ouom.neriplayer.data.model.stableKey
+
+@Entity(
+    tableName = "play_history",
+    indices = [
+        Index(
+            value = ["played_at"],
+            orders = [Index.Order.DESC],
+            name = "index_play_history_played_at"
+        ),
+        Index(
+            value = ["identity_id", "identity_album", "identity_media_uri"],
+            name = "index_play_history_identity_parts"
+        )
+    ]
+)
+internal data class PlayHistoryEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "identity_key")
+    val identityKey: String,
+    @ColumnInfo(name = "identity_id")
+    val identityId: Long,
+    @ColumnInfo(name = "identity_album")
+    val identityAlbum: String,
+    @ColumnInfo(name = "identity_media_uri")
+    val identityMediaUri: String?,
+    val id: Long,
+    val name: String,
+    val artist: String,
+    val album: String,
+    @ColumnInfo(name = "album_id")
+    val albumId: Long,
+    @ColumnInfo(name = "duration_ms")
+    val durationMs: Long,
+    @ColumnInfo(name = "resume_position_ms")
+    val resumePositionMs: Long,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "media_uri")
+    val mediaUri: String?,
+    @ColumnInfo(name = "matched_lyric")
+    val matchedLyric: String?,
+    @ColumnInfo(name = "matched_translated_lyric")
+    val matchedTranslatedLyric: String?,
+    @ColumnInfo(name = "custom_cover_url")
+    val customCoverUrl: String?,
+    @ColumnInfo(name = "custom_name")
+    val customName: String?,
+    @ColumnInfo(name = "custom_artist")
+    val customArtist: String?,
+    @ColumnInfo(name = "original_name")
+    val originalName: String?,
+    @ColumnInfo(name = "original_artist")
+    val originalArtist: String?,
+    @ColumnInfo(name = "original_cover_url")
+    val originalCoverUrl: String?,
+    @ColumnInfo(name = "original_lyric")
+    val originalLyric: String?,
+    @ColumnInfo(name = "original_translated_lyric")
+    val originalTranslatedLyric: String?,
+    @ColumnInfo(name = "local_file_name")
+    val localFileName: String?,
+    @ColumnInfo(name = "local_file_path")
+    val localFilePath: String?,
+    @ColumnInfo(name = "channel_id")
+    val channelId: String?,
+    @ColumnInfo(name = "audio_id")
+    val audioId: String?,
+    @ColumnInfo(name = "sub_audio_id")
+    val subAudioId: String?,
+    @ColumnInfo(name = "source_stable_key")
+    val sourceStableKey: String?,
+    @ColumnInfo(name = "played_at")
+    val playedAt: Long
+)
+
+internal fun PlayedEntry.toEntity(): PlayHistoryEntity {
+    val identity = SongIdentity(
+        id = id,
+        album = album,
+        mediaUri = localFilePath ?: mediaUri
+    )
+    return PlayHistoryEntity(
+        identityKey = identity.stableKey(),
+        identityId = identity.id,
+        identityAlbum = identity.album,
+        identityMediaUri = identity.mediaUri,
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        albumId = albumId,
+        durationMs = durationMs,
+        resumePositionMs = resumePositionMs,
+        coverUrl = coverUrl,
+        mediaUri = mediaUri,
+        matchedLyric = matchedLyric,
+        matchedTranslatedLyric = matchedTranslatedLyric,
+        customCoverUrl = customCoverUrl,
+        customName = customName,
+        customArtist = customArtist,
+        originalName = originalName,
+        originalArtist = originalArtist,
+        originalCoverUrl = originalCoverUrl,
+        originalLyric = originalLyric,
+        originalTranslatedLyric = originalTranslatedLyric,
+        localFileName = localFileName,
+        localFilePath = localFilePath,
+        channelId = channelId,
+        audioId = audioId,
+        subAudioId = subAudioId,
+        sourceStableKey = sourceStableKey,
+        playedAt = playedAt
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/PlaybackQueueEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/PlaybackQueueEntities.kt
@@ -1,0 +1,95 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+internal const val PLAYBACK_QUEUE_MAIN = "main"
+internal const val PLAYBACK_QUEUE_SHUFFLE_RESTORE = "shuffle_restore"
+internal const val PLAYBACK_QUEUE_STATE_ID = 1
+
+@Entity(
+    tableName = "playback_queue_state"
+)
+internal data class PlaybackQueueStateEntity(
+    @PrimaryKey
+    val id: Int = PLAYBACK_QUEUE_STATE_ID,
+    @ColumnInfo(name = "current_index")
+    val currentIndex: Int,
+    @ColumnInfo(name = "media_url")
+    val mediaUrl: String?,
+    @ColumnInfo(name = "position_ms")
+    val positionMs: Long,
+    @ColumnInfo(name = "should_resume_playback")
+    val shouldResumePlayback: Boolean,
+    @ColumnInfo(name = "repeat_mode")
+    val repeatMode: Int?,
+    @ColumnInfo(name = "shuffle_enabled")
+    val shuffleEnabled: Boolean?,
+    @ColumnInfo(name = "shuffle_restore_index")
+    val shuffleRestoreIndex: Int?,
+    @ColumnInfo(name = "updated_at")
+    val updatedAt: Long
+)
+
+@Entity(
+    tableName = "playback_queue_song",
+    primaryKeys = ["queue_id", "position"]
+)
+internal data class PlaybackQueueSongEntity(
+    @ColumnInfo(name = "queue_id")
+    val queueId: String,
+    val position: Int,
+    val id: Long,
+    val name: String,
+    val artist: String,
+    val album: String,
+    @ColumnInfo(name = "album_id")
+    val albumId: Long,
+    @ColumnInfo(name = "duration_ms")
+    val durationMs: Long,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "media_uri")
+    val mediaUri: String?,
+    @ColumnInfo(name = "matched_lyric")
+    val matchedLyric: String?,
+    @ColumnInfo(name = "matched_translated_lyric")
+    val matchedTranslatedLyric: String?,
+    @ColumnInfo(name = "matched_lyric_source")
+    val matchedLyricSource: String?,
+    @ColumnInfo(name = "matched_song_id")
+    val matchedSongId: String?,
+    @ColumnInfo(name = "user_lyric_offset_ms")
+    val userLyricOffsetMs: Long,
+    @ColumnInfo(name = "custom_cover_url")
+    val customCoverUrl: String?,
+    @ColumnInfo(name = "custom_name")
+    val customName: String?,
+    @ColumnInfo(name = "custom_artist")
+    val customArtist: String?,
+    @ColumnInfo(name = "original_name")
+    val originalName: String?,
+    @ColumnInfo(name = "original_artist")
+    val originalArtist: String?,
+    @ColumnInfo(name = "original_cover_url")
+    val originalCoverUrl: String?,
+    @ColumnInfo(name = "original_lyric")
+    val originalLyric: String?,
+    @ColumnInfo(name = "original_translated_lyric")
+    val originalTranslatedLyric: String?,
+    @ColumnInfo(name = "local_file_name")
+    val localFileName: String?,
+    @ColumnInfo(name = "local_file_path")
+    val localFilePath: String?,
+    @ColumnInfo(name = "channel_id")
+    val channelId: String?,
+    @ColumnInfo(name = "audio_id")
+    val audioId: String?,
+    @ColumnInfo(name = "sub_audio_id")
+    val subAudioId: String?,
+    @ColumnInfo(name = "playlist_context_id")
+    val playlistContextId: String?,
+    @ColumnInfo(name = "stream_url")
+    val streamUrl: String?
+)

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/PlaybackStatEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/PlaybackStatEntities.kt
@@ -1,0 +1,228 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import moe.ouom.neriplayer.data.stats.PlaybackStatBucket
+import moe.ouom.neriplayer.data.stats.TrackStat
+
+@Entity(
+    tableName = "playback_stat",
+    indices = [
+        Index(
+            value = ["last_played_at"],
+            orders = [Index.Order.DESC],
+            name = "index_playback_stat_last_played"
+        ),
+        Index(value = ["media_uri"], name = "index_playback_stat_media_uri")
+    ]
+)
+internal data class PlaybackStatEntity(
+    @androidx.room.PrimaryKey
+    @ColumnInfo(name = "identity_key")
+    val identityKey: String,
+    val id: Long,
+    val name: String,
+    val artist: String,
+    val album: String,
+    @ColumnInfo(name = "album_id")
+    val albumId: Long,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "duration_ms")
+    val durationMs: Long,
+    @ColumnInfo(name = "total_listen_ms")
+    val totalListenMs: Long,
+    @ColumnInfo(name = "play_count")
+    val playCount: Int,
+    @ColumnInfo(name = "last_played_at")
+    val lastPlayedAt: Long,
+    @ColumnInfo(name = "first_played_at")
+    val firstPlayedAt: Long,
+    @ColumnInfo(name = "media_uri")
+    val mediaUri: String?,
+    @ColumnInfo(name = "local_file_path")
+    val localFilePath: String?,
+    @ColumnInfo(name = "local_file_name")
+    val localFileName: String?,
+    @ColumnInfo(name = "custom_name")
+    val customName: String?,
+    @ColumnInfo(name = "custom_artist")
+    val customArtist: String?,
+    @ColumnInfo(name = "custom_cover_url")
+    val customCoverUrl: String?
+)
+
+@Entity(
+    tableName = "playback_stat_bucket",
+    primaryKeys = ["day_start_at", "identity_key"],
+    foreignKeys = [
+        ForeignKey(
+            entity = PlaybackStatEntity::class,
+            parentColumns = ["identity_key"],
+            childColumns = ["identity_key"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(
+            value = ["day_start_at", "identity_key"],
+            orders = [Index.Order.DESC, Index.Order.ASC],
+            name = "index_playback_stat_bucket_day"
+        ),
+        Index(value = ["identity_key"], name = "index_playback_stat_bucket_identity")
+    ]
+)
+internal data class PlaybackStatBucketEntity(
+    @ColumnInfo(name = "day_start_at")
+    val dayStartAt: Long,
+    @ColumnInfo(name = "identity_key")
+    val identityKey: String,
+    val id: Long,
+    val name: String,
+    val artist: String,
+    val album: String,
+    @ColumnInfo(name = "album_id")
+    val albumId: Long,
+    @ColumnInfo(name = "cover_url")
+    val coverUrl: String?,
+    @ColumnInfo(name = "duration_ms")
+    val durationMs: Long,
+    @ColumnInfo(name = "total_listen_ms")
+    val totalListenMs: Long,
+    @ColumnInfo(name = "play_count")
+    val playCount: Int,
+    @ColumnInfo(name = "last_played_at")
+    val lastPlayedAt: Long,
+    @ColumnInfo(name = "first_played_at")
+    val firstPlayedAt: Long,
+    @ColumnInfo(name = "media_uri")
+    val mediaUri: String?,
+    @ColumnInfo(name = "local_file_path")
+    val localFilePath: String?,
+    @ColumnInfo(name = "local_file_name")
+    val localFileName: String?,
+    @ColumnInfo(name = "custom_name")
+    val customName: String?,
+    @ColumnInfo(name = "custom_artist")
+    val customArtist: String?,
+    @ColumnInfo(name = "custom_cover_url")
+    val customCoverUrl: String?
+)
+
+@Entity(
+    tableName = "playback_stat_counter_shard",
+    primaryKeys = ["identity_key", "device_id", "epoch_started_at"],
+    foreignKeys = [
+        ForeignKey(
+            entity = PlaybackStatEntity::class,
+            parentColumns = ["identity_key"],
+            childColumns = ["identity_key"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(value = ["identity_key"], name = "index_playback_stat_counter_identity")
+    ]
+)
+internal data class PlaybackStatCounterShardEntity(
+    @ColumnInfo(name = "identity_key")
+    val identityKey: String,
+    @ColumnInfo(name = "device_id")
+    val deviceId: String,
+    @ColumnInfo(name = "epoch_started_at")
+    val epochStartedAt: Long,
+    @ColumnInfo(name = "total_listen_ms")
+    val totalListenMs: Long,
+    @ColumnInfo(name = "play_count")
+    val playCount: Int,
+    @ColumnInfo(name = "first_played_at")
+    val firstPlayedAt: Long,
+    @ColumnInfo(name = "last_played_at")
+    val lastPlayedAt: Long
+)
+
+@Entity(
+    tableName = "playback_stat_daily_counter_shard",
+    primaryKeys = ["day_start_at", "identity_key", "device_id", "epoch_started_at"],
+    foreignKeys = [
+        ForeignKey(
+            entity = PlaybackStatBucketEntity::class,
+            parentColumns = ["day_start_at", "identity_key"],
+            childColumns = ["day_start_at", "identity_key"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(
+            value = ["day_start_at", "identity_key"],
+            name = "index_playback_stat_daily_counter_scope"
+        )
+    ]
+)
+internal data class PlaybackStatDailyCounterShardEntity(
+    @ColumnInfo(name = "day_start_at")
+    val dayStartAt: Long,
+    @ColumnInfo(name = "identity_key")
+    val identityKey: String,
+    @ColumnInfo(name = "device_id")
+    val deviceId: String,
+    @ColumnInfo(name = "epoch_started_at")
+    val epochStartedAt: Long,
+    @ColumnInfo(name = "total_listen_ms")
+    val totalListenMs: Long,
+    @ColumnInfo(name = "play_count")
+    val playCount: Int,
+    @ColumnInfo(name = "first_played_at")
+    val firstPlayedAt: Long,
+    @ColumnInfo(name = "last_played_at")
+    val lastPlayedAt: Long
+)
+
+internal fun TrackStat.toEntity(): PlaybackStatEntity {
+    return PlaybackStatEntity(
+        identityKey = identityKey,
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        albumId = albumId,
+        coverUrl = coverUrl,
+        durationMs = durationMs,
+        totalListenMs = totalListenMs,
+        playCount = playCount,
+        lastPlayedAt = lastPlayedAt,
+        firstPlayedAt = firstPlayedAt,
+        mediaUri = mediaUri,
+        localFilePath = localFilePath,
+        localFileName = localFileName,
+        customName = customName,
+        customArtist = customArtist,
+        customCoverUrl = customCoverUrl
+    )
+}
+
+internal fun PlaybackStatBucket.toEntity(): PlaybackStatBucketEntity {
+    return PlaybackStatBucketEntity(
+        dayStartAt = dayStartAt,
+        identityKey = identityKey,
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        albumId = albumId,
+        coverUrl = coverUrl,
+        durationMs = durationMs,
+        totalListenMs = totalListenMs,
+        playCount = playCount,
+        lastPlayedAt = lastPlayedAt,
+        firstPlayedAt = firstPlayedAt,
+        mediaUri = mediaUri,
+        localFilePath = localFilePath,
+        localFileName = localFileName,
+        customName = customName,
+        customArtist = customArtist,
+        customCoverUrl = customCoverUrl
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/PlaylistUsageEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/PlaylistUsageEntities.kt
@@ -1,0 +1,111 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import moe.ouom.neriplayer.data.playlist.usage.UsageEntry
+import moe.ouom.neriplayer.data.playlist.usage.usageKey
+import moe.ouom.neriplayer.data.sync.model.SyncPlaybackCounterShard
+
+@Entity(
+    tableName = "playlist_usage",
+    indices = [
+        Index(
+            value = ["last_opened"],
+            orders = [Index.Order.DESC],
+            name = "index_playlist_usage_last_opened"
+        ),
+        Index(value = ["source", "playlist_id"], name = "index_playlist_usage_source_id")
+    ]
+)
+internal data class PlaylistUsageEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "usage_key")
+    val usageKey: String,
+    val id: Long,
+    val name: String,
+    @ColumnInfo(name = "pic_url")
+    val picUrl: String?,
+    @ColumnInfo(name = "track_count")
+    val trackCount: Int,
+    val source: String,
+    @ColumnInfo(name = "last_opened")
+    val lastOpened: Long,
+    @ColumnInfo(name = "open_count")
+    val openCount: Int,
+    @ColumnInfo(name = "first_opened")
+    val firstOpened: Long,
+    @ColumnInfo(name = "counter_base_open_count")
+    val counterBaseOpenCount: Long,
+    val fid: Long?,
+    val mid: Long?,
+    @ColumnInfo(name = "browse_id")
+    val browseId: String?,
+    @ColumnInfo(name = "playlist_id")
+    val playlistId: String?,
+    val subtype: String?,
+    val subtitle: String?
+)
+
+@Entity(
+    tableName = "playlist_usage_counter_shard",
+    primaryKeys = ["usage_key", "device_id", "epoch_started_at"],
+    foreignKeys = [
+        androidx.room.ForeignKey(
+            entity = PlaylistUsageEntity::class,
+            parentColumns = ["usage_key"],
+            childColumns = ["usage_key"],
+            onDelete = androidx.room.ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(value = ["usage_key"], name = "index_playlist_usage_counter_usage_key")
+    ]
+)
+internal data class PlaylistUsageCounterShardEntity(
+    @ColumnInfo(name = "usage_key")
+    val usageKey: String,
+    @ColumnInfo(name = "device_id")
+    val deviceId: String,
+    @ColumnInfo(name = "epoch_started_at")
+    val epochStartedAt: Long,
+    @ColumnInfo(name = "play_count")
+    val playCount: Int,
+    @ColumnInfo(name = "first_played_at")
+    val firstPlayedAt: Long,
+    @ColumnInfo(name = "last_played_at")
+    val lastPlayedAt: Long
+)
+
+internal fun UsageEntry.toEntity(): PlaylistUsageEntity {
+    return PlaylistUsageEntity(
+        usageKey = usageKey(),
+        id = id,
+        name = name,
+        picUrl = picUrl,
+        trackCount = trackCount,
+        source = source,
+        lastOpened = lastOpened,
+        openCount = openCount,
+        firstOpened = firstOpened,
+        counterBaseOpenCount = counterBaseOpenCount,
+        fid = fid,
+        mid = mid,
+        browseId = browseId,
+        playlistId = playlistId,
+        subtype = subtype,
+        subtitle = subtitle
+    )
+}
+
+internal fun SyncPlaybackCounterShard.toEntity(usageKey: String): PlaylistUsageCounterShardEntity {
+    return PlaylistUsageCounterShardEntity(
+        usageKey = usageKey,
+        deviceId = deviceId,
+        epochStartedAt = epochStartedAt,
+        playCount = playCount,
+        firstPlayedAt = firstPlayedAt,
+        lastPlayedAt = lastPlayedAt
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/SyncEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/SyncEntities.kt
@@ -1,0 +1,84 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+internal object SyncTransportId {
+    const val GITHUB = "github"
+    const val WEBDAV = "webdav"
+}
+
+internal object SyncOutboxStatus {
+    const val PENDING = "pending"
+    const val APPLIED_TO_SECURE_STORAGE = "applied_to_secure_storage"
+    const val DELIVERED = "delivered"
+    const val FAILED_RETRYABLE = "failed_retryable"
+    const val FAILED_PERMANENT = "failed_permanent"
+}
+
+@Entity(
+    tableName = "sync_outbox",
+    indices = [
+        Index(
+            value = ["operation_id"],
+            orders = [Index.Order.ASC],
+            unique = true,
+            name = "index_sync_outbox_operation_id"
+        ),
+        Index(
+            value = ["status", "sequence"],
+            orders = [Index.Order.ASC, Index.Order.ASC],
+            name = "index_sync_outbox_status_sequence"
+        )
+    ]
+)
+internal data class SyncOutboxEntity(
+    @PrimaryKey(autoGenerate = true)
+    val sequence: Long = 0L,
+    @ColumnInfo(name = "operation_id")
+    val operationId: String,
+    @ColumnInfo(name = "expected_domain_revision")
+    val expectedDomainRevision: Long,
+    @ColumnInfo(name = "payload_version")
+    val payloadVersion: Int,
+    @ColumnInfo(name = "mutation_payload_json")
+    val mutationPayloadJson: String,
+    val status: String = SyncOutboxStatus.PENDING,
+    @ColumnInfo(name = "attempt_count")
+    val attemptCount: Int = 0,
+    @ColumnInfo(name = "last_error_type")
+    val lastErrorType: String? = null,
+    @ColumnInfo(name = "created_at")
+    val createdAt: Long,
+    @ColumnInfo(name = "updated_at")
+    val updatedAt: Long = createdAt
+)
+
+@Entity(tableName = "sync_replica_checkpoint")
+internal data class SyncReplicaCheckpointEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "transport_id")
+    val transportId: String,
+    @ColumnInfo(name = "domain_revision")
+    val domainRevision: Long,
+    @ColumnInfo(name = "remote_version")
+    val remoteVersion: String?,
+    @ColumnInfo(name = "remote_fingerprint")
+    val remoteFingerprint: String?,
+    val status: String,
+    @ColumnInfo(name = "last_synced_at")
+    val lastSyncedAt: Long,
+    @ColumnInfo(name = "last_attempt_at")
+    val lastAttemptAt: Long
+)
+
+@Entity(tableName = "migration_metadata")
+internal data class MigrationMetadataEntity(
+    @PrimaryKey
+    val key: String,
+    val value: String?,
+    @ColumnInfo(name = "updated_at")
+    val updatedAt: Long
+)

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/TrafficStatsEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/TrafficStatsEntities.kt
@@ -1,0 +1,66 @@
+package moe.ouom.neriplayer.data.local.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import moe.ouom.neriplayer.data.traffic.TrafficStatsBucket
+
+@Entity(
+    tableName = "traffic_stats_bucket",
+    indices = [
+        Index(
+            value = ["day_start_at"],
+            orders = [Index.Order.DESC],
+            name = "index_traffic_stats_bucket_day"
+        )
+    ]
+)
+internal data class TrafficStatsBucketEntity(
+    @androidx.room.PrimaryKey
+    @ColumnInfo(name = "day_start_at")
+    val dayStartAt: Long,
+    @ColumnInfo(name = "wifi_bytes")
+    val wifiBytes: Long,
+    @ColumnInfo(name = "mobile_bytes")
+    val mobileBytes: Long,
+    @ColumnInfo(name = "roaming_bytes")
+    val roamingBytes: Long,
+    @ColumnInfo(name = "playback_network_bytes")
+    val playbackNetworkBytes: Long,
+    @ColumnInfo(name = "download_network_bytes")
+    val downloadNetworkBytes: Long,
+    @ColumnInfo(name = "cache_hit_bytes")
+    val cacheHitBytes: Long,
+    @ColumnInfo(name = "request_count")
+    val requestCount: Int,
+    @ColumnInfo(name = "cache_hit_count")
+    val cacheHitCount: Int
+)
+
+internal fun TrafficStatsBucket.toEntity(): TrafficStatsBucketEntity {
+    return TrafficStatsBucketEntity(
+        dayStartAt = dayStartAt,
+        wifiBytes = wifiBytes,
+        mobileBytes = mobileBytes,
+        roamingBytes = roamingBytes,
+        playbackNetworkBytes = playbackNetworkBytes,
+        downloadNetworkBytes = downloadNetworkBytes,
+        cacheHitBytes = cacheHitBytes,
+        requestCount = requestCount,
+        cacheHitCount = cacheHitCount
+    )
+}
+
+internal fun TrafficStatsBucketEntity.toDomain(): TrafficStatsBucket {
+    return TrafficStatsBucket(
+        dayStartAt = dayStartAt,
+        wifiBytes = wifiBytes,
+        mobileBytes = mobileBytes,
+        roamingBytes = roamingBytes,
+        playbackNetworkBytes = playbackNetworkBytes,
+        downloadNetworkBytes = downloadNetworkBytes,
+        cacheHitBytes = cacheHitBytes,
+        requestCount = requestCount,
+        cacheHitCount = cacheHitCount
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/BiliVideoSkipRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/BiliVideoSkipRoomStore.kt
@@ -16,6 +16,17 @@ internal data class BiliVideoSkipRoomSnapshot(
     val drafts: List<BiliVideoSkipDraft>
 )
 
+internal enum class BiliVideoSkipRoomImportStatus {
+    IMPORTED,
+    SKIPPED_ALREADY_PRIMARY
+}
+
+internal data class BiliVideoSkipRoomImportResult(
+    val status: BiliVideoSkipRoomImportStatus,
+    val ruleCount: Int,
+    val draftCount: Int
+)
+
 internal class BiliVideoSkipRoomStore(
     private val database: NeriUserDataDatabase
 ) {
@@ -59,10 +70,14 @@ internal class BiliVideoSkipRoomStore(
         rules: List<BiliVideoSkipRule>,
         drafts: List<BiliVideoSkipDraft>,
         now: Long = System.currentTimeMillis()
-    ) {
-        database.withTransaction {
+    ): BiliVideoSkipRoomImportResult {
+        return database.withTransaction {
             if (isRoomPrimary()) {
-                return@withTransaction
+                return@withTransaction BiliVideoSkipRoomImportResult(
+                    status = BiliVideoSkipRoomImportStatus.SKIPPED_ALREADY_PRIMARY,
+                    ruleCount = rules.size,
+                    draftCount = drafts.size
+                )
             }
             val dao = database.biliVideoSkipDao()
             dao.deleteIntervals()
@@ -78,6 +93,11 @@ internal class BiliVideoSkipRoomStore(
             )
             dao.insertDrafts(drafts.map(BiliVideoSkipDraft::toEntity))
             markRoomPrimary(now)
+            BiliVideoSkipRoomImportResult(
+                status = BiliVideoSkipRoomImportStatus.IMPORTED,
+                ruleCount = rules.size,
+                draftCount = drafts.size
+            )
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/BiliVideoSkipRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/BiliVideoSkipRoomStore.kt
@@ -55,6 +55,32 @@ internal class BiliVideoSkipRoomStore(
         }
     }
 
+    suspend fun importLegacyAndPromote(
+        rules: List<BiliVideoSkipRule>,
+        drafts: List<BiliVideoSkipDraft>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            if (isRoomPrimary()) {
+                return@withTransaction
+            }
+            val dao = database.biliVideoSkipDao()
+            dao.deleteIntervals()
+            dao.deleteRules()
+            dao.deleteDrafts()
+            dao.insertRules(rules.map(BiliVideoSkipRule::toEntity))
+            dao.insertIntervals(
+                rules.flatMap { rule ->
+                    rule.intervals.mapIndexed { position, interval ->
+                        interval.toEntity(rule.target, position)
+                    }
+                }
+            )
+            dao.insertDrafts(drafts.map(BiliVideoSkipDraft::toEntity))
+            markRoomPrimary(now)
+        }
+    }
+
     suspend fun replaceRules(
         rules: List<BiliVideoSkipRule>,
         now: Long = System.currentTimeMillis()

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/BiliVideoSkipRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/BiliVideoSkipRoomStore.kt
@@ -1,0 +1,172 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import androidx.room.withTransaction
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipDraftEntity
+import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipIntervalEntity
+import moe.ouom.neriplayer.data.local.database.entity.BiliVideoSkipRuleEntity
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+import moe.ouom.neriplayer.data.platform.bili.BiliVideoSkipDraft
+import moe.ouom.neriplayer.data.platform.bili.BiliVideoSkipInterval
+import moe.ouom.neriplayer.data.platform.bili.BiliVideoSkipRule
+import moe.ouom.neriplayer.data.platform.bili.BiliVideoSkipTarget
+
+internal data class BiliVideoSkipRoomSnapshot(
+    val rules: List<BiliVideoSkipRule>,
+    val drafts: List<BiliVideoSkipDraft>
+)
+
+internal class BiliVideoSkipRoomStore(
+    private val database: NeriUserDataDatabase
+) {
+    suspend fun isRoomPrimary(): Boolean {
+        return database.syncMetadataDao()
+            .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+            ?.value == ROOM_PRIMARY_STATE
+    }
+
+    suspend fun readIfRoomPrimary(): BiliVideoSkipRoomSnapshot? {
+        if (!isRoomPrimary()) {
+            return null
+        }
+        return readSnapshot()
+    }
+
+    suspend fun replaceAll(
+        rules: List<BiliVideoSkipRule>,
+        drafts: List<BiliVideoSkipDraft>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            val dao = database.biliVideoSkipDao()
+            dao.deleteIntervals()
+            dao.deleteRules()
+            dao.deleteDrafts()
+            dao.insertRules(rules.map(BiliVideoSkipRule::toEntity))
+            dao.insertIntervals(
+                rules.flatMap { rule ->
+                    rule.intervals.mapIndexed { position, interval ->
+                        interval.toEntity(rule.target, position)
+                    }
+                }
+            )
+            dao.insertDrafts(drafts.map(BiliVideoSkipDraft::toEntity))
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun replaceRules(
+        rules: List<BiliVideoSkipRule>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            val dao = database.biliVideoSkipDao()
+            dao.deleteIntervals()
+            dao.deleteRules()
+            dao.insertRules(rules.map(BiliVideoSkipRule::toEntity))
+            dao.insertIntervals(
+                rules.flatMap { rule ->
+                    rule.intervals.mapIndexed { position, interval ->
+                        interval.toEntity(rule.target, position)
+                    }
+                }
+            )
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun replaceDrafts(
+        drafts: List<BiliVideoSkipDraft>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            val dao = database.biliVideoSkipDao()
+            dao.deleteDrafts()
+            dao.insertDrafts(drafts.map(BiliVideoSkipDraft::toEntity))
+            markRoomPrimary(now)
+        }
+    }
+
+    private suspend fun readSnapshot(): BiliVideoSkipRoomSnapshot {
+        return database.withTransaction {
+            val dao = database.biliVideoSkipDao()
+            val intervalsByTarget = dao.getIntervals()
+                .groupBy { it.bvid to it.cid }
+                .mapValues { (_, intervals) ->
+                    intervals.sortedBy(BiliVideoSkipIntervalEntity::position)
+                        .map { interval ->
+                            BiliVideoSkipInterval(
+                                startMs = interval.startMs,
+                                endMs = interval.endMs
+                            )
+                        }
+                }
+            BiliVideoSkipRoomSnapshot(
+                rules = dao.getRules().map { rule ->
+                    BiliVideoSkipRule(
+                        target = BiliVideoSkipTarget(rule.bvid, rule.cid),
+                        intervals = intervalsByTarget[rule.bvid to rule.cid].orEmpty(),
+                        modifiedAt = rule.modifiedAt,
+                        isDeleted = rule.isDeleted
+                    )
+                },
+                drafts = dao.getDrafts().map { draft ->
+                    BiliVideoSkipDraft(
+                        target = BiliVideoSkipTarget(draft.bvid, draft.cid),
+                        startText = draft.startText,
+                        endText = draft.endText,
+                        modifiedAt = draft.modifiedAt
+                    )
+                }
+            )
+        }
+    }
+
+    private suspend fun markRoomPrimary(now: Long) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = CUTOVER_STATE_METADATA_KEY,
+                value = ROOM_PRIMARY_STATE,
+                updatedAt = now
+            )
+        )
+    }
+
+    companion object {
+        const val CUTOVER_STATE_METADATA_KEY = "bili_video_skip_cutover_state"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+    }
+}
+
+private fun BiliVideoSkipRule.toEntity(): BiliVideoSkipRuleEntity {
+    return BiliVideoSkipRuleEntity(
+        bvid = target.bvid,
+        cid = target.cid,
+        modifiedAt = modifiedAt,
+        isDeleted = isDeleted
+    )
+}
+
+private fun BiliVideoSkipInterval.toEntity(
+    target: BiliVideoSkipTarget,
+    position: Int
+): BiliVideoSkipIntervalEntity {
+    return BiliVideoSkipIntervalEntity(
+        bvid = target.bvid,
+        cid = target.cid,
+        position = position,
+        startMs = startMs,
+        endMs = endMs
+    )
+}
+
+private fun BiliVideoSkipDraft.toEntity(): BiliVideoSkipDraftEntity {
+    return BiliVideoSkipDraftEntity(
+        targetKey = target.stableKey(),
+        bvid = target.bvid,
+        cid = target.cid,
+        startText = startText,
+        endText = endText,
+        modifiedAt = modifiedAt
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/CoverUrlMappingRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/CoverUrlMappingRoomStore.kt
@@ -26,6 +26,12 @@ internal class CoverUrlMappingRoomStore(
         now: Long = System.currentTimeMillis()
     ) {
         database.withTransaction {
+            val cutoverState = database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value
+            if (isReadableRoomState(cutoverState)) {
+                return@withTransaction
+            }
             val dao = database.coverUrlMappingDao()
             dao.deleteAll()
             dao.upsert(mappings.toEntities(now))

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/CoverUrlMappingRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/CoverUrlMappingRoomStore.kt
@@ -1,0 +1,125 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import androidx.room.withTransaction
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.CoverUrlMappingEntity
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+
+internal class CoverUrlMappingRoomStore(
+    private val database: NeriUserDataDatabase
+) {
+    suspend fun readIfRoomPrimary(): Map<String, String>? {
+        val state = database.syncMetadataDao()
+            .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+            ?.value
+        if (!isReadableRoomState(state)) {
+            return null
+        }
+        return database.coverUrlMappingDao()
+            .getAll()
+            .associate { entity -> entity.localUrl to entity.networkUrl }
+    }
+
+    suspend fun importLegacyAndPromote(
+        mappings: Map<String, String>,
+        cleanupEligible: Boolean,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            val dao = database.coverUrlMappingDao()
+            dao.deleteAll()
+            dao.upsert(mappings.toEntities(now))
+            markRoomPrimary(cleanupEligible, now)
+        }
+    }
+
+    suspend fun upsert(
+        localUrl: String,
+        networkUrl: String,
+        cleanupEligible: Boolean,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            val currentState = database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value
+            database.coverUrlMappingDao().upsert(
+                CoverUrlMappingEntity(
+                    localUrl = localUrl,
+                    networkUrl = networkUrl,
+                    updatedAt = now
+                )
+            )
+            val shouldKeepBlocked = currentState == ROOM_PRIMARY_WITH_LEGACY_IMPORT_FAILURE_STATE
+            markRoomPrimary(
+                cleanupEligible = cleanupEligible && !shouldKeepBlocked,
+                now = now
+            )
+        }
+    }
+
+    suspend fun delete(
+        localUrls: Collection<String>,
+        cleanupEligible: Boolean,
+        now: Long = System.currentTimeMillis()
+    ) {
+        val normalizedUrls = localUrls.filter(String::isNotBlank)
+        if (normalizedUrls.isEmpty()) return
+        database.withTransaction {
+            val currentState = database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value
+            database.coverUrlMappingDao().delete(normalizedUrls)
+            val shouldKeepBlocked = currentState == ROOM_PRIMARY_WITH_LEGACY_IMPORT_FAILURE_STATE
+            markRoomPrimary(
+                cleanupEligible = cleanupEligible && !shouldKeepBlocked,
+                now = now
+            )
+        }
+    }
+
+    private suspend fun markRoomPrimary(cleanupEligible: Boolean, now: Long) {
+        val state = if (cleanupEligible) {
+            ROOM_PRIMARY_STATE
+        } else {
+            ROOM_PRIMARY_WITH_LEGACY_IMPORT_FAILURE_STATE
+        }
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(CUTOVER_STATE_METADATA_KEY, state, now)
+        )
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(IMPORT_SCHEMA_METADATA_KEY, "1", now)
+        )
+    }
+
+    private fun Map<String, String>.toEntities(now: Long): List<CoverUrlMappingEntity> {
+        return entries.map { (localUrl, networkUrl) ->
+            CoverUrlMappingEntity(
+                localUrl = localUrl,
+                networkUrl = networkUrl,
+                updatedAt = now
+            )
+        }
+    }
+
+    private fun metadata(key: String, value: String, now: Long): MigrationMetadataEntity {
+        return MigrationMetadataEntity(
+            key = key,
+            value = value,
+            updatedAt = now
+        )
+    }
+
+    private fun isReadableRoomState(state: String?): Boolean {
+        return state == ROOM_PRIMARY_STATE ||
+            state == ROOM_PRIMARY_WITH_LEGACY_IMPORT_FAILURE_STATE
+    }
+
+    companion object {
+        const val CUTOVER_STATE_METADATA_KEY = "cover_url_mapping_cutover_state"
+        const val IMPORT_SCHEMA_METADATA_KEY = "cover_url_mapping_import_schema"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+        const val ROOM_PRIMARY_WITH_LEGACY_IMPORT_FAILURE_STATE =
+            "room_primary_legacy_import_failed"
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/CoverUrlMappingRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/CoverUrlMappingRoomStore.kt
@@ -56,9 +56,8 @@ internal class CoverUrlMappingRoomStore(
                     updatedAt = now
                 )
             )
-            val shouldKeepBlocked = currentState == ROOM_PRIMARY_WITH_LEGACY_IMPORT_FAILURE_STATE
             markRoomPrimary(
-                cleanupEligible = cleanupEligible && !shouldKeepBlocked,
+                cleanupEligible = currentState == ROOM_PRIMARY_STATE || cleanupEligible,
                 now = now
             )
         }
@@ -75,10 +74,11 @@ internal class CoverUrlMappingRoomStore(
             val currentState = database.syncMetadataDao()
                 .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
                 ?.value
-            database.coverUrlMappingDao().delete(normalizedUrls)
-            val shouldKeepBlocked = currentState == ROOM_PRIMARY_WITH_LEGACY_IMPORT_FAILURE_STATE
+            normalizedUrls.chunked(500).forEach { chunk ->
+                database.coverUrlMappingDao().delete(chunk)
+            }
             markRoomPrimary(
-                cleanupEligible = cleanupEligible && !shouldKeepBlocked,
+                cleanupEligible = currentState == ROOM_PRIMARY_STATE || cleanupEligible,
                 now = now
             )
         }
@@ -117,8 +117,7 @@ internal class CoverUrlMappingRoomStore(
     }
 
     private fun isReadableRoomState(state: String?): Boolean {
-        return state == ROOM_PRIMARY_STATE ||
-            state == ROOM_PRIMARY_WITH_LEGACY_IMPORT_FAILURE_STATE
+        return state == ROOM_PRIMARY_STATE
     }
 
     companion object {

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStore.kt
@@ -1,0 +1,150 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import androidx.room.withTransaction
+import com.google.gson.Gson
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
+import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
+import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.playlist.favorite.FavoritePlaylist
+
+internal class FavoritePlaylistRoomStore(
+    private val database: NeriUserDataDatabase,
+    private val gson: Gson = Gson()
+) {
+    suspend fun readIfRoomPrimary(): List<FavoritePlaylist>? {
+        if (database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value != ROOM_PRIMARY_STATE
+        ) {
+            return null
+        }
+        return readPlaylists()
+    }
+
+    suspend fun importLegacyAndPromote(
+        favorites: List<FavoritePlaylist>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        replaceAll(favorites, now)
+    }
+
+    suspend fun replaceAll(
+        favorites: List<FavoritePlaylist>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            database.favoritePlaylistDao().deleteAllSongs()
+            database.favoritePlaylistDao().deleteAllPlaylists()
+            insertAll(favorites)
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
+        )
+    }
+
+    private suspend fun readPlaylists(): List<FavoritePlaylist> {
+        val songsByKey = database.favoritePlaylistDao()
+            .getSongs()
+            .groupBy { song -> song.playlistId to song.source }
+            .mapValues { (_, songs) ->
+                songs.sortedBy(FavoritePlaylistSongEntity::displayPosition)
+                    .map { song ->
+                        runCatching {
+                            gson.fromJson(song.songPayloadJson, SongItem::class.java)
+                        }.getOrElse { error ->
+                            throw IllegalStateException(
+                                "Invalid favorite song payload at " +
+                                    "${song.playlistId}/${song.source}/" +
+                                    "${song.displayPosition}",
+                                error
+                            )
+                        }
+                    }
+            }
+        return database.favoritePlaylistDao().getPlaylists().map { playlist ->
+            FavoritePlaylist(
+                id = playlist.playlistId,
+                name = playlist.name,
+                coverUrl = playlist.coverUrl,
+                trackCount = playlist.trackCount,
+                source = playlist.source,
+                browseId = playlist.browseId,
+                playlistId = playlist.remotePlaylistId,
+                subtitle = playlist.subtitle,
+                songs = songsByKey[playlist.playlistId to playlist.source].orEmpty(),
+                addedTime = playlist.addedTime,
+                sortOrder = playlist.sortOrder,
+                modifiedAt = playlist.modifiedAt,
+                isDeleted = playlist.isDeleted
+            )
+        }
+    }
+
+    private suspend fun insertAll(favorites: List<FavoritePlaylist>) {
+        val normalized = favorites
+            .groupBy { it.id to it.source }
+            .map { (_, snapshots) ->
+                snapshots.maxByOrNull { maxOf(it.modifiedAt, it.addedTime) }!!
+            }
+        database.favoritePlaylistDao().upsertPlaylists(
+            normalized.map(FavoritePlaylist::toEntity)
+        )
+        database.favoritePlaylistDao().upsertSongs(
+            normalized.flatMap { favorite ->
+                favorite.songs.mapIndexed { index, song ->
+                    FavoritePlaylistSongEntity(
+                        playlistId = favorite.id,
+                        source = favorite.source,
+                        displayPosition = index,
+                        songPayloadJson = gson.toJson(song)
+                    )
+                }
+            }
+        )
+    }
+
+    private suspend fun markRoomPrimary(now: Long) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(CUTOVER_STATE_METADATA_KEY, ROOM_PRIMARY_STATE, now)
+        )
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(IMPORT_SCHEMA_METADATA_KEY, "1", now)
+        )
+    }
+
+    private fun metadata(key: String, value: String, now: Long) =
+        moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity(
+            key = key,
+            value = value,
+            updatedAt = now
+        )
+
+    companion object {
+        const val CUTOVER_STATE_METADATA_KEY = "favorite_playlist_cutover_state"
+        const val IMPORT_SCHEMA_METADATA_KEY = "favorite_playlist_import_schema"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+        const val LEGACY_JSON_STATE = "legacy_json"
+    }
+}
+
+private fun FavoritePlaylist.toEntity(): FavoritePlaylistEntity {
+    return FavoritePlaylistEntity(
+        playlistId = id,
+        source = source,
+        name = name,
+        coverUrl = coverUrl,
+        trackCount = trackCount,
+        browseId = browseId,
+        remotePlaylistId = playlistId,
+        subtitle = subtitle,
+        addedTime = addedTime,
+        sortOrder = sortOrder,
+        modifiedAt = modifiedAt,
+        isDeleted = isDeleted
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStore.kt
@@ -26,7 +26,18 @@ internal class FavoritePlaylistRoomStore(
         favorites: List<FavoritePlaylist>,
         now: Long = System.currentTimeMillis()
     ) {
-        replaceAll(favorites, now)
+        database.withTransaction {
+            val cutoverState = database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value
+            if (cutoverState == ROOM_PRIMARY_STATE) {
+                return@withTransaction
+            }
+            database.favoritePlaylistDao().deleteAllSongs()
+            database.favoritePlaylistDao().deleteAllPlaylists()
+            insertAll(favorites)
+            markRoomPrimary(now)
+        }
     }
 
     suspend fun promoteExistingAndRead(

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStore.kt
@@ -41,6 +41,39 @@ internal class FavoritePlaylistRoomStore(
         }
     }
 
+    suspend fun writeIncremental(
+        previous: List<FavoritePlaylist>,
+        next: List<FavoritePlaylist>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        val previousByKey = previous.associateBy(FavoritePlaylist::storageKey)
+        val nextByKey = next.associateBy(FavoritePlaylist::storageKey)
+        val changedKeys = (previousByKey.keys + nextByKey.keys)
+            .filter { key -> previousByKey[key] != nextByKey[key] }
+            .toSet()
+        if (changedKeys.isEmpty()) {
+            return
+        }
+        val removedKeys = changedKeys.filter { it !in nextByKey }
+        val changedFavorites = next.filter { it.storageKey() in changedKeys }
+        database.withTransaction {
+            val dao = database.favoritePlaylistDao()
+            removedKeys.forEach { key ->
+                dao.deletePlaylist(key.playlistId, key.source)
+            }
+            changedFavorites.forEach { favorite ->
+                dao.deleteSongs(favorite.id, favorite.source)
+            }
+            dao.upsertPlaylists(changedFavorites.map(FavoritePlaylist::toEntity))
+            dao.upsertSongs(
+                changedFavorites.flatMap { favorite ->
+                    favorite.toSongEntities()
+                }
+            )
+            markRoomPrimary(now)
+        }
+    }
+
     suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
         database.syncMetadataDao().upsertMigrationMetadata(
             metadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
@@ -96,16 +129,20 @@ internal class FavoritePlaylistRoomStore(
         )
         database.favoritePlaylistDao().upsertSongs(
             normalized.flatMap { favorite ->
-                favorite.songs.mapIndexed { index, song ->
-                    FavoritePlaylistSongEntity(
-                        playlistId = favorite.id,
-                        source = favorite.source,
-                        displayPosition = index,
-                        songPayloadJson = gson.toJson(song)
-                    )
-                }
+                favorite.toSongEntities()
             }
         )
+    }
+
+    private fun FavoritePlaylist.toSongEntities(): List<FavoritePlaylistSongEntity> {
+        return songs.mapIndexed { index, song ->
+            FavoritePlaylistSongEntity(
+                playlistId = id,
+                source = source,
+                displayPosition = index,
+                songPayloadJson = gson.toJson(song)
+            )
+        }
     }
 
     private suspend fun markRoomPrimary(now: Long) {
@@ -130,6 +167,15 @@ internal class FavoritePlaylistRoomStore(
         const val ROOM_PRIMARY_STATE = "room_primary"
         const val LEGACY_JSON_STATE = "legacy_json"
     }
+}
+
+private data class FavoritePlaylistStorageKey(
+    val playlistId: Long,
+    val source: String
+)
+
+private fun FavoritePlaylist.storageKey(): FavoritePlaylistStorageKey {
+    return FavoritePlaylistStorageKey(playlistId = id, source = source)
 }
 
 private fun FavoritePlaylist.toEntity(): FavoritePlaylistEntity {

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStore.kt
@@ -29,6 +29,16 @@ internal class FavoritePlaylistRoomStore(
         replaceAll(favorites, now)
     }
 
+    suspend fun promoteExistingAndRead(
+        now: Long = System.currentTimeMillis()
+    ): List<FavoritePlaylist> {
+        return database.withTransaction {
+            val favorites = readPlaylists()
+            markRoomPrimary(now)
+            favorites
+        }
+    }
+
     suspend fun replaceAll(
         favorites: List<FavoritePlaylist>,
         now: Long = System.currentTimeMillis()
@@ -72,12 +82,6 @@ internal class FavoritePlaylistRoomStore(
             )
             markRoomPrimary(now)
         }
-    }
-
-    suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
-        database.syncMetadataDao().upsertMigrationMetadata(
-            metadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
-        )
     }
 
     private suspend fun readPlaylists(): List<FavoritePlaylist> {
@@ -165,7 +169,6 @@ internal class FavoritePlaylistRoomStore(
         const val CUTOVER_STATE_METADATA_KEY = "favorite_playlist_cutover_state"
         const val IMPORT_SCHEMA_METADATA_KEY = "favorite_playlist_import_schema"
         const val ROOM_PRIMARY_STATE = "room_primary"
-        const val LEGACY_JSON_STATE = "legacy_json"
     }
 }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/FavoritePlaylistRoomStore.kt
@@ -1,16 +1,27 @@
 package moe.ouom.neriplayer.data.local.database.store
 
 import androidx.room.withTransaction
-import com.google.gson.Gson
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongEntity
+import moe.ouom.neriplayer.data.local.database.entity.FavoritePlaylistSongNeteaseArtistEntity
+import moe.ouom.neriplayer.core.api.search.MusicPlatform
 import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.model.NeteaseArtistSummary
 import moe.ouom.neriplayer.data.playlist.favorite.FavoritePlaylist
 
+internal enum class FavoritePlaylistRoomImportStatus {
+    IMPORTED,
+    SKIPPED_ALREADY_PRIMARY
+}
+
+internal data class FavoritePlaylistRoomImportResult(
+    val status: FavoritePlaylistRoomImportStatus,
+    val playlistCount: Int
+)
+
 internal class FavoritePlaylistRoomStore(
-    private val database: NeriUserDataDatabase,
-    private val gson: Gson = Gson()
+    private val database: NeriUserDataDatabase
 ) {
     suspend fun readIfRoomPrimary(): List<FavoritePlaylist>? {
         if (database.syncMetadataDao()
@@ -19,24 +30,32 @@ internal class FavoritePlaylistRoomStore(
         ) {
             return null
         }
-        return readPlaylists()
+        return database.withTransaction { readPlaylistsUnsafe() }
     }
 
     suspend fun importLegacyAndPromote(
         favorites: List<FavoritePlaylist>,
         now: Long = System.currentTimeMillis()
-    ) {
-        database.withTransaction {
+    ): FavoritePlaylistRoomImportResult {
+        return database.withTransaction {
             val cutoverState = database.syncMetadataDao()
                 .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
                 ?.value
             if (cutoverState == ROOM_PRIMARY_STATE) {
-                return@withTransaction
+                return@withTransaction FavoritePlaylistRoomImportResult(
+                    status = FavoritePlaylistRoomImportStatus.SKIPPED_ALREADY_PRIMARY,
+                    playlistCount = favorites.size
+                )
             }
             database.favoritePlaylistDao().deleteAllSongs()
+            database.favoritePlaylistDao().deleteAllSongNeteaseArtists()
             database.favoritePlaylistDao().deleteAllPlaylists()
             insertAll(favorites)
             markRoomPrimary(now)
+            FavoritePlaylistRoomImportResult(
+                status = FavoritePlaylistRoomImportStatus.IMPORTED,
+                playlistCount = favorites.size
+            )
         }
     }
 
@@ -44,7 +63,7 @@ internal class FavoritePlaylistRoomStore(
         now: Long = System.currentTimeMillis()
     ): List<FavoritePlaylist> {
         return database.withTransaction {
-            val favorites = readPlaylists()
+            val favorites = readPlaylistsUnsafe()
             markRoomPrimary(now)
             favorites
         }
@@ -56,6 +75,7 @@ internal class FavoritePlaylistRoomStore(
     ) {
         database.withTransaction {
             database.favoritePlaylistDao().deleteAllSongs()
+            database.favoritePlaylistDao().deleteAllSongNeteaseArtists()
             database.favoritePlaylistDao().deleteAllPlaylists()
             insertAll(favorites)
             markRoomPrimary(now)
@@ -84,6 +104,7 @@ internal class FavoritePlaylistRoomStore(
             }
             changedFavorites.forEach { favorite ->
                 dao.deleteSongs(favorite.id, favorite.source)
+                dao.deleteSongNeteaseArtists(favorite.id, favorite.source)
             }
             dao.upsertPlaylists(changedFavorites.map(FavoritePlaylist::toEntity))
             dao.upsertSongs(
@@ -91,28 +112,30 @@ internal class FavoritePlaylistRoomStore(
                     favorite.toSongEntities()
                 }
             )
+            dao.upsertSongNeteaseArtists(
+                changedFavorites.flatMap { favorite ->
+                    favorite.toSongNeteaseArtistEntities()
+                }
+            )
             markRoomPrimary(now)
         }
     }
 
-    private suspend fun readPlaylists(): List<FavoritePlaylist> {
+    private suspend fun readPlaylistsUnsafe(): List<FavoritePlaylist> {
         val songsByKey = database.favoritePlaylistDao()
             .getSongs()
             .groupBy { song -> song.playlistId to song.source }
             .mapValues { (_, songs) ->
                 songs.sortedBy(FavoritePlaylistSongEntity::displayPosition)
-                    .map { song ->
-                        runCatching {
-                            gson.fromJson(song.songPayloadJson, SongItem::class.java)
-                        }.getOrElse { error ->
-                            throw IllegalStateException(
-                                "Invalid favorite song payload at " +
-                                    "${song.playlistId}/${song.source}/" +
-                                    "${song.displayPosition}",
-                                error
-                            )
-                        }
-                    }
+            }
+        val artistsByKey = database.favoritePlaylistDao()
+            .getSongNeteaseArtists()
+            .groupBy { artist ->
+                FavoritePlaylistSongKey(
+                    artist.playlistId,
+                    artist.source,
+                    artist.displayPosition
+                )
             }
         return database.favoritePlaylistDao().getPlaylists().map { playlist ->
             FavoritePlaylist(
@@ -124,7 +147,26 @@ internal class FavoritePlaylistRoomStore(
                 browseId = playlist.browseId,
                 playlistId = playlist.remotePlaylistId,
                 subtitle = playlist.subtitle,
-                songs = songsByKey[playlist.playlistId to playlist.source].orEmpty(),
+                songs = songsByKey[playlist.playlistId to playlist.source]
+                    .orEmpty()
+                    .map { song ->
+                        song.toSongItem().copy(
+                            neteaseArtists = artistsByKey[
+                                FavoritePlaylistSongKey(
+                                    playlist.playlistId,
+                                    playlist.source,
+                                    song.displayPosition
+                                )
+                            ].orEmpty()
+                                .sortedBy(FavoritePlaylistSongNeteaseArtistEntity::artistPosition)
+                                .map { artist ->
+                                    NeteaseArtistSummary(
+                                        id = artist.artistId,
+                                        name = artist.artistName
+                                    )
+                                }
+                        )
+                    },
                 addedTime = playlist.addedTime,
                 sortOrder = playlist.sortOrder,
                 modifiedAt = playlist.modifiedAt,
@@ -143,9 +185,10 @@ internal class FavoritePlaylistRoomStore(
             normalized.map(FavoritePlaylist::toEntity)
         )
         database.favoritePlaylistDao().upsertSongs(
-            normalized.flatMap { favorite ->
-                favorite.toSongEntities()
-            }
+            normalized.flatMap { favorite -> favorite.toSongEntities() }
+        )
+        database.favoritePlaylistDao().upsertSongNeteaseArtists(
+            normalized.flatMap { favorite -> favorite.toSongNeteaseArtistEntities() }
         )
     }
 
@@ -155,8 +198,52 @@ internal class FavoritePlaylistRoomStore(
                 playlistId = id,
                 source = source,
                 displayPosition = index,
-                songPayloadJson = gson.toJson(song)
+                id = song.id,
+                name = song.name,
+                artist = song.artist,
+                album = song.album,
+                albumId = song.albumId,
+                durationMs = song.durationMs,
+                coverUrl = song.coverUrl,
+                mediaUri = song.mediaUri,
+                matchedLyric = song.matchedLyric,
+                matchedTranslatedLyric = song.matchedTranslatedLyric,
+                matchedLyricSource = song.matchedLyricSource?.name,
+                matchedSongId = song.matchedSongId,
+                userLyricOffsetMs = song.userLyricOffsetMs,
+                customCoverUrl = song.customCoverUrl,
+                customName = song.customName,
+                customArtist = song.customArtist,
+                originalName = song.originalName,
+                originalArtist = song.originalArtist,
+                originalCoverUrl = song.originalCoverUrl,
+                originalLyric = song.originalLyric,
+                originalTranslatedLyric = song.originalTranslatedLyric,
+                localFileName = song.localFileName,
+                localFilePath = song.localFilePath,
+                channelId = song.channelId,
+                audioId = song.audioId,
+                subAudioId = song.subAudioId,
+                playlistContextId = song.playlistContextId,
+                sourceStableKey = song.sourceStableKey,
+                addedAt = song.addedAt,
+                structuredSchemaVersion = 2
             )
+        }
+    }
+
+    private fun FavoritePlaylist.toSongNeteaseArtistEntities(): List<FavoritePlaylistSongNeteaseArtistEntity> {
+        return songs.flatMapIndexed { songPosition, song ->
+            song.neteaseArtists.orEmpty().mapIndexed { artistPosition, artist ->
+                FavoritePlaylistSongNeteaseArtistEntity(
+                    playlistId = id,
+                    source = source,
+                    displayPosition = songPosition,
+                    artistPosition = artistPosition,
+                    artistId = artist.id,
+                    artistName = artist.name
+                )
+            }
         }
     }
 
@@ -187,6 +274,49 @@ private data class FavoritePlaylistStorageKey(
     val playlistId: Long,
     val source: String
 )
+
+private data class FavoritePlaylistSongKey(
+    val playlistId: Long,
+    val source: String,
+    val displayPosition: Int
+)
+
+private fun FavoritePlaylistSongEntity.toSongItem(): SongItem {
+    return SongItem(
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        albumId = albumId,
+        durationMs = durationMs,
+        coverUrl = coverUrl,
+        mediaUri = mediaUri,
+        matchedLyric = matchedLyric,
+        matchedTranslatedLyric = matchedTranslatedLyric,
+        matchedLyricSource = matchedLyricSource?.let { value ->
+            runCatching { MusicPlatform.valueOf(value) }.getOrNull()
+        },
+        matchedSongId = matchedSongId,
+        userLyricOffsetMs = userLyricOffsetMs,
+        customCoverUrl = customCoverUrl,
+        customName = customName,
+        customArtist = customArtist,
+        originalName = originalName,
+        originalArtist = originalArtist,
+        originalCoverUrl = originalCoverUrl,
+        originalLyric = originalLyric,
+        originalTranslatedLyric = originalTranslatedLyric,
+        localFileName = localFileName,
+        localFilePath = localFilePath,
+        channelId = channelId,
+        audioId = audioId,
+        subAudioId = subAudioId,
+        playlistContextId = playlistContextId,
+        sourceStableKey = sourceStableKey,
+        addedAt = addedAt,
+        streamUrl = null
+    )
+}
 
 private fun FavoritePlaylist.storageKey(): FavoritePlaylistStorageKey {
     return FavoritePlaylistStorageKey(playlistId = id, source = source)

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
@@ -188,6 +188,14 @@ internal class LegacyJsonCleanupCoordinator(
             TargetDefinition(
                 "traffic_stats_daily.json",
                 TrafficStatsRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "last_playlist.json",
+                "playback_queue_cutover_state"
+            ),
+            TargetDefinition(
+                "last_playback_state.json",
+                "playback_queue_cutover_state"
             )
         )
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
@@ -201,6 +201,10 @@ internal class LegacyJsonCleanupCoordinator(
                 "bili_video_skip_cutover_state"
             ),
             TargetDefinition(
+                "cover_url_mapping.json",
+                CoverUrlMappingRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
                 "pending_download_queue_v1.json",
                 DownloadRecoveryRoomStore.PENDING_QUEUE_CUTOVER_STATE_KEY
             ),

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
@@ -81,28 +81,7 @@ internal class LegacyJsonCleanupCoordinator(
         }
 
         val freshPlan = buildPlan()
-        if (freshPlan.blockedTargets.isNotEmpty()) {
-            val blockedFiles = freshPlan.blockedTargets.map(LegacyJsonCleanupTarget::fileName)
-            database.syncMetadataDao().upsertMigrationMetadata(
-                MigrationMetadataEntity(
-                    key = CLEANUP_AUDIT_METADATA_KEY,
-                    value = buildAuditValue(
-                        status = LegacyJsonCleanupStatus.BLOCKED,
-                        deleted = emptyList(),
-                        failed = emptyList(),
-                        blocked = blockedFiles
-                    ),
-                    updatedAt = System.currentTimeMillis()
-                )
-            )
-            return LegacyJsonCleanupResult(
-                status = LegacyJsonCleanupStatus.BLOCKED,
-                deletedFiles = emptyList(),
-                failedFiles = emptyList(),
-                blockedFiles = blockedFiles
-            )
-        }
-
+        val blockedFiles = freshPlan.blockedTargets.map(LegacyJsonCleanupTarget::fileName)
         val deleted = mutableListOf<String>()
         val failed = mutableListOf<String>()
         freshPlan.existingEligibleTargets.forEach { target ->
@@ -113,15 +92,15 @@ internal class LegacyJsonCleanupCoordinator(
                 failed += target.fileName
             }
         }
-        val status = if (failed.isEmpty()) {
-            LegacyJsonCleanupStatus.COMPLETED
-        } else {
-            LegacyJsonCleanupStatus.PARTIAL_FAILURE
+        val status = when {
+            failed.isNotEmpty() -> LegacyJsonCleanupStatus.PARTIAL_FAILURE
+            blockedFiles.isNotEmpty() -> LegacyJsonCleanupStatus.BLOCKED
+            else -> LegacyJsonCleanupStatus.COMPLETED
         }
         database.syncMetadataDao().upsertMigrationMetadata(
             MigrationMetadataEntity(
                 key = CLEANUP_AUDIT_METADATA_KEY,
-                value = buildAuditValue(status, deleted, failed, emptyList()),
+                value = buildAuditValue(status, deleted, failed, blockedFiles),
                 updatedAt = System.currentTimeMillis()
             )
         )
@@ -129,7 +108,7 @@ internal class LegacyJsonCleanupCoordinator(
             status = status,
             deletedFiles = deleted,
             failedFiles = failed,
-            blockedFiles = emptyList()
+            blockedFiles = blockedFiles
         )
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
@@ -82,12 +82,24 @@ internal class LegacyJsonCleanupCoordinator(
 
         val freshPlan = buildPlan()
         if (freshPlan.blockedTargets.isNotEmpty()) {
+            val blockedFiles = freshPlan.blockedTargets.map(LegacyJsonCleanupTarget::fileName)
+            database.syncMetadataDao().upsertMigrationMetadata(
+                MigrationMetadataEntity(
+                    key = CLEANUP_AUDIT_METADATA_KEY,
+                    value = buildAuditValue(
+                        status = LegacyJsonCleanupStatus.BLOCKED,
+                        deleted = emptyList(),
+                        failed = emptyList(),
+                        blocked = blockedFiles
+                    ),
+                    updatedAt = System.currentTimeMillis()
+                )
+            )
             return LegacyJsonCleanupResult(
                 status = LegacyJsonCleanupStatus.BLOCKED,
                 deletedFiles = emptyList(),
                 failedFiles = emptyList(),
-                blockedFiles = freshPlan.blockedTargets
-                    .map(LegacyJsonCleanupTarget::fileName)
+                blockedFiles = blockedFiles
             )
         }
 
@@ -109,7 +121,7 @@ internal class LegacyJsonCleanupCoordinator(
         database.syncMetadataDao().upsertMigrationMetadata(
             MigrationMetadataEntity(
                 key = CLEANUP_AUDIT_METADATA_KEY,
-                value = buildAuditValue(status, deleted, failed),
+                value = buildAuditValue(status, deleted, failed, emptyList()),
                 updatedAt = System.currentTimeMillis()
             )
         )
@@ -124,12 +136,14 @@ internal class LegacyJsonCleanupCoordinator(
     private fun buildAuditValue(
         status: LegacyJsonCleanupStatus,
         deleted: List<String>,
-        failed: List<String>
+        failed: List<String>,
+        blocked: List<String>
     ): String {
         return buildString {
             append("status=").append(status.name)
             append(";deleted=").append(deleted.joinToString(","))
             append(";failed=").append(failed.joinToString(","))
+            append(";blocked=").append(blocked.joinToString(","))
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
@@ -2,6 +2,7 @@ package moe.ouom.neriplayer.data.local.database.store
 
 import android.content.Context
 import java.io.File
+import moe.ouom.neriplayer.core.download.storage.queue.DownloadRecoveryRoomStore
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
 
@@ -204,6 +205,14 @@ internal class LegacyJsonCleanupCoordinator(
             TargetDefinition(
                 "bili_video_skip_drafts.json",
                 "bili_video_skip_cutover_state"
+            ),
+            TargetDefinition(
+                "pending_download_queue_v1.json",
+                DownloadRecoveryRoomStore.PENDING_QUEUE_CUTOVER_STATE_KEY
+            ),
+            TargetDefinition(
+                "cancelled_download_keys_v1.json",
+                DownloadRecoveryRoomStore.CANCELLED_KEYS_CUTOVER_STATE_KEY
             )
         )
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
@@ -196,6 +196,14 @@ internal class LegacyJsonCleanupCoordinator(
             TargetDefinition(
                 "last_playback_state.json",
                 "playback_queue_cutover_state"
+            ),
+            TargetDefinition(
+                "bili_video_skip_rules.json",
+                "bili_video_skip_cutover_state"
+            ),
+            TargetDefinition(
+                "bili_video_skip_drafts.json",
+                "bili_video_skip_cutover_state"
             )
         )
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
@@ -3,6 +3,7 @@ package moe.ouom.neriplayer.data.local.database.store
 import android.content.Context
 import java.io.File
 import moe.ouom.neriplayer.core.download.catalog.DownloadedSongCatalogRoomStore
+import moe.ouom.neriplayer.core.download.storage.snapshot.ManagedDownloadSnapshotRoomStore
 import moe.ouom.neriplayer.core.download.storage.queue.DownloadRecoveryRoomStore
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
@@ -219,6 +220,10 @@ internal class LegacyJsonCleanupCoordinator(
             TargetDefinition(
                 "downloaded_song_catalog_v3.json",
                 DownloadedSongCatalogRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "managed_download_snapshot_v1.json",
+                ManagedDownloadSnapshotRoomStore.CUTOVER_STATE_METADATA_KEY
             )
         )
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
@@ -2,6 +2,7 @@ package moe.ouom.neriplayer.data.local.database.store
 
 import android.content.Context
 import java.io.File
+import moe.ouom.neriplayer.core.download.catalog.DownloadedSongCatalogRoomStore
 import moe.ouom.neriplayer.core.download.storage.queue.DownloadRecoveryRoomStore
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
@@ -213,6 +214,14 @@ internal class LegacyJsonCleanupCoordinator(
             TargetDefinition(
                 "cancelled_download_keys_v1.json",
                 DownloadRecoveryRoomStore.CANCELLED_KEYS_CUTOVER_STATE_KEY
+            ),
+            TargetDefinition(
+                "downloaded_song_catalog_v4.json",
+                DownloadedSongCatalogRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "downloaded_song_catalog_v3.json",
+                DownloadedSongCatalogRoomStore.CUTOVER_STATE_METADATA_KEY
             )
         )
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
@@ -1,0 +1,194 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import android.content.Context
+import java.io.File
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+
+internal enum class LegacyJsonCleanupStatus {
+    NOT_CONFIRMED,
+    BLOCKED,
+    COMPLETED,
+    PARTIAL_FAILURE
+}
+
+internal data class LegacyJsonCleanupTarget(
+    val fileName: String,
+    val cutoverStateKey: String,
+    val exists: Boolean,
+    val eligible: Boolean,
+    val reason: String?
+)
+
+internal data class LegacyJsonCleanupPlan(
+    val targets: List<LegacyJsonCleanupTarget>
+) {
+    val blockedTargets: List<LegacyJsonCleanupTarget>
+        get() = targets.filter { it.exists && !it.eligible }
+
+    val existingEligibleTargets: List<LegacyJsonCleanupTarget>
+        get() = targets.filter { it.exists && it.eligible }
+}
+
+internal data class LegacyJsonCleanupResult(
+    val status: LegacyJsonCleanupStatus,
+    val deletedFiles: List<String>,
+    val failedFiles: List<String>,
+    val blockedFiles: List<String>
+)
+
+internal class LegacyJsonCleanupCoordinator(
+    private val context: Context,
+    private val database: NeriUserDataDatabase =
+        NeriUserDataDatabase.getInstance(context.applicationContext)
+) {
+    suspend fun buildPlan(): LegacyJsonCleanupPlan {
+        val targets = TARGETS.map { target ->
+            val state = database.syncMetadataDao()
+                .getMigrationMetadata(target.cutoverStateKey)
+                ?.value
+            val file = File(context.filesDir, target.fileName)
+            val exists = file.exists()
+            LegacyJsonCleanupTarget(
+                fileName = target.fileName,
+                cutoverStateKey = target.cutoverStateKey,
+                exists = exists,
+                eligible = state == ROOM_PRIMARY_STATE,
+                reason = when {
+                    !exists -> null
+                    state == ROOM_PRIMARY_STATE -> null
+                    state == null -> "Room primary marker is missing"
+                    else -> "Room primary marker is $state"
+                }
+            )
+        }
+        return LegacyJsonCleanupPlan(targets)
+    }
+
+    suspend fun execute(
+        plan: LegacyJsonCleanupPlan,
+        confirmed: Boolean
+    ): LegacyJsonCleanupResult {
+        if (!confirmed) {
+            return LegacyJsonCleanupResult(
+                status = LegacyJsonCleanupStatus.NOT_CONFIRMED,
+                deletedFiles = emptyList(),
+                failedFiles = emptyList(),
+                blockedFiles = plan.blockedTargets.map(LegacyJsonCleanupTarget::fileName)
+            )
+        }
+
+        val freshPlan = buildPlan()
+        if (freshPlan.blockedTargets.isNotEmpty()) {
+            return LegacyJsonCleanupResult(
+                status = LegacyJsonCleanupStatus.BLOCKED,
+                deletedFiles = emptyList(),
+                failedFiles = emptyList(),
+                blockedFiles = freshPlan.blockedTargets
+                    .map(LegacyJsonCleanupTarget::fileName)
+            )
+        }
+
+        val deleted = mutableListOf<String>()
+        val failed = mutableListOf<String>()
+        freshPlan.existingEligibleTargets.forEach { target ->
+            val file = File(context.filesDir, target.fileName)
+            if (file.delete()) {
+                deleted += target.fileName
+            } else if (file.exists()) {
+                failed += target.fileName
+            }
+        }
+        val status = if (failed.isEmpty()) {
+            LegacyJsonCleanupStatus.COMPLETED
+        } else {
+            LegacyJsonCleanupStatus.PARTIAL_FAILURE
+        }
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = CLEANUP_AUDIT_METADATA_KEY,
+                value = buildAuditValue(status, deleted, failed),
+                updatedAt = System.currentTimeMillis()
+            )
+        )
+        return LegacyJsonCleanupResult(
+            status = status,
+            deletedFiles = deleted,
+            failedFiles = failed,
+            blockedFiles = emptyList()
+        )
+    }
+
+    private fun buildAuditValue(
+        status: LegacyJsonCleanupStatus,
+        deleted: List<String>,
+        failed: List<String>
+    ): String {
+        return buildString {
+            append("status=").append(status.name)
+            append(";deleted=").append(deleted.joinToString(","))
+            append(";failed=").append(failed.joinToString(","))
+        }
+    }
+
+    private data class TargetDefinition(
+        val fileName: String,
+        val cutoverStateKey: String
+    )
+
+    companion object {
+        const val CLEANUP_AUDIT_METADATA_KEY = "legacy_json_cleanup_last_result"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+
+        private val TARGETS = listOf(
+            TargetDefinition(
+                "local_playlists.json",
+                LocalPlaylistRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "local_playlists.json.bak",
+                LocalPlaylistRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "local_playlists.json.sync-pending.json",
+                LocalPlaylistRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "play_history.json",
+                PlayHistoryRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "playlist_usage.json",
+                PlaylistUsageRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "local_playlist_playback_stats.json",
+                LocalPlaylistPlaybackRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "playback_stats.json",
+                PlaybackStatsRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "playback_stats_daily.json",
+                PlaybackStatsRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "playback_stats_meta.json",
+                PlaybackStatsRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "playback_stats_counters.json",
+                PlaybackStatsRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "favorite_playlists.json",
+                FavoritePlaylistRoomStore.CUTOVER_STATE_METADATA_KEY
+            ),
+            TargetDefinition(
+                "traffic_stats_daily.json",
+                TrafficStatsRoomStore.CUTOVER_STATE_METADATA_KEY
+            )
+        )
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinator.kt
@@ -5,6 +5,7 @@ import java.io.File
 import moe.ouom.neriplayer.core.download.catalog.DownloadedSongCatalogRoomStore
 import moe.ouom.neriplayer.core.download.storage.snapshot.ManagedDownloadSnapshotRoomStore
 import moe.ouom.neriplayer.core.download.storage.queue.DownloadRecoveryRoomStore
+import moe.ouom.neriplayer.core.player.persistence.PlaybackQueueRoomStore
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
 
@@ -187,19 +188,19 @@ internal class LegacyJsonCleanupCoordinator(
             ),
             TargetDefinition(
                 "last_playlist.json",
-                "playback_queue_cutover_state"
+                PlaybackQueueRoomStore.CUTOVER_STATE_METADATA_KEY
             ),
             TargetDefinition(
                 "last_playback_state.json",
-                "playback_queue_cutover_state"
+                PlaybackQueueRoomStore.CUTOVER_STATE_METADATA_KEY
             ),
             TargetDefinition(
                 "bili_video_skip_rules.json",
-                "bili_video_skip_cutover_state"
+                BiliVideoSkipRoomStore.CUTOVER_STATE_METADATA_KEY
             ),
             TargetDefinition(
                 "bili_video_skip_drafts.json",
-                "bili_video_skip_cutover_state"
+                BiliVideoSkipRoomStore.CUTOVER_STATE_METADATA_KEY
             ),
             TargetDefinition(
                 "cover_url_mapping.json",

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistPlaybackRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistPlaybackRoomStore.kt
@@ -24,7 +24,19 @@ internal class LocalPlaylistPlaybackRoomStore(
         stats: List<LocalPlaylistPlaybackStat>,
         now: Long = System.currentTimeMillis()
     ) {
-        replaceAll(stats, now)
+        database.withTransaction {
+            val cutoverState = database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value
+            if (cutoverState == ROOM_PRIMARY_STATE) {
+                return@withTransaction
+            }
+            database.localPlaylistPlaybackDao().deleteAllCounterShards()
+            database.localPlaylistPlaybackDao().deleteAllBuckets()
+            database.localPlaylistPlaybackDao().deleteAllStats()
+            insertStats(stats)
+            markRoomPrimary(now)
+        }
     }
 
     suspend fun replaceAll(

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistPlaybackRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistPlaybackRoomStore.kt
@@ -1,0 +1,182 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import androidx.room.withTransaction
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.toEntity
+import moe.ouom.neriplayer.data.playlist.usage.LocalPlaylistPlayBucket
+import moe.ouom.neriplayer.data.playlist.usage.LocalPlaylistPlaybackStat
+import moe.ouom.neriplayer.data.sync.model.SyncPlaybackCounterShard
+
+internal class LocalPlaylistPlaybackRoomStore(
+    private val database: NeriUserDataDatabase
+) {
+    suspend fun readIfRoomPrimary(): List<LocalPlaylistPlaybackStat>? {
+        if (database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value != ROOM_PRIMARY_STATE
+        ) {
+            return null
+        }
+        return readStats()
+    }
+
+    suspend fun importLegacyAndPromote(
+        stats: List<LocalPlaylistPlaybackStat>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        replaceAll(stats, now)
+    }
+
+    suspend fun replaceAll(
+        stats: List<LocalPlaylistPlaybackStat>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            database.localPlaylistPlaybackDao().deleteAllCounterShards()
+            database.localPlaylistPlaybackDao().deleteAllBuckets()
+            database.localPlaylistPlaybackDao().deleteAllStats()
+            insertStats(stats)
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
+        )
+    }
+
+    suspend fun writeIncremental(
+        previous: List<LocalPlaylistPlaybackStat>,
+        next: List<LocalPlaylistPlaybackStat>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        val previousById = previous.associateBy(LocalPlaylistPlaybackStat::playlistId)
+        val nextById = next.associateBy(LocalPlaylistPlaybackStat::playlistId)
+        val changedIds = (previousById.keys + nextById.keys)
+            .filter { id -> previousById[id] != nextById[id] }
+            .toSet()
+        val removedIds = changedIds.filter { it !in nextById }
+        database.withTransaction {
+            removedIds.chunked(500).forEach { chunk ->
+                if (chunk.isNotEmpty()) {
+                    database.localPlaylistPlaybackDao().deleteCounterShards(chunk)
+                    database.localPlaylistPlaybackDao().deleteBuckets(chunk)
+                    database.localPlaylistPlaybackDao().deleteStats(chunk)
+                }
+            }
+            changedIds
+                .filter { it in nextById }
+                .toList()
+                .chunked(500)
+                .forEach { chunk ->
+                    database.localPlaylistPlaybackDao().deleteCounterShards(chunk)
+                    database.localPlaylistPlaybackDao().deleteBuckets(chunk)
+                }
+            insertStats(next.filter { it.playlistId in changedIds })
+            markRoomPrimary(now)
+        }
+    }
+
+    private suspend fun insertStats(stats: List<LocalPlaylistPlaybackStat>) {
+        database.localPlaylistPlaybackDao().upsertStats(
+            stats.map(LocalPlaylistPlaybackStat::toEntity)
+        )
+        database.localPlaylistPlaybackDao().upsertBuckets(
+            stats.flatMap { stat ->
+                stat.dailyPlayBuckets.orEmpty().map { bucket ->
+                    bucket.toEntity(stat.playlistId)
+                }
+            }
+        )
+        database.localPlaylistPlaybackDao().upsertCounterShards(
+            stats.flatMap { stat ->
+                buildList {
+                    addAll(
+                        stat.counterShards.orEmpty().map { shard ->
+                            shard.toEntity(stat.playlistId, dayStartAt = 0L)
+                        }
+                    )
+                    stat.dailyPlayBuckets.orEmpty().forEach { bucket ->
+                        addAll(
+                            bucket.counterShards.orEmpty().map { shard ->
+                                shard.toEntity(stat.playlistId, bucket.dayStartAt)
+                            }
+                        )
+                    }
+                }
+            }
+        )
+    }
+
+    private suspend fun readStats(): List<LocalPlaylistPlaybackStat> {
+        val bucketsByPlaylist = database.localPlaylistPlaybackDao()
+            .getBuckets()
+            .groupBy { it.playlistId }
+        val shardsByScope = database.localPlaylistPlaybackDao()
+            .getCounterShards()
+            .groupBy { it.playlistId to it.dayStartAt }
+        return database.localPlaylistPlaybackDao().getStats().map { stat ->
+            LocalPlaylistPlaybackStat(
+                playlistId = stat.playlistId,
+                totalPlayCount = stat.totalPlayCount,
+                firstPlayedAt = stat.firstPlayedAt,
+                lastPlayedAt = stat.lastPlayedAt,
+                counterBasePlayCount = stat.counterBasePlayCount,
+                counterShards = shardsByScope[stat.playlistId to 0L]
+                    .orEmpty()
+                    .map(::toCounterShard),
+                dailyPlayBuckets = bucketsByPlaylist[stat.playlistId]
+                    .orEmpty()
+                    .map { bucket ->
+                        LocalPlaylistPlayBucket(
+                            dayStartAt = bucket.dayStartAt,
+                            playCount = bucket.playCount,
+                            firstPlayedAt = bucket.firstPlayedAt,
+                            lastPlayedAt = bucket.lastPlayedAt,
+                            counterBasePlayCount = bucket.counterBasePlayCount,
+                            counterShards = shardsByScope[
+                                stat.playlistId to bucket.dayStartAt
+                            ].orEmpty().map(::toCounterShard)
+                        )
+                    }
+            )
+        }
+    }
+
+    private fun toCounterShard(
+        shard: moe.ouom.neriplayer.data.local.database.entity
+            .LocalPlaylistPlaybackCounterShardEntity
+    ): SyncPlaybackCounterShard {
+        return SyncPlaybackCounterShard(
+            deviceId = shard.deviceId,
+            epochStartedAt = shard.epochStartedAt,
+            playCount = shard.playCount,
+            firstPlayedAt = shard.firstPlayedAt,
+            lastPlayedAt = shard.lastPlayedAt
+        )
+    }
+
+    private suspend fun markRoomPrimary(now: Long) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(CUTOVER_STATE_METADATA_KEY, ROOM_PRIMARY_STATE, now)
+        )
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(IMPORT_SCHEMA_METADATA_KEY, "1", now)
+        )
+    }
+
+    private fun metadata(key: String, value: String, now: Long) =
+        moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity(
+            key = key,
+            value = value,
+            updatedAt = now
+        )
+
+    companion object {
+        const val CUTOVER_STATE_METADATA_KEY = "local_playlist_playback_cutover_state"
+        const val IMPORT_SCHEMA_METADATA_KEY = "local_playlist_playback_import_schema"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+        const val LEGACY_JSON_STATE = "legacy_json"
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistPlaybackRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistPlaybackRoomStore.kt
@@ -115,14 +115,14 @@ internal class LocalPlaylistPlaybackRoomStore(
         )
     }
 
-    private suspend fun readStats(): List<LocalPlaylistPlaybackStat> {
+    private suspend fun readStats(): List<LocalPlaylistPlaybackStat> = database.withTransaction {
         val bucketsByPlaylist = database.localPlaylistPlaybackDao()
             .getBuckets()
             .groupBy { it.playlistId }
         val shardsByScope = database.localPlaylistPlaybackDao()
             .getCounterShards()
             .groupBy { it.playlistId to it.dayStartAt }
-        return database.localPlaylistPlaybackDao().getStats().map { stat ->
+        database.localPlaylistPlaybackDao().getStats().map { stat ->
             LocalPlaylistPlaybackStat(
                 playlistId = stat.playlistId,
                 totalPlayCount = stat.totalPlayCount,

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistPlaybackRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistPlaybackRoomStore.kt
@@ -40,12 +40,6 @@ internal class LocalPlaylistPlaybackRoomStore(
         }
     }
 
-    suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
-        database.syncMetadataDao().upsertMigrationMetadata(
-            metadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
-        )
-    }
-
     suspend fun writeIncremental(
         previous: List<LocalPlaylistPlaybackStat>,
         next: List<LocalPlaylistPlaybackStat>,
@@ -177,6 +171,5 @@ internal class LocalPlaylistPlaybackRoomStore(
         const val CUTOVER_STATE_METADATA_KEY = "local_playlist_playback_cutover_state"
         const val IMPORT_SCHEMA_METADATA_KEY = "local_playlist_playback_import_schema"
         const val ROOM_PRIMARY_STATE = "room_primary"
-        const val LEGACY_JSON_STATE = "legacy_json"
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomMapper.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomMapper.kt
@@ -1,13 +1,15 @@
 package moe.ouom.neriplayer.data.local.database.store
 
-import com.google.gson.Gson
+import moe.ouom.neriplayer.core.api.search.MusicPlatform
 import moe.ouom.neriplayer.data.local.database.entity.LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION
 import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistEntity
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberNeteaseArtistEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberTokenEntity
 import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
 import moe.ouom.neriplayer.data.local.playlist.model.LocalPlaylist
+import moe.ouom.neriplayer.data.model.NeteaseArtistSummary
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.data.model.identity
 import moe.ouom.neriplayer.data.model.stableKey
@@ -18,6 +20,7 @@ internal data class LocalPlaylistRoomSnapshot(
     val playlists: List<LocalPlaylistEntity>,
     val tracks: List<TrackEntity>,
     val members: List<PlaylistMemberEntity>,
+    val memberNeteaseArtists: List<PlaylistMemberNeteaseArtistEntity>,
     val memberTokens: List<PlaylistMemberTokenEntity>,
     val migrationMetadata: List<MigrationMetadataEntity>
 )
@@ -29,9 +32,7 @@ internal data class LocalPlaylistRoomValidationResult(
     val firstMismatch: String?
 )
 
-internal class LocalPlaylistRoomMapper(
-    private val gson: Gson = Gson()
-) {
+internal class LocalPlaylistRoomMapper {
     fun toSnapshot(
         playlists: List<LocalPlaylist>,
         sourceDigest: String? = null,
@@ -40,6 +41,7 @@ internal class LocalPlaylistRoomMapper(
         val trackMap = LinkedHashMap<String, TrackEntity>()
         val playlistEntities = ArrayList<LocalPlaylistEntity>(playlists.size)
         val memberEntities = ArrayList<PlaylistMemberEntity>()
+        val memberNeteaseArtistEntities = ArrayList<PlaylistMemberNeteaseArtistEntity>()
         val tokenEntities = ArrayList<PlaylistMemberTokenEntity>()
 
         playlists.forEachIndexed { playlistIndex, playlist ->
@@ -53,6 +55,15 @@ internal class LocalPlaylistRoomMapper(
                     identityKey = identityKey,
                     displayPosition = songIndex
                 )
+                song.neteaseArtists.orEmpty().forEachIndexed { artistPosition, artist ->
+                    memberNeteaseArtistEntities += PlaylistMemberNeteaseArtistEntity(
+                        playlistId = playlist.id,
+                        identityKey = identityKey,
+                        artistPosition = artistPosition,
+                        artistId = artist.id,
+                        artistName = artist.name
+                    )
+                }
                 song.syncMembershipTokens
                     .normalizedSyncCausalTokens()
                     .forEachIndexed { tokenIndex, token ->
@@ -71,6 +82,7 @@ internal class LocalPlaylistRoomMapper(
             playlists = playlistEntities,
             tracks = trackMap.values.toList(),
             members = memberEntities,
+            memberNeteaseArtists = memberNeteaseArtistEntities,
             memberTokens = tokenEntities,
             migrationMetadata = buildMigrationMetadata(sourceDigest, now)
         )
@@ -80,12 +92,16 @@ internal class LocalPlaylistRoomMapper(
         playlists: List<LocalPlaylistEntity>,
         tracks: List<TrackEntity>,
         members: List<PlaylistMemberEntity>,
+        memberNeteaseArtists: List<PlaylistMemberNeteaseArtistEntity>,
         memberTokens: List<PlaylistMemberTokenEntity>
     ): List<LocalPlaylist> {
         val tracksByIdentity = tracks.associateBy(TrackEntity::identityKey)
         val membersByPlaylist = members.groupBy(PlaylistMemberEntity::playlistId)
         val tokensByMember = memberTokens.groupBy { token ->
             PlaylistMemberKey(token.playlistId, token.identityKey)
+        }
+        val artistsByMember = memberNeteaseArtists.groupBy { artist ->
+            PlaylistMemberKey(artist.playlistId, artist.identityKey)
         }
 
         return playlists
@@ -104,7 +120,9 @@ internal class LocalPlaylistRoomMapper(
                             "Missing track row for ${member.identityKey}"
                         }
                         member.toSongItem(
-                            track = track,
+                            artists = artistsByMember[
+                                PlaylistMemberKey(member.playlistId, member.identityKey)
+                            ].orEmpty(),
                             tokens = tokensByMember[
                                 PlaylistMemberKey(member.playlistId, member.identityKey)
                             ].orEmpty()
@@ -128,6 +146,7 @@ internal class LocalPlaylistRoomMapper(
             playlists = snapshot.playlists,
             tracks = snapshot.tracks,
             members = snapshot.members,
+            memberNeteaseArtists = snapshot.memberNeteaseArtists,
             memberTokens = snapshot.memberTokens
         )
         val expected = playlists.map { playlist ->
@@ -135,6 +154,7 @@ internal class LocalPlaylistRoomMapper(
                 songs = playlist.songs.mapTo(mutableListOf()) { song ->
                     song.copy(
                         streamUrl = null,
+                        neteaseArtists = song.neteaseArtists.orEmpty(),
                         syncMembershipTokens = song.syncMembershipTokens.normalizedSyncCausalTokens()
                     )
                 }
@@ -175,14 +195,26 @@ internal class LocalPlaylistRoomMapper(
             durationMs = durationMs,
             coverUrl = coverUrl,
             mediaUri = mediaUri,
+            matchedLyric = matchedLyric,
+            matchedTranslatedLyric = matchedTranslatedLyric,
+            matchedLyricSource = matchedLyricSource?.name,
+            matchedSongId = matchedSongId,
+            userLyricOffsetMs = userLyricOffsetMs,
+            customCoverUrl = customCoverUrl,
+            customName = customName,
+            customArtist = customArtist,
+            originalName = originalName,
+            originalArtist = originalArtist,
+            originalCoverUrl = originalCoverUrl,
+            originalLyric = originalLyric,
+            originalTranslatedLyric = originalTranslatedLyric,
             channelId = channelId,
             audioId = audioId,
             subAudioId = subAudioId,
             sourceStableKey = sourceStableKey,
             localFileName = localFileName,
             localFilePath = localFilePath,
-            payloadSchemaVersion = LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION,
-            durablePayloadJson = gson.toJson(withoutTransientDatabaseState())
+            structuredSchemaVersion = LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION
         )
     }
 
@@ -198,23 +230,81 @@ internal class LocalPlaylistRoomMapper(
             addedAt = addedAt,
             orderTieBreak = displayPosition,
             playlistContextId = playlistContextId,
-            memberPayloadSchemaVersion = LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION,
-            memberPayloadJson = gson.toJson(withoutTransientDatabaseState())
+            songId = id,
+            name = name,
+            artist = artist,
+            album = album,
+            albumId = albumId,
+            durationMs = durationMs,
+            coverUrl = coverUrl,
+            mediaUri = mediaUri,
+            matchedLyric = matchedLyric,
+            matchedTranslatedLyric = matchedTranslatedLyric,
+            matchedLyricSource = matchedLyricSource?.name,
+            matchedSongId = matchedSongId,
+            userLyricOffsetMs = userLyricOffsetMs,
+            customCoverUrl = customCoverUrl,
+            customName = customName,
+            customArtist = customArtist,
+            originalName = originalName,
+            originalArtist = originalArtist,
+            originalCoverUrl = originalCoverUrl,
+            originalLyric = originalLyric,
+            originalTranslatedLyric = originalTranslatedLyric,
+            localFileName = localFileName,
+            localFilePath = localFilePath,
+            channelId = channelId,
+            audioId = audioId,
+            subAudioId = subAudioId,
+            sourceStableKey = sourceStableKey,
+            structuredSchemaVersion = LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION
         )
     }
 
     private fun PlaylistMemberEntity.toSongItem(
-        track: TrackEntity,
+        artists: List<PlaylistMemberNeteaseArtistEntity>,
         tokens: List<PlaylistMemberTokenEntity>
     ): SongItem {
-        val payload = requireNotNull(
-            decodeSong(memberPayloadJson) ?: decodeSong(track.durablePayloadJson)
-        ) {
-            "Song payload is missing for ${track.identityKey}"
-        }
-        return payload.copy(
-            addedAt = addedAt,
+        return SongItem(
+            id = songId,
+            name = name,
+            artist = artist,
+            album = album,
+            albumId = albumId,
+            durationMs = durationMs,
+            coverUrl = coverUrl,
+            mediaUri = mediaUri,
+            matchedLyric = matchedLyric,
+            matchedTranslatedLyric = matchedTranslatedLyric,
+            matchedLyricSource = matchedLyricSource?.let { value ->
+                runCatching { MusicPlatform.valueOf(value) }.getOrNull()
+            },
+            matchedSongId = matchedSongId,
+            userLyricOffsetMs = userLyricOffsetMs,
+            customCoverUrl = customCoverUrl,
+            customName = customName,
+            customArtist = customArtist,
+            originalName = originalName,
+            originalArtist = originalArtist,
+            originalCoverUrl = originalCoverUrl,
+            originalLyric = originalLyric,
+            originalTranslatedLyric = originalTranslatedLyric,
+            localFileName = localFileName,
+            localFilePath = localFilePath,
+            channelId = channelId,
+            audioId = audioId,
+            subAudioId = subAudioId,
             playlistContextId = playlistContextId,
+            sourceStableKey = sourceStableKey,
+            neteaseArtists = artists
+                .sortedBy(PlaylistMemberNeteaseArtistEntity::artistPosition)
+                .map { artist ->
+                    NeteaseArtistSummary(
+                        id = artist.artistId,
+                        name = artist.artistName
+                    )
+                },
+            addedAt = addedAt,
             syncMembershipTokens = tokens
                 .sortedWith(
                     compareBy<PlaylistMemberTokenEntity> { it.tokenIndex }
@@ -229,16 +319,6 @@ internal class LocalPlaylistRoomMapper(
                 },
             streamUrl = null
         )
-    }
-
-    private fun decodeSong(payload: String): SongItem? {
-        return runCatching {
-            gson.fromJson(payload, SongItem::class.java)
-        }.getOrNull()
-    }
-
-    private fun SongItem.withoutTransientDatabaseState(): SongItem {
-        return copy(streamUrl = null)
     }
 
     private fun buildMigrationMetadata(

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomMapper.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomMapper.kt
@@ -328,14 +328,14 @@ internal class LocalPlaylistRoomMapper {
         return buildList {
             add(
                 MigrationMetadataEntity(
-                    key = "local_playlist_import_schema",
+                    key = LocalPlaylistRoomStore.IMPORT_SCHEMA_METADATA_KEY,
                     value = LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION.toString(),
                     updatedAt = now
                 )
             )
             add(
                 MigrationMetadataEntity(
-                    key = "local_playlist_cutover_state",
+                    key = LocalPlaylistRoomStore.CUTOVER_STATE_METADATA_KEY,
                     value = "shadow",
                     updatedAt = now
                 )
@@ -343,7 +343,7 @@ internal class LocalPlaylistRoomMapper {
             sourceDigest?.let { digest ->
                 add(
                     MigrationMetadataEntity(
-                        key = "local_playlist_source_digest",
+                        key = LocalPlaylistRoomStore.SOURCE_DIGEST_METADATA_KEY,
                         value = digest,
                         updatedAt = now
                     )

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomMapper.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomMapper.kt
@@ -1,0 +1,293 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import com.google.gson.Gson
+import moe.ouom.neriplayer.data.local.database.entity.LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION
+import moe.ouom.neriplayer.data.local.database.entity.LocalPlaylistEntity
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaylistMemberTokenEntity
+import moe.ouom.neriplayer.data.local.database.entity.TrackEntity
+import moe.ouom.neriplayer.data.local.playlist.model.LocalPlaylist
+import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.model.identity
+import moe.ouom.neriplayer.data.model.stableKey
+import moe.ouom.neriplayer.data.sync.model.SyncCausalToken
+import moe.ouom.neriplayer.data.sync.model.normalizedSyncCausalTokens
+
+internal data class LocalPlaylistRoomSnapshot(
+    val playlists: List<LocalPlaylistEntity>,
+    val tracks: List<TrackEntity>,
+    val members: List<PlaylistMemberEntity>,
+    val memberTokens: List<PlaylistMemberTokenEntity>,
+    val migrationMetadata: List<MigrationMetadataEntity>
+)
+
+internal data class LocalPlaylistRoomValidationResult(
+    val equivalent: Boolean,
+    val playlistCount: Int,
+    val memberCount: Int,
+    val firstMismatch: String?
+)
+
+internal class LocalPlaylistRoomMapper(
+    private val gson: Gson = Gson()
+) {
+    fun toSnapshot(
+        playlists: List<LocalPlaylist>,
+        sourceDigest: String? = null,
+        now: Long = System.currentTimeMillis()
+    ): LocalPlaylistRoomSnapshot {
+        val trackMap = LinkedHashMap<String, TrackEntity>()
+        val playlistEntities = ArrayList<LocalPlaylistEntity>(playlists.size)
+        val memberEntities = ArrayList<PlaylistMemberEntity>()
+        val tokenEntities = ArrayList<PlaylistMemberTokenEntity>()
+
+        playlists.forEachIndexed { playlistIndex, playlist ->
+            playlistEntities += playlist.toEntity(playlistIndex)
+            playlist.songs.forEachIndexed { songIndex, song ->
+                val identity = song.identity()
+                val identityKey = identity.stableKey()
+                trackMap.putIfAbsent(identityKey, song.toTrackEntity(identityKey))
+                memberEntities += song.toMemberEntity(
+                    playlistId = playlist.id,
+                    identityKey = identityKey,
+                    displayPosition = songIndex
+                )
+                song.syncMembershipTokens
+                    .normalizedSyncCausalTokens()
+                    .forEachIndexed { tokenIndex, token ->
+                        tokenEntities += PlaylistMemberTokenEntity(
+                            playlistId = playlist.id,
+                            identityKey = identityKey,
+                            deviceId = token.deviceId,
+                            counter = token.counter,
+                            tokenIndex = tokenIndex
+                        )
+                    }
+            }
+        }
+
+        return LocalPlaylistRoomSnapshot(
+            playlists = playlistEntities,
+            tracks = trackMap.values.toList(),
+            members = memberEntities,
+            memberTokens = tokenEntities,
+            migrationMetadata = buildMigrationMetadata(sourceDigest, now)
+        )
+    }
+
+    fun toDomain(
+        playlists: List<LocalPlaylistEntity>,
+        tracks: List<TrackEntity>,
+        members: List<PlaylistMemberEntity>,
+        memberTokens: List<PlaylistMemberTokenEntity>
+    ): List<LocalPlaylist> {
+        val tracksByIdentity = tracks.associateBy(TrackEntity::identityKey)
+        val membersByPlaylist = members.groupBy(PlaylistMemberEntity::playlistId)
+        val tokensByMember = memberTokens.groupBy { token ->
+            PlaylistMemberKey(token.playlistId, token.identityKey)
+        }
+
+        return playlists
+            .sortedWith(compareBy<LocalPlaylistEntity> { it.displayPosition }.thenBy { it.playlistId })
+            .map { playlist ->
+                val songs = membersByPlaylist[playlist.playlistId]
+                    .orEmpty()
+                    .sortedWith(
+                        compareBy<PlaylistMemberEntity> { it.displayPosition }
+                            .thenByDescending { it.addedAt }
+                            .thenBy { it.orderTieBreak }
+                            .thenBy { it.identityKey }
+                    )
+                    .map { member ->
+                        val track = requireNotNull(tracksByIdentity[member.identityKey]) {
+                            "Missing track row for ${member.identityKey}"
+                        }
+                        member.toSongItem(
+                            track = track,
+                            tokens = tokensByMember[
+                                PlaylistMemberKey(member.playlistId, member.identityKey)
+                            ].orEmpty()
+                        )
+                    }
+                    .toMutableList()
+                LocalPlaylist(
+                    id = playlist.playlistId,
+                    name = playlist.name,
+                    songs = songs,
+                    modifiedAt = playlist.modifiedAt,
+                    customCoverUrl = playlist.customCoverUrl,
+                    songOrderVersion = playlist.songOrderVersion
+                )
+            }
+    }
+
+    fun validateRoundTrip(playlists: List<LocalPlaylist>): LocalPlaylistRoomValidationResult {
+        val snapshot = toSnapshot(playlists)
+        val roundTrip = toDomain(
+            playlists = snapshot.playlists,
+            tracks = snapshot.tracks,
+            members = snapshot.members,
+            memberTokens = snapshot.memberTokens
+        )
+        val expected = playlists.map { playlist ->
+            playlist.copy(
+                songs = playlist.songs.mapTo(mutableListOf()) { song ->
+                    song.copy(
+                        streamUrl = null,
+                        syncMembershipTokens = song.syncMembershipTokens.normalizedSyncCausalTokens()
+                    )
+                }
+            )
+        }
+        return LocalPlaylistRoomValidationResult(
+            equivalent = expected == roundTrip,
+            playlistCount = snapshot.playlists.size,
+            memberCount = snapshot.members.size,
+            firstMismatch = firstMismatch(expected, roundTrip)
+        )
+    }
+
+    private fun LocalPlaylist.toEntity(displayPosition: Int): LocalPlaylistEntity {
+        return LocalPlaylistEntity(
+            playlistId = id,
+            name = name,
+            displayPosition = displayPosition,
+            customCoverUrl = customCoverUrl,
+            modifiedAt = modifiedAt,
+            songOrderVersion = songOrderVersion,
+            isSystem = id < 0L
+        )
+    }
+
+    private fun SongItem.toTrackEntity(identityKey: String): TrackEntity {
+        val identity = identity()
+        return TrackEntity(
+            identityKey = identityKey,
+            identityId = identity.id,
+            identityAlbum = identity.album,
+            identityMediaUri = identity.mediaUri,
+            songId = id,
+            name = name,
+            artist = artist,
+            album = album,
+            albumId = albumId,
+            durationMs = durationMs,
+            coverUrl = coverUrl,
+            mediaUri = mediaUri,
+            channelId = channelId,
+            audioId = audioId,
+            subAudioId = subAudioId,
+            sourceStableKey = sourceStableKey,
+            localFileName = localFileName,
+            localFilePath = localFilePath,
+            payloadSchemaVersion = LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION,
+            durablePayloadJson = gson.toJson(withoutTransientDatabaseState())
+        )
+    }
+
+    private fun SongItem.toMemberEntity(
+        playlistId: Long,
+        identityKey: String,
+        displayPosition: Int
+    ): PlaylistMemberEntity {
+        return PlaylistMemberEntity(
+            playlistId = playlistId,
+            identityKey = identityKey,
+            displayPosition = displayPosition,
+            addedAt = addedAt,
+            orderTieBreak = displayPosition,
+            playlistContextId = playlistContextId,
+            memberPayloadSchemaVersion = LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION,
+            memberPayloadJson = gson.toJson(withoutTransientDatabaseState())
+        )
+    }
+
+    private fun PlaylistMemberEntity.toSongItem(
+        track: TrackEntity,
+        tokens: List<PlaylistMemberTokenEntity>
+    ): SongItem {
+        val payload = requireNotNull(
+            decodeSong(memberPayloadJson) ?: decodeSong(track.durablePayloadJson)
+        ) {
+            "Song payload is missing for ${track.identityKey}"
+        }
+        return payload.copy(
+            addedAt = addedAt,
+            playlistContextId = playlistContextId,
+            syncMembershipTokens = tokens
+                .sortedWith(
+                    compareBy<PlaylistMemberTokenEntity> { it.tokenIndex }
+                        .thenBy { it.deviceId }
+                        .thenBy { it.counter }
+                )
+                .map { token ->
+                    SyncCausalToken(
+                        deviceId = token.deviceId,
+                        counter = token.counter
+                    )
+                },
+            streamUrl = null
+        )
+    }
+
+    private fun decodeSong(payload: String): SongItem? {
+        return runCatching {
+            gson.fromJson(payload, SongItem::class.java)
+        }.getOrNull()
+    }
+
+    private fun SongItem.withoutTransientDatabaseState(): SongItem {
+        return copy(streamUrl = null)
+    }
+
+    private fun buildMigrationMetadata(
+        sourceDigest: String?,
+        now: Long
+    ): List<MigrationMetadataEntity> {
+        return buildList {
+            add(
+                MigrationMetadataEntity(
+                    key = "local_playlist_import_schema",
+                    value = LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION.toString(),
+                    updatedAt = now
+                )
+            )
+            add(
+                MigrationMetadataEntity(
+                    key = "local_playlist_cutover_state",
+                    value = "shadow",
+                    updatedAt = now
+                )
+            )
+            sourceDigest?.let { digest ->
+                add(
+                    MigrationMetadataEntity(
+                        key = "local_playlist_source_digest",
+                        value = digest,
+                        updatedAt = now
+                    )
+                )
+            }
+        }
+    }
+
+    private fun firstMismatch(
+        expected: List<LocalPlaylist>,
+        actual: List<LocalPlaylist>
+    ): String? {
+        if (expected == actual) return null
+        if (expected.size != actual.size) {
+            return "playlist count expected=${expected.size} actual=${actual.size}"
+        }
+        expected.zip(actual).forEachIndexed { index, (left, right) ->
+            if (left != right) return "playlist[$index] expected=$left actual=$right"
+        }
+        return "unknown mismatch"
+    }
+
+    private data class PlaylistMemberKey(
+        val playlistId: Long,
+        val identityKey: String
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomShadowImporter.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomShadowImporter.kt
@@ -1,0 +1,65 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import android.content.Context
+import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.playlist.LocalPlaylistRepository
+
+internal class LocalPlaylistRoomShadowImporter(
+    context: Context,
+    private val repository: LocalPlaylistRepository
+) {
+    private val appContext = context.applicationContext
+
+    suspend fun importIfNeeded() {
+        if (!repository.awaitInitialized()) {
+            NPLogger.w(TAG, "Skip Room shadow import because playlist load failed")
+            return
+        }
+
+        val playlists = repository.playlists.value
+        val sourceDigest = LocalPlaylistRoomStore.sourceDigest(playlists)
+        val store = LocalPlaylistRoomStore(
+            database = NeriUserDataDatabase.getInstance(appContext)
+        )
+        if (store.isRoomPrimary()) {
+            NPLogger.d(TAG, "Skip legacy shadow import because Room is already primary")
+            return
+        }
+        val result = runCatching {
+            store.importShadowSnapshotIfChanged(
+                playlists = playlists,
+                sourceDigest = sourceDigest
+            )
+        }.getOrElse { error ->
+            NPLogger.e(TAG, "Room shadow import failed; JSON remains authoritative", error)
+            return
+        }
+
+        when (result.status) {
+            LocalPlaylistRoomShadowImportStatus.IMPORTED -> {
+                NPLogger.i(
+                    TAG,
+                    "Room shadow import completed: playlists=${result.playlistCount}, " +
+                        "members=${result.memberCount}"
+                )
+            }
+
+            LocalPlaylistRoomShadowImportStatus.SKIPPED_UNCHANGED -> {
+                NPLogger.d(TAG, "Room shadow import skipped because source digest is unchanged")
+            }
+
+            LocalPlaylistRoomShadowImportStatus.SKIPPED_NOT_EQUIVALENT -> {
+                NPLogger.w(
+                    TAG,
+                    "Room shadow import skipped because mapper is not equivalent: " +
+                        result.firstMismatch
+                )
+            }
+        }
+    }
+
+    private companion object {
+        const val TAG = "LocalPlaylistRoomShadow"
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomStore.kt
@@ -29,7 +29,7 @@ internal class LocalPlaylistRoomStore(
     private val database: NeriUserDataDatabase,
     private val gson: Gson = Gson()
 ) {
-    private val mapper = LocalPlaylistRoomMapper(gson)
+    private val mapper = LocalPlaylistRoomMapper()
 
     suspend fun isRoomPrimary(): Boolean {
         return database.syncMetadataDao()
@@ -57,6 +57,7 @@ internal class LocalPlaylistRoomStore(
                 playlists = snapshot.playlists,
                 tracks = snapshot.tracks,
                 members = snapshot.members,
+                memberNeteaseArtists = snapshot.memberNeteaseArtists,
                 memberTokens = snapshot.memberTokens
             )
             snapshot.migrationMetadata
@@ -114,11 +115,14 @@ internal class LocalPlaylistRoomStore(
         )
         val tracksByIdentity = snapshot.tracks.associateBy { it.identityKey }
         val changedMembers = snapshot.members
+        val changedMemberNeteaseArtists = snapshot.memberNeteaseArtists
         val changedTokens = snapshot.memberTokens
 
         database.withTransaction {
             removedIds.forEach { playlistId ->
                 database.localPlaylistDao().deleteMemberTokensForPlaylist(playlistId)
+                database.localPlaylistDao()
+                    .deleteMemberNeteaseArtistsForPlaylist(playlistId)
                 database.localPlaylistDao().deleteMembersForPlaylist(playlistId)
                 database.localPlaylistDao().deletePlaylist(playlistId)
             }
@@ -136,11 +140,14 @@ internal class LocalPlaylistRoomStore(
                 .forEach { playlistId ->
                     if (playlistId !in removedIds) {
                         database.localPlaylistDao().deleteMemberTokensForPlaylist(playlistId)
+                        database.localPlaylistDao()
+                            .deleteMemberNeteaseArtistsForPlaylist(playlistId)
                         database.localPlaylistDao().deleteMembersForPlaylist(playlistId)
                     }
                 }
             database.localPlaylistDao().insertTracks(tracksByIdentity.values.toList())
             database.localPlaylistDao().insertMembers(changedMembers)
+            database.localPlaylistDao().insertMemberNeteaseArtists(changedMemberNeteaseArtists)
             database.localPlaylistDao().insertMemberTokens(changedTokens)
             database.localPlaylistDao().deleteOrphanTracks()
             database.syncMetadataDao().upsertMigrationMetadata(
@@ -166,6 +173,8 @@ internal class LocalPlaylistRoomStore(
                 playlists = database.localPlaylistDao().getPlaylists(),
                 tracks = database.localPlaylistDao().getTracks(),
                 members = database.localPlaylistDao().getMembers(),
+                memberNeteaseArtists = database.localPlaylistDao()
+                    .getMemberNeteaseArtists(),
                 memberTokens = database.localPlaylistDao().getMemberTokens()
             )
         }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomStore.kt
@@ -11,6 +11,7 @@ import moe.ouom.neriplayer.data.model.identity
 import moe.ouom.neriplayer.data.model.stableKey
 import java.security.MessageDigest
 import java.util.UUID
+import moe.ouom.neriplayer.core.logging.NPLogger
 
 internal enum class LocalPlaylistRoomShadowImportStatus {
     IMPORTED,
@@ -46,7 +47,8 @@ internal class LocalPlaylistRoomStore(
 
     suspend fun replacePlaylists(
         playlists: List<LocalPlaylist>,
-        sourceDigest: String? = null
+        sourceDigest: String? = null,
+        cutoverState: String = ROOM_PRIMARY_STATE
     ) {
         val snapshot = mapper.toSnapshot(
             playlists = playlists,
@@ -63,7 +65,7 @@ internal class LocalPlaylistRoomStore(
             snapshot.migrationMetadata
                 .map { metadata ->
                     if (metadata.key == CUTOVER_STATE_METADATA_KEY) {
-                        metadata.copy(value = ROOM_PRIMARY_STATE)
+                        metadata.copy(value = cutoverState)
                     } else {
                         metadata
                     }
@@ -138,12 +140,10 @@ internal class LocalPlaylistRoomStore(
             changedIds
                 .filter { it in nextById }
                 .forEach { playlistId ->
-                    if (playlistId !in removedIds) {
-                        database.localPlaylistDao().deleteMemberTokensForPlaylist(playlistId)
-                        database.localPlaylistDao()
-                            .deleteMemberNeteaseArtistsForPlaylist(playlistId)
-                        database.localPlaylistDao().deleteMembersForPlaylist(playlistId)
-                    }
+                    database.localPlaylistDao().deleteMemberTokensForPlaylist(playlistId)
+                    database.localPlaylistDao()
+                        .deleteMemberNeteaseArtistsForPlaylist(playlistId)
+                    database.localPlaylistDao().deleteMembersForPlaylist(playlistId)
                 }
             database.localPlaylistDao().insertTracks(tracksByIdentity.values.toList())
             database.localPlaylistDao().insertMembers(changedMembers)
@@ -195,6 +195,8 @@ internal class LocalPlaylistRoomStore(
                         entry.mutationPayloadJson,
                         moe.ouom.neriplayer.data.local.playlist.LocalPlaylistSyncMutation::class.java
                     )
+                }.onFailure { error ->
+                    NPLogger.w("LocalPlaylistRoomStore", "Skipping invalid sync outbox entry", error)
                 }.getOrNull()
             }
         ).takeIf { it.mutations.isNotEmpty() }
@@ -204,6 +206,9 @@ internal class LocalPlaylistRoomStore(
         outbox: LocalPlaylistSyncMutationOutbox,
         now: Long = System.currentTimeMillis()
     ) {
+        require(outbox.mutations.size <= MAX_PENDING_OUTBOX_ENTRIES) {
+            "Pending playlist sync outbox exceeds $MAX_PENDING_OUTBOX_ENTRIES entries"
+        }
         database.withTransaction {
             database.syncMetadataDao().deleteOutboxByStatus(SyncOutboxStatus.PENDING)
             outbox.mutations.forEachIndexed { index, mutation ->
@@ -254,7 +259,7 @@ internal class LocalPlaylistRoomStore(
             )
         }
 
-        replacePlaylists(playlists, sourceDigest)
+        replacePlaylists(playlists, sourceDigest, cutoverState = "shadow")
         return LocalPlaylistRoomShadowImportResult(
             status = LocalPlaylistRoomShadowImportStatus.IMPORTED,
             playlistCount = validation.playlistCount,

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomStore.kt
@@ -44,20 +44,6 @@ internal class LocalPlaylistRoomStore(
         return readPlaylists()
     }
 
-    suspend fun markLegacyJsonPrimary(
-        sourceDigest: String,
-        now: Long = System.currentTimeMillis()
-    ) {
-        database.withTransaction {
-            database.syncMetadataDao().upsertMigrationMetadata(
-                migrationMetadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
-            )
-            database.syncMetadataDao().upsertMigrationMetadata(
-                migrationMetadata(SOURCE_DIGEST_METADATA_KEY, sourceDigest, now)
-            )
-        }
-    }
-
     suspend fun replacePlaylists(
         playlists: List<LocalPlaylist>,
         sourceDigest: String? = null
@@ -293,7 +279,6 @@ internal class LocalPlaylistRoomStore(
         const val CUTOVER_STATE_METADATA_KEY = "local_playlist_cutover_state"
         const val IMPORT_SCHEMA_METADATA_KEY = "local_playlist_import_schema"
         const val ROOM_PRIMARY_STATE = "room_primary"
-        const val LEGACY_JSON_STATE = "legacy_json"
         private const val MAX_PENDING_OUTBOX_ENTRIES = 256
 
         fun sourceDigest(playlists: List<LocalPlaylist>): String {

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomStore.kt
@@ -1,0 +1,382 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import androidx.room.withTransaction
+import com.google.gson.Gson
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.SyncOutboxEntity
+import moe.ouom.neriplayer.data.local.database.entity.SyncOutboxStatus
+import moe.ouom.neriplayer.data.local.playlist.model.LocalPlaylist
+import moe.ouom.neriplayer.data.local.playlist.LocalPlaylistSyncMutationOutbox
+import moe.ouom.neriplayer.data.model.identity
+import moe.ouom.neriplayer.data.model.stableKey
+import java.security.MessageDigest
+import java.util.UUID
+
+internal enum class LocalPlaylistRoomShadowImportStatus {
+    IMPORTED,
+    SKIPPED_UNCHANGED,
+    SKIPPED_NOT_EQUIVALENT
+}
+
+internal data class LocalPlaylistRoomShadowImportResult(
+    val status: LocalPlaylistRoomShadowImportStatus,
+    val playlistCount: Int,
+    val memberCount: Int,
+    val firstMismatch: String? = null
+)
+
+internal class LocalPlaylistRoomStore(
+    private val database: NeriUserDataDatabase,
+    private val gson: Gson = Gson()
+) {
+    private val mapper = LocalPlaylistRoomMapper(gson)
+
+    suspend fun isRoomPrimary(): Boolean {
+        return database.syncMetadataDao()
+            .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+            ?.value == ROOM_PRIMARY_STATE
+    }
+
+    suspend fun readIfRoomPrimary(): List<LocalPlaylist>? {
+        if (!isRoomPrimary()) {
+            return null
+        }
+        return readPlaylists()
+    }
+
+    suspend fun markLegacyJsonPrimary(
+        sourceDigest: String,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            database.syncMetadataDao().upsertMigrationMetadata(
+                migrationMetadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
+            )
+            database.syncMetadataDao().upsertMigrationMetadata(
+                migrationMetadata(SOURCE_DIGEST_METADATA_KEY, sourceDigest, now)
+            )
+        }
+    }
+
+    suspend fun replacePlaylists(
+        playlists: List<LocalPlaylist>,
+        sourceDigest: String? = null
+    ) {
+        val snapshot = mapper.toSnapshot(
+            playlists = playlists,
+            sourceDigest = sourceDigest
+        )
+        database.withTransaction {
+            database.localPlaylistDao().replaceSnapshot(
+                playlists = snapshot.playlists,
+                tracks = snapshot.tracks,
+                members = snapshot.members,
+                memberTokens = snapshot.memberTokens
+            )
+            snapshot.migrationMetadata
+                .map { metadata ->
+                    if (metadata.key == CUTOVER_STATE_METADATA_KEY) {
+                        metadata.copy(value = ROOM_PRIMARY_STATE)
+                    } else {
+                        metadata
+                    }
+                }
+                .forEach { metadata ->
+                    database.syncMetadataDao().upsertMigrationMetadata(metadata)
+                }
+        }
+    }
+
+    suspend fun writeIncremental(
+        previous: List<LocalPlaylist>,
+        next: List<LocalPlaylist>,
+        sourceDigest: String,
+        now: Long = System.currentTimeMillis()
+    ) {
+        val previousById = previous.associateBy(LocalPlaylist::id)
+        val nextById = next.associateBy(LocalPlaylist::id)
+        val previousPositions = previous.withIndex().associate { it.value.id to it.index }
+        val nextPositions = next.withIndex().associate { it.value.id to it.index }
+        val changedIds = (previousById.keys + nextById.keys)
+            .filter { playlistId ->
+                previousById[playlistId] != nextById[playlistId] ||
+                    previousPositions[playlistId] != nextPositions[playlistId]
+            }
+            .toSet()
+        if (changedIds.isEmpty()) {
+            database.withTransaction {
+                database.syncMetadataDao().upsertMigrationMetadata(
+                    migrationMetadata(CUTOVER_STATE_METADATA_KEY, ROOM_PRIMARY_STATE, now)
+                )
+                database.syncMetadataDao().upsertMigrationMetadata(
+                    migrationMetadata(SOURCE_DIGEST_METADATA_KEY, sourceDigest, now)
+                )
+            }
+            return
+        }
+
+        val removedIds = changedIds.filter { it !in nextById }
+        val changedPlaylists = next
+            .filter { it.id in changedIds }
+            .map { playlist ->
+                playlist to nextPositions.getValue(playlist.id)
+            }
+        val snapshot = mapper.toSnapshot(
+            playlists = changedPlaylists.map { it.first },
+            sourceDigest = sourceDigest,
+            now = now
+        )
+        val tracksByIdentity = snapshot.tracks.associateBy { it.identityKey }
+        val changedMembers = snapshot.members
+        val changedTokens = snapshot.memberTokens
+
+        database.withTransaction {
+            removedIds.forEach { playlistId ->
+                database.localPlaylistDao().deleteMemberTokensForPlaylist(playlistId)
+                database.localPlaylistDao().deleteMembersForPlaylist(playlistId)
+                database.localPlaylistDao().deletePlaylist(playlistId)
+            }
+
+            database.localPlaylistDao().insertPlaylists(
+                changedPlaylists.map { (playlist, position) ->
+                    snapshot.playlists
+                        .first { it.playlistId == playlist.id }
+                        .copy(displayPosition = position)
+                }
+            )
+
+            changedIds
+                .filter { it in nextById }
+                .forEach { playlistId ->
+                    if (playlistId !in removedIds) {
+                        database.localPlaylistDao().deleteMemberTokensForPlaylist(playlistId)
+                        database.localPlaylistDao().deleteMembersForPlaylist(playlistId)
+                    }
+                }
+            database.localPlaylistDao().insertTracks(tracksByIdentity.values.toList())
+            database.localPlaylistDao().insertMembers(changedMembers)
+            database.localPlaylistDao().insertMemberTokens(changedTokens)
+            database.localPlaylistDao().deleteOrphanTracks()
+            database.syncMetadataDao().upsertMigrationMetadata(
+                migrationMetadata(CUTOVER_STATE_METADATA_KEY, ROOM_PRIMARY_STATE, now)
+            )
+            database.syncMetadataDao().upsertMigrationMetadata(
+                migrationMetadata(SOURCE_DIGEST_METADATA_KEY, sourceDigest, now)
+            )
+            database.syncMetadataDao().upsertMigrationMetadata(
+                migrationMetadata(
+                    IMPORT_SCHEMA_METADATA_KEY,
+                    moe.ouom.neriplayer.data.local.database.entity
+                        .LOCAL_PLAYLIST_PAYLOAD_SCHEMA_VERSION.toString(),
+                    now
+                )
+            )
+        }
+    }
+
+    suspend fun readPlaylists(): List<LocalPlaylist> {
+        return database.withTransaction {
+            mapper.toDomain(
+                playlists = database.localPlaylistDao().getPlaylists(),
+                tracks = database.localPlaylistDao().getTracks(),
+                members = database.localPlaylistDao().getMembers(),
+                memberTokens = database.localPlaylistDao().getMemberTokens()
+            )
+        }
+    }
+
+    suspend fun readPendingSyncMutationOutbox(): LocalPlaylistSyncMutationOutbox? {
+        val entries = database.syncMetadataDao().getOutbox(
+            statuses = listOf(SyncOutboxStatus.PENDING),
+            limit = MAX_PENDING_OUTBOX_ENTRIES
+        )
+        if (entries.isEmpty()) {
+            return null
+        }
+        return LocalPlaylistSyncMutationOutbox(
+            mutations = entries.mapNotNull { entry ->
+                runCatching {
+                    gson.fromJson(
+                        entry.mutationPayloadJson,
+                        moe.ouom.neriplayer.data.local.playlist.LocalPlaylistSyncMutation::class.java
+                    )
+                }.getOrNull()
+            }
+        ).takeIf { it.mutations.isNotEmpty() }
+    }
+
+    suspend fun writePendingSyncMutationOutbox(
+        outbox: LocalPlaylistSyncMutationOutbox,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            database.syncMetadataDao().deleteOutboxByStatus(SyncOutboxStatus.PENDING)
+            outbox.mutations.forEachIndexed { index, mutation ->
+                database.syncMetadataDao().insertOutbox(
+                    SyncOutboxEntity(
+                        operationId = "playlist-mutation-${UUID.randomUUID()}-$index",
+                        expectedDomainRevision = 0L,
+                        payloadVersion = 1,
+                        mutationPayloadJson = gson.toJson(mutation),
+                        createdAt = now,
+                        updatedAt = now
+                    )
+                )
+            }
+        }
+    }
+
+    suspend fun clearPendingSyncMutationOutbox() {
+        database.syncMetadataDao().deleteOutboxByStatus(SyncOutboxStatus.PENDING)
+    }
+
+    fun validateRoundTrip(playlists: List<LocalPlaylist>): LocalPlaylistRoomValidationResult {
+        return mapper.validateRoundTrip(playlists)
+    }
+
+    suspend fun importShadowSnapshotIfChanged(
+        playlists: List<LocalPlaylist>,
+        sourceDigest: String
+    ): LocalPlaylistRoomShadowImportResult {
+        val currentDigest = database.syncMetadataDao()
+            .getMigrationMetadata(SOURCE_DIGEST_METADATA_KEY)
+            ?.value
+        if (currentDigest == sourceDigest) {
+            return LocalPlaylistRoomShadowImportResult(
+                status = LocalPlaylistRoomShadowImportStatus.SKIPPED_UNCHANGED,
+                playlistCount = playlists.size,
+                memberCount = playlists.sumOf { it.songs.size }
+            )
+        }
+
+        val validation = mapper.validateRoundTrip(playlists)
+        if (!validation.equivalent) {
+            return LocalPlaylistRoomShadowImportResult(
+                status = LocalPlaylistRoomShadowImportStatus.SKIPPED_NOT_EQUIVALENT,
+                playlistCount = validation.playlistCount,
+                memberCount = validation.memberCount,
+                firstMismatch = validation.firstMismatch
+            )
+        }
+
+        replacePlaylists(playlists, sourceDigest)
+        return LocalPlaylistRoomShadowImportResult(
+            status = LocalPlaylistRoomShadowImportStatus.IMPORTED,
+            playlistCount = validation.playlistCount,
+            memberCount = validation.memberCount
+        )
+    }
+
+    suspend fun importLegacyAndPromote(
+        playlists: List<LocalPlaylist>,
+        sourceDigest: String
+    ): LocalPlaylistRoomShadowImportResult {
+        val validation = mapper.validateRoundTrip(playlists)
+        if (!validation.equivalent) {
+            return LocalPlaylistRoomShadowImportResult(
+                status = LocalPlaylistRoomShadowImportStatus.SKIPPED_NOT_EQUIVALENT,
+                playlistCount = validation.playlistCount,
+                memberCount = validation.memberCount,
+                firstMismatch = validation.firstMismatch
+            )
+        }
+        replacePlaylists(playlists, sourceDigest)
+        return LocalPlaylistRoomShadowImportResult(
+            status = LocalPlaylistRoomShadowImportStatus.IMPORTED,
+            playlistCount = validation.playlistCount,
+            memberCount = validation.memberCount
+        )
+    }
+
+    companion object {
+        const val SOURCE_DIGEST_METADATA_KEY = "local_playlist_source_digest"
+        const val CUTOVER_STATE_METADATA_KEY = "local_playlist_cutover_state"
+        const val IMPORT_SCHEMA_METADATA_KEY = "local_playlist_import_schema"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+        const val LEGACY_JSON_STATE = "legacy_json"
+        private const val MAX_PENDING_OUTBOX_ENTRIES = 256
+
+        fun sourceDigest(playlists: List<LocalPlaylist>): String {
+            return domainDigest(playlists)
+        }
+
+        fun domainDigest(playlists: List<LocalPlaylist>): String {
+            val digest = MessageDigest.getInstance("SHA-256")
+            val canonical = StringBuilder()
+            fun append(value: Any?) {
+                val text = value?.toString() ?: "<null>"
+                canonical.append(text.length).append(':').append(text).append('|')
+            }
+            append(playlists.size)
+            playlists.forEachIndexed { playlistIndex, playlist ->
+                append(playlistIndex)
+                append(playlist.id)
+                append(playlist.name)
+                append(playlist.modifiedAt)
+                append(playlist.customCoverUrl)
+                append(playlist.songOrderVersion)
+                append(playlist.songs.size)
+                playlist.songs.forEachIndexed { songIndex, song ->
+                    append(songIndex)
+                    append(song.identity().stableKey())
+                    append(song.id)
+                    append(song.name)
+                    append(song.artist)
+                    append(song.album)
+                    append(song.albumId)
+                    append(song.durationMs)
+                    append(song.coverUrl)
+                    append(song.mediaUri)
+                    append(song.matchedLyric)
+                    append(song.matchedTranslatedLyric)
+                    append(song.matchedLyricSource)
+                    append(song.matchedSongId)
+                    append(song.userLyricOffsetMs)
+                    append(song.customCoverUrl)
+                    append(song.customName)
+                    append(song.customArtist)
+                    append(song.originalName)
+                    append(song.originalArtist)
+                    append(song.originalCoverUrl)
+                    append(song.originalLyric)
+                    append(song.originalTranslatedLyric)
+                    append(song.localFileName)
+                    append(song.localFilePath)
+                    append(song.channelId)
+                    append(song.audioId)
+                    append(song.subAudioId)
+                    append(song.playlistContextId)
+                    append(song.sourceStableKey)
+                    append(song.addedAt)
+                    append(song.neteaseArtists?.size ?: 0)
+                    song.neteaseArtists.orEmpty().forEach { artist ->
+                        append(artist.id)
+                            append(artist.name)
+                        }
+                    append(song.syncMembershipTokens?.size ?: 0)
+                    song.syncMembershipTokens
+                        .orEmpty()
+                        .sortedWith(compareBy({ it.deviceId }, { it.counter }))
+                        .forEach { token ->
+                            append(token.deviceId)
+                            append(token.counter)
+                        }
+                }
+            }
+            return digest.digest(canonical.toString().toByteArray(Charsets.UTF_8))
+                .joinToString(separator = "") { byte ->
+                    "%02x".format(byte.toInt() and 0xff)
+                }
+        }
+
+        private fun migrationMetadata(
+            key: String,
+            value: String,
+            now: Long
+        ) = moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity(
+            key = key,
+            value = value,
+            updatedAt = now
+        )
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlatformPlaylistCacheRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlatformPlaylistCacheRoomStore.kt
@@ -1,0 +1,218 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import androidx.room.withTransaction
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheTrackArtistEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheTrackEntity
+
+internal data class PlatformPlaylistCacheRecord(
+    val platform: String,
+    val cacheKey: String,
+    val sourceId: Long? = null,
+    val alternateKey: String? = null,
+    val kind: String? = null,
+    val title: String? = null,
+    val subtitle: String? = null,
+    val creatorName: String? = null,
+    val coverUrl: String? = null,
+    val playCount: Long? = null,
+    val trackCount: Int = 0,
+    val totalCount: Int = 0,
+    val signaturePrimary: String? = null,
+    val signatureSecondary: String? = null,
+    val hasMore: Boolean? = null,
+    val savedAtMs: Long,
+    val tracks: List<PlatformPlaylistCacheTrackRecord>
+)
+
+internal data class PlatformPlaylistCacheTrackRecord(
+    val itemId: Long? = null,
+    val itemKey: String? = null,
+    val name: String,
+    val artist: String,
+    val album: String = "",
+    val albumId: Long? = null,
+    val durationMs: Long = 0L,
+    val coverUrl: String? = null,
+    val audioId: String? = null,
+    val uploaderMid: Long? = null,
+    val addedAt: Long = 0L,
+    val artists: List<PlatformPlaylistCacheArtistRecord> = emptyList()
+)
+
+internal data class PlatformPlaylistCacheArtistRecord(
+    val id: Long,
+    val name: String
+)
+
+internal class PlatformPlaylistCacheRoomStore(
+    private val database: NeriUserDataDatabase
+) {
+    suspend fun read(
+        platform: String,
+        cacheKey: String
+    ): PlatformPlaylistCacheRecord? {
+        return database.withTransaction {
+            val dao = database.platformPlaylistCacheDao()
+            val cache = dao.getCache(platform, cacheKey) ?: return@withTransaction null
+            val tracks = dao.getTracks(platform, cacheKey)
+            val artistsByTrack = dao.getArtists(platform, cacheKey)
+                .groupBy(PlatformPlaylistCacheTrackArtistEntity::trackPosition)
+            cache.toRecord(
+                tracks = tracks.map { track ->
+                    track.toRecord(
+                        artists = artistsByTrack[track.position]
+                            .orEmpty()
+                            .map { artist -> artist.toRecord() }
+                    )
+                }
+            )
+        }
+    }
+
+    suspend fun replace(record: PlatformPlaylistCacheRecord) {
+        database.withTransaction {
+            val dao = database.platformPlaylistCacheDao()
+            dao.deleteArtists(record.platform, record.cacheKey)
+            dao.deleteTracks(record.platform, record.cacheKey)
+            dao.upsertCache(record.toEntity())
+            dao.insertTracks(record.toTrackEntities())
+            dao.insertArtists(record.toArtistEntities())
+        }
+    }
+
+    suspend fun replaceIfNewer(record: PlatformPlaylistCacheRecord) {
+        database.withTransaction {
+            val dao = database.platformPlaylistCacheDao()
+            val existing = dao.getCache(record.platform, record.cacheKey)
+            if (existing != null && existing.savedAtMs > record.savedAtMs) {
+                return@withTransaction
+            }
+            dao.deleteArtists(record.platform, record.cacheKey)
+            dao.deleteTracks(record.platform, record.cacheKey)
+            dao.upsertCache(record.toEntity())
+            dao.insertTracks(record.toTrackEntities())
+            dao.insertArtists(record.toArtistEntities())
+        }
+    }
+
+    suspend fun clear(
+        platform: String,
+        cacheKey: String
+    ) {
+        database.withTransaction {
+            val dao = database.platformPlaylistCacheDao()
+            dao.deleteArtists(platform, cacheKey)
+            dao.deleteTracks(platform, cacheKey)
+            dao.deleteCache(platform, cacheKey)
+        }
+    }
+
+    private fun PlatformPlaylistCacheRecord.toEntity(): PlatformPlaylistCacheEntity {
+        return PlatformPlaylistCacheEntity(
+            platform = platform,
+            cacheKey = cacheKey,
+            sourceId = sourceId,
+            alternateKey = alternateKey,
+            kind = kind,
+            title = title,
+            subtitle = subtitle,
+            creatorName = creatorName,
+            coverUrl = coverUrl,
+            playCount = playCount,
+            trackCount = trackCount,
+            totalCount = totalCount,
+            signaturePrimary = signaturePrimary,
+            signatureSecondary = signatureSecondary,
+            hasMore = hasMore,
+            savedAtMs = savedAtMs
+        )
+    }
+
+    private fun PlatformPlaylistCacheRecord.toTrackEntities(): List<PlatformPlaylistCacheTrackEntity> {
+        return tracks.mapIndexed { index, track ->
+            PlatformPlaylistCacheTrackEntity(
+                platform = platform,
+                cacheKey = cacheKey,
+                position = index,
+                itemId = track.itemId,
+                itemKey = track.itemKey,
+                name = track.name,
+                artist = track.artist,
+                album = track.album,
+                albumId = track.albumId,
+                durationMs = track.durationMs,
+                coverUrl = track.coverUrl,
+                audioId = track.audioId,
+                uploaderMid = track.uploaderMid,
+                addedAt = track.addedAt
+            )
+        }
+    }
+
+    private fun PlatformPlaylistCacheRecord.toArtistEntities(): List<PlatformPlaylistCacheTrackArtistEntity> {
+        return tracks.flatMapIndexed { trackIndex, track ->
+            track.artists.mapIndexed { artistIndex, artist ->
+                PlatformPlaylistCacheTrackArtistEntity(
+                    platform = platform,
+                    cacheKey = cacheKey,
+                    trackPosition = trackIndex,
+                    artistPosition = artistIndex,
+                    artistId = artist.id,
+                    name = artist.name
+                )
+            }
+        }
+    }
+
+    private fun PlatformPlaylistCacheEntity.toRecord(
+        tracks: List<PlatformPlaylistCacheTrackRecord>
+    ): PlatformPlaylistCacheRecord {
+        return PlatformPlaylistCacheRecord(
+            platform = platform,
+            cacheKey = cacheKey,
+            sourceId = sourceId,
+            alternateKey = alternateKey,
+            kind = kind,
+            title = title,
+            subtitle = subtitle,
+            creatorName = creatorName,
+            coverUrl = coverUrl,
+            playCount = playCount,
+            trackCount = trackCount,
+            totalCount = totalCount,
+            signaturePrimary = signaturePrimary,
+            signatureSecondary = signatureSecondary,
+            hasMore = hasMore,
+            savedAtMs = savedAtMs,
+            tracks = tracks
+        )
+    }
+
+    private fun PlatformPlaylistCacheTrackEntity.toRecord(
+        artists: List<PlatformPlaylistCacheArtistRecord>
+    ): PlatformPlaylistCacheTrackRecord {
+        return PlatformPlaylistCacheTrackRecord(
+            itemId = itemId,
+            itemKey = itemKey,
+            name = name,
+            artist = artist,
+            album = album,
+            albumId = albumId,
+            durationMs = durationMs,
+            coverUrl = coverUrl,
+            audioId = audioId,
+            uploaderMid = uploaderMid,
+            addedAt = addedAt,
+            artists = artists
+        )
+    }
+
+    private fun PlatformPlaylistCacheTrackArtistEntity.toRecord(): PlatformPlaylistCacheArtistRecord {
+        return PlatformPlaylistCacheArtistRecord(
+            id = artistId,
+            name = name
+        )
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlatformPlaylistCacheRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlatformPlaylistCacheRoomStore.kt
@@ -46,10 +46,26 @@ internal data class PlatformPlaylistCacheArtistRecord(
     val name: String
 )
 
+internal interface PlatformPlaylistCacheStore {
+    suspend fun read(
+        platform: String,
+        cacheKey: String
+    ): PlatformPlaylistCacheRecord?
+
+    suspend fun replace(record: PlatformPlaylistCacheRecord)
+
+    suspend fun replaceIfNewer(record: PlatformPlaylistCacheRecord)
+
+    suspend fun clear(
+        platform: String,
+        cacheKey: String
+    )
+}
+
 internal class PlatformPlaylistCacheRoomStore(
     private val database: NeriUserDataDatabase
-) {
-    suspend fun read(
+) : PlatformPlaylistCacheStore {
+    override suspend fun read(
         platform: String,
         cacheKey: String
     ): PlatformPlaylistCacheRecord? {
@@ -71,7 +87,7 @@ internal class PlatformPlaylistCacheRoomStore(
         }
     }
 
-    suspend fun replace(record: PlatformPlaylistCacheRecord) {
+    override suspend fun replace(record: PlatformPlaylistCacheRecord) {
         database.withTransaction {
             val dao = database.platformPlaylistCacheDao()
             dao.deleteArtists(record.platform, record.cacheKey)
@@ -82,7 +98,7 @@ internal class PlatformPlaylistCacheRoomStore(
         }
     }
 
-    suspend fun replaceIfNewer(record: PlatformPlaylistCacheRecord) {
+    override suspend fun replaceIfNewer(record: PlatformPlaylistCacheRecord) {
         database.withTransaction {
             val dao = database.platformPlaylistCacheDao()
             val existing = dao.getCache(record.platform, record.cacheKey)
@@ -97,7 +113,7 @@ internal class PlatformPlaylistCacheRoomStore(
         }
     }
 
-    suspend fun clear(
+    override suspend fun clear(
         platform: String,
         cacheKey: String
     ) {

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomMapper.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomMapper.kt
@@ -1,0 +1,67 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import moe.ouom.neriplayer.data.history.PlayedEntry
+import moe.ouom.neriplayer.data.local.database.entity.PlayHistoryEntity
+import moe.ouom.neriplayer.data.local.database.entity.toEntity
+import moe.ouom.neriplayer.data.model.SongIdentity
+import moe.ouom.neriplayer.data.model.stableKey
+
+internal class PlayHistoryRoomMapper {
+    fun toEntities(entries: List<PlayedEntry>): List<PlayHistoryEntity> {
+        return entries.map(PlayedEntry::toEntity)
+    }
+
+    fun toDomain(entries: List<PlayHistoryEntity>): List<PlayedEntry> {
+        return entries
+            .sortedWith(compareByDescending<PlayHistoryEntity> { it.playedAt }.thenBy { it.identityKey })
+            .map { it.toDomain() }
+    }
+
+    fun validateRoundTrip(entries: List<PlayedEntry>): Boolean {
+        val normalized = entries.sortedWith(
+            compareByDescending<PlayedEntry> { it.playedAt }.thenBy {
+                SongIdentity(it.id, it.album, it.localFilePath ?: it.mediaUri).stableKey()
+            }
+        )
+        return toDomain(toEntities(entries)) == normalized
+    }
+
+    private fun PlayHistoryEntity.toDomain(): PlayedEntry {
+        val expectedIdentity = SongIdentity(
+            id = identityId,
+            album = identityAlbum,
+            mediaUri = identityMediaUri
+        ).stableKey()
+        check(expectedIdentity == identityKey) {
+            "Play history identity mismatch: expected=$expectedIdentity actual=$identityKey"
+        }
+        return PlayedEntry(
+            id = id,
+            name = name,
+            artist = artist,
+            album = album,
+            albumId = albumId,
+            durationMs = durationMs,
+            resumePositionMs = resumePositionMs,
+            coverUrl = coverUrl,
+            mediaUri = mediaUri,
+            matchedLyric = matchedLyric,
+            matchedTranslatedLyric = matchedTranslatedLyric,
+            customCoverUrl = customCoverUrl,
+            customName = customName,
+            customArtist = customArtist,
+            originalName = originalName,
+            originalArtist = originalArtist,
+            originalCoverUrl = originalCoverUrl,
+            originalLyric = originalLyric,
+            originalTranslatedLyric = originalTranslatedLyric,
+            localFileName = localFileName,
+            localFilePath = localFilePath,
+            channelId = channelId,
+            audioId = audioId,
+            subAudioId = subAudioId,
+            sourceStableKey = sourceStableKey,
+            playedAt = playedAt
+        )
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomStore.kt
@@ -1,0 +1,135 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import androidx.room.withTransaction
+import moe.ouom.neriplayer.data.history.PlayedEntry
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+
+internal enum class PlayHistoryRoomImportStatus {
+    IMPORTED,
+    SKIPPED_NOT_EQUIVALENT
+}
+
+internal data class PlayHistoryRoomImportResult(
+    val status: PlayHistoryRoomImportStatus,
+    val entryCount: Int
+)
+
+internal class PlayHistoryRoomStore(
+    private val database: NeriUserDataDatabase
+) {
+    private val mapper = PlayHistoryRoomMapper()
+
+    suspend fun readIfRoomPrimary(): List<PlayedEntry>? {
+        val state = database.syncMetadataDao()
+            .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+            ?.value
+        if (state != ROOM_PRIMARY_STATE) return null
+        return mapper.toDomain(database.playHistoryDao().getAll())
+    }
+
+    suspend fun importLegacyAndPromote(
+        entries: List<PlayedEntry>,
+        now: Long = System.currentTimeMillis()
+    ): PlayHistoryRoomImportResult {
+        if (!mapper.validateRoundTrip(entries)) {
+            return PlayHistoryRoomImportResult(
+                status = PlayHistoryRoomImportStatus.SKIPPED_NOT_EQUIVALENT,
+                entryCount = entries.size
+            )
+        }
+        replaceAll(entries, now)
+        return PlayHistoryRoomImportResult(
+            status = PlayHistoryRoomImportStatus.IMPORTED,
+            entryCount = entries.size
+        )
+    }
+
+    suspend fun writeIncremental(
+        previous: List<PlayedEntry>,
+        next: List<PlayedEntry>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        val previousByKey = previous.associateBy(::identityKey)
+        val nextByKey = next.associateBy(::identityKey)
+        val changedEntries = next.filter { entry ->
+            previousByKey[identityKey(entry)] != entry
+        }
+        val removedKeys = previousByKey.keys - nextByKey.keys
+        database.withTransaction {
+            if (changedEntries.isNotEmpty()) {
+                database.playHistoryDao().upsert(mapper.toEntities(changedEntries))
+            }
+            removedKeys.toList().chunked(500).forEach { chunk ->
+                if (chunk.isNotEmpty()) {
+                    database.playHistoryDao().deleteByIdentityKeys(chunk)
+                }
+            }
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun replaceAll(
+        entries: List<PlayedEntry>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            database.playHistoryDao().deleteAll()
+            database.playHistoryDao().upsert(mapper.toEntities(entries))
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun clear(now: Long = System.currentTimeMillis()) {
+        database.withTransaction {
+            database.playHistoryDao().deleteAll()
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            migrationMetadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
+        )
+    }
+
+    private suspend fun markRoomPrimary(now: Long) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            migrationMetadata(CUTOVER_STATE_METADATA_KEY, ROOM_PRIMARY_STATE, now)
+        )
+        database.syncMetadataDao().upsertMigrationMetadata(
+            migrationMetadata(
+                IMPORT_SCHEMA_METADATA_KEY,
+                PLAY_HISTORY_SCHEMA_VERSION.toString(),
+                now
+            )
+        )
+    }
+
+    private fun identityKey(entry: PlayedEntry): String {
+        return buildString {
+            append(entry.id)
+            append('|')
+            append(entry.album)
+            append('|')
+            append(entry.localFilePath ?: entry.mediaUri.orEmpty())
+        }
+    }
+
+    private fun migrationMetadata(
+        key: String,
+        value: String,
+        now: Long
+    ) = moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity(
+        key = key,
+        value = value,
+        updatedAt = now
+    )
+
+    companion object {
+        const val CUTOVER_STATE_METADATA_KEY = "play_history_cutover_state"
+        const val IMPORT_SCHEMA_METADATA_KEY = "play_history_import_schema"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+        const val LEGACY_JSON_STATE = "legacy_json"
+        private const val PLAY_HISTORY_SCHEMA_VERSION = 1
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomStore.kt
@@ -86,12 +86,6 @@ internal class PlayHistoryRoomStore(
         }
     }
 
-    suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
-        database.syncMetadataDao().upsertMigrationMetadata(
-            migrationMetadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
-        )
-    }
-
     private suspend fun markRoomPrimary(now: Long) {
         database.syncMetadataDao().upsertMigrationMetadata(
             migrationMetadata(CUTOVER_STATE_METADATA_KEY, ROOM_PRIMARY_STATE, now)
@@ -129,7 +123,6 @@ internal class PlayHistoryRoomStore(
         const val CUTOVER_STATE_METADATA_KEY = "play_history_cutover_state"
         const val IMPORT_SCHEMA_METADATA_KEY = "play_history_import_schema"
         const val ROOM_PRIMARY_STATE = "room_primary"
-        const val LEGACY_JSON_STATE = "legacy_json"
         private const val PLAY_HISTORY_SCHEMA_VERSION = 1
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomStore.kt
@@ -6,6 +6,7 @@ import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 
 internal enum class PlayHistoryRoomImportStatus {
     IMPORTED,
+    SKIPPED_ALREADY_PRIMARY,
     SKIPPED_NOT_EQUIVALENT
 }
 
@@ -37,11 +38,24 @@ internal class PlayHistoryRoomStore(
                 entryCount = entries.size
             )
         }
-        replaceAll(entries, now)
-        return PlayHistoryRoomImportResult(
-            status = PlayHistoryRoomImportStatus.IMPORTED,
-            entryCount = entries.size
-        )
+        return database.withTransaction {
+            val cutoverState = database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value
+            if (cutoverState == ROOM_PRIMARY_STATE) {
+                return@withTransaction PlayHistoryRoomImportResult(
+                    status = PlayHistoryRoomImportStatus.SKIPPED_ALREADY_PRIMARY,
+                    entryCount = entries.size
+                )
+            }
+            database.playHistoryDao().deleteAll()
+            database.playHistoryDao().upsert(mapper.toEntities(entries))
+            markRoomPrimary(now)
+            PlayHistoryRoomImportResult(
+                status = PlayHistoryRoomImportStatus.IMPORTED,
+                entryCount = entries.size
+            )
+        }
     }
 
     suspend fun writeIncremental(

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStore.kt
@@ -166,12 +166,6 @@ internal class PlaybackStatsRoomStore(
         }
     }
 
-    suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
-        database.syncMetadataDao().upsertMigrationMetadata(
-            metadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
-        )
-    }
-
     private suspend fun readSnapshot(): PlaybackStatsRoomSnapshot {
         val dao = database.playbackStatsDao()
         val stats = dao.getStats().map(PlaybackStatEntity::toDomain)
@@ -284,7 +278,6 @@ internal class PlaybackStatsRoomStore(
         const val CLEARED_AT_METADATA_KEY = "playback_stats_cleared_at"
         const val COUNTER_EPOCH_METADATA_KEY = "playback_stats_counter_epoch"
         const val ROOM_PRIMARY_STATE = "room_primary"
-        const val LEGACY_JSON_STATE = "legacy_json"
     }
 }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStore.kt
@@ -41,14 +41,29 @@ internal class PlaybackStatsRoomStore(
         clearedAt: Long,
         now: Long = System.currentTimeMillis()
     ) {
-        replaceAll(
-            stats = stats,
-            dailyStats = dailyStats,
-            counterSnapshot = counterSnapshot,
-            counterEpochStartedAt = counterEpochStartedAt,
-            clearedAt = clearedAt,
-            now = now
-        )
+        database.withTransaction {
+            val cutoverState = database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value
+            if (cutoverState == ROOM_PRIMARY_STATE) {
+                return@withTransaction
+            }
+            val dao = database.playbackStatsDao()
+            dao.deleteAllDailyCounterShards()
+            dao.deleteAllCounterShards()
+            dao.deleteAllBuckets()
+            dao.deleteAllStats()
+            insertAll(
+                stats = stats,
+                dailyStats = dailyStats,
+                counterSnapshot = counterSnapshot
+            )
+            markRoomPrimary(
+                clearedAt = clearedAt,
+                counterEpochStartedAt = counterEpochStartedAt,
+                now = now
+            )
+        }
     }
 
     suspend fun replaceAll(

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStore.kt
@@ -108,11 +108,13 @@ internal class PlaybackStatsRoomStore(
                         key
                     ) != dailyCounterKeysForIdentity(counterSnapshot, key)
             }
+            .toSet()
         val changedKeys = (previousByKey.keys + nextByKey.keys +
             previousDailyByKey.keys + nextDailyByKey.keys + counterChangedKeys)
             .filter { key ->
                 previousByKey[key] != nextByKey[key] ||
-                    previousDailyByKey[key] != nextDailyByKey[key]
+                    previousDailyByKey[key] != nextDailyByKey[key] ||
+                    key in counterChangedKeys
             }
             .toSet()
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaybackStatsRoomStore.kt
@@ -1,0 +1,398 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import androidx.room.withTransaction
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatBucketEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatCounterShardEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatDailyCounterShardEntity
+import moe.ouom.neriplayer.data.local.database.entity.PlaybackStatEntity
+import moe.ouom.neriplayer.data.local.database.entity.toEntity
+import moe.ouom.neriplayer.data.stats.PlaybackStatBucket
+import moe.ouom.neriplayer.data.stats.PlaybackStatsSyncCounterSnapshot
+import moe.ouom.neriplayer.data.stats.TrackStat
+import moe.ouom.neriplayer.data.sync.model.SyncPlaybackCounterShard
+
+internal data class PlaybackStatsRoomSnapshot(
+    val stats: List<TrackStat>,
+    val dailyStats: List<PlaybackStatBucket>,
+    val counterSnapshot: PlaybackStatsSyncCounterSnapshot,
+    val counterEpochStartedAt: Long,
+    val clearedAt: Long
+)
+
+internal class PlaybackStatsRoomStore(
+    private val database: NeriUserDataDatabase
+) {
+    suspend fun readIfRoomPrimary(): PlaybackStatsRoomSnapshot? {
+        if (database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value != ROOM_PRIMARY_STATE
+        ) {
+            return null
+        }
+        return readSnapshot()
+    }
+
+    suspend fun importLegacyAndPromote(
+        stats: List<TrackStat>,
+        dailyStats: List<PlaybackStatBucket>,
+        counterSnapshot: PlaybackStatsSyncCounterSnapshot,
+        counterEpochStartedAt: Long,
+        clearedAt: Long,
+        now: Long = System.currentTimeMillis()
+    ) {
+        replaceAll(
+            stats = stats,
+            dailyStats = dailyStats,
+            counterSnapshot = counterSnapshot,
+            counterEpochStartedAt = counterEpochStartedAt,
+            clearedAt = clearedAt,
+            now = now
+        )
+    }
+
+    suspend fun replaceAll(
+        stats: List<TrackStat>,
+        dailyStats: List<PlaybackStatBucket>,
+        counterSnapshot: PlaybackStatsSyncCounterSnapshot,
+        counterEpochStartedAt: Long,
+        clearedAt: Long,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            val dao = database.playbackStatsDao()
+            dao.deleteAllDailyCounterShards()
+            dao.deleteAllCounterShards()
+            dao.deleteAllBuckets()
+            dao.deleteAllStats()
+            insertAll(
+                stats = stats,
+                dailyStats = dailyStats,
+                counterSnapshot = counterSnapshot
+            )
+            markRoomPrimary(
+                clearedAt = clearedAt,
+                counterEpochStartedAt = counterEpochStartedAt,
+                now = now
+            )
+        }
+    }
+
+    suspend fun writeIncremental(
+        previousStats: List<TrackStat>,
+        nextStats: List<TrackStat>,
+        previousDailyStats: List<PlaybackStatBucket>,
+        nextDailyStats: List<PlaybackStatBucket>,
+        previousCounterSnapshot: PlaybackStatsSyncCounterSnapshot,
+        counterSnapshot: PlaybackStatsSyncCounterSnapshot,
+        counterEpochStartedAt: Long,
+        clearedAt: Long,
+        now: Long = System.currentTimeMillis()
+    ) {
+        val previousByKey = previousStats.associateBy(TrackStat::identityKey)
+        val nextByKey = nextStats.associateBy(TrackStat::identityKey)
+        val previousDailyByKey = previousDailyStats.groupBy(PlaybackStatBucket::identityKey)
+        val nextDailyByKey = nextDailyStats.groupBy(PlaybackStatBucket::identityKey)
+        val previousTrackCounterKeys = previousCounterSnapshot.trackShardsByIdentity.keys
+        val nextTrackCounterKeys = counterSnapshot.trackShardsByIdentity.keys
+        val previousDailyCounterKeys = previousCounterSnapshot.dailyShardsByBucketKey.keys
+        val nextDailyCounterKeys = counterSnapshot.dailyShardsByBucketKey.keys
+        val counterChangedKeys = (
+            previousTrackCounterKeys + nextTrackCounterKeys +
+                previousDailyCounterKeys.map(::identityKeyFromDailyCounterKey) +
+                nextDailyCounterKeys.map(::identityKeyFromDailyCounterKey)
+            ).filter { key ->
+                previousCounterSnapshot.trackShards(key) != counterSnapshot.trackShards(key) ||
+                    dailyCounterKeysForIdentity(
+                        previousCounterSnapshot,
+                        key
+                    ) != dailyCounterKeysForIdentity(counterSnapshot, key)
+            }
+        val changedKeys = (previousByKey.keys + nextByKey.keys +
+            previousDailyByKey.keys + nextDailyByKey.keys + counterChangedKeys)
+            .filter { key ->
+                previousByKey[key] != nextByKey[key] ||
+                    previousDailyByKey[key] != nextDailyByKey[key]
+            }
+            .toSet()
+
+        database.withTransaction {
+            val dao = database.playbackStatsDao()
+            changedKeys.chunked(500).forEach { chunk ->
+                if (chunk.isEmpty()) return@forEach
+                dao.deleteDailyCounterShards(chunk)
+                dao.deleteCounterShards(chunk)
+                dao.deleteBuckets(chunk)
+                dao.deleteStats(chunk.filter { it !in nextByKey })
+            }
+            changedKeys
+                .filter { it in nextByKey }
+                .toList()
+                .chunked(500)
+                .forEach { chunk ->
+                    if (chunk.isEmpty()) return@forEach
+                    val chunkStats = nextStats.filter { it.identityKey in chunk }
+                    val chunkBuckets = nextDailyStats.filter { it.identityKey in chunk }
+                    dao.upsertStats(chunkStats.map(TrackStat::toEntity))
+                    dao.upsertBuckets(chunkBuckets.map(PlaybackStatBucket::toEntity))
+                    dao.upsertCounterShards(
+                        chunk.flatMap { key ->
+                            counterSnapshot.trackShards(key).map { shard ->
+                                shard.toTrackEntity(key)
+                            }
+                        }
+                    )
+                    dao.upsertDailyCounterShards(
+                        chunkBuckets.flatMap { bucket ->
+                            counterSnapshot.dailyShards(
+                                dayStartAt = bucket.dayStartAt,
+                                identityKey = bucket.identityKey
+                            ).map { shard ->
+                                shard.toDailyEntity(
+                                    dayStartAt = bucket.dayStartAt,
+                                    identityKey = bucket.identityKey
+                                )
+                            }
+                        }
+                    )
+                }
+            markRoomPrimary(
+                clearedAt = clearedAt,
+                counterEpochStartedAt = counterEpochStartedAt,
+                now = now
+            )
+        }
+    }
+
+    suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
+        )
+    }
+
+    private suspend fun readSnapshot(): PlaybackStatsRoomSnapshot {
+        val dao = database.playbackStatsDao()
+        val stats = dao.getStats().map(PlaybackStatEntity::toDomain)
+        val buckets = dao.getBuckets().map(PlaybackStatBucketEntity::toDomain)
+        val trackShards = dao.getCounterShards()
+            .groupBy(PlaybackStatCounterShardEntity::identityKey)
+            .mapValues { (_, shards) ->
+                shards.map(PlaybackStatCounterShardEntity::toDomain)
+            }
+        val dailyShards = dao.getDailyCounterShards()
+            .groupBy { it.dayStartAt to it.identityKey }
+            .mapKeys { (key, _) ->
+                PlaybackStatsSyncCounterSnapshot.dailyCounterKey(
+                    dayStartAt = key.first,
+                    identityKey = key.second
+                )
+            }
+            .mapValues { (_, shards) ->
+                shards.map(PlaybackStatDailyCounterShardEntity::toDomain)
+            }
+        val clearedAt = database.syncMetadataDao()
+            .getMigrationMetadata(CLEARED_AT_METADATA_KEY)
+            ?.value
+            ?.toLongOrNull()
+            ?.coerceAtLeast(0L)
+            ?: 0L
+        val counterEpochStartedAt = database.syncMetadataDao()
+            .getMigrationMetadata(COUNTER_EPOCH_METADATA_KEY)
+            ?.value
+            ?.toLongOrNull()
+            ?.coerceAtLeast(0L)
+            ?: clearedAt
+        return PlaybackStatsRoomSnapshot(
+            stats = stats,
+            dailyStats = buckets,
+            counterSnapshot = PlaybackStatsSyncCounterSnapshot(
+                trackShardsByIdentity = trackShards,
+                dailyShardsByBucketKey = dailyShards
+            ),
+            counterEpochStartedAt = counterEpochStartedAt,
+            clearedAt = clearedAt
+        )
+    }
+
+    private suspend fun insertAll(
+        stats: List<TrackStat>,
+        dailyStats: List<PlaybackStatBucket>,
+        counterSnapshot: PlaybackStatsSyncCounterSnapshot
+    ) {
+        val statKeys = stats.mapTo(mutableSetOf(), TrackStat::identityKey)
+        val validBuckets = dailyStats.filter { it.identityKey in statKeys }
+        val dao = database.playbackStatsDao()
+        dao.upsertStats(stats.map(TrackStat::toEntity))
+        dao.upsertBuckets(validBuckets.map(PlaybackStatBucket::toEntity))
+        dao.upsertCounterShards(
+            stats.flatMap { stat ->
+                counterSnapshot.trackShards(stat.identityKey).map { shard ->
+                    shard.toTrackEntity(stat.identityKey)
+                }
+            }
+        )
+        dao.upsertDailyCounterShards(
+            validBuckets.flatMap { bucket ->
+                counterSnapshot.dailyShards(
+                    dayStartAt = bucket.dayStartAt,
+                    identityKey = bucket.identityKey
+                ).map { shard ->
+                    shard.toDailyEntity(
+                        dayStartAt = bucket.dayStartAt,
+                        identityKey = bucket.identityKey
+                    )
+                }
+            }
+        )
+    }
+
+    private suspend fun markRoomPrimary(
+        clearedAt: Long,
+        counterEpochStartedAt: Long,
+        now: Long
+    ) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(CUTOVER_STATE_METADATA_KEY, ROOM_PRIMARY_STATE, now)
+        )
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(IMPORT_SCHEMA_METADATA_KEY, "1", now)
+        )
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(CLEARED_AT_METADATA_KEY, clearedAt.coerceAtLeast(0L).toString(), now)
+        )
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(
+                COUNTER_EPOCH_METADATA_KEY,
+                counterEpochStartedAt.coerceAtLeast(0L).toString(),
+                now
+            )
+        )
+    }
+
+    private fun metadata(key: String, value: String, now: Long) =
+        moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity(
+            key = key,
+            value = value,
+            updatedAt = now
+        )
+
+    companion object {
+        const val CUTOVER_STATE_METADATA_KEY = "playback_stats_cutover_state"
+        const val IMPORT_SCHEMA_METADATA_KEY = "playback_stats_import_schema"
+        const val CLEARED_AT_METADATA_KEY = "playback_stats_cleared_at"
+        const val COUNTER_EPOCH_METADATA_KEY = "playback_stats_counter_epoch"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+        const val LEGACY_JSON_STATE = "legacy_json"
+    }
+}
+
+private fun identityKeyFromDailyCounterKey(key: String): String {
+    return key.substringAfter('|', missingDelimiterValue = key)
+}
+
+private fun dailyCounterKeysForIdentity(
+    snapshot: PlaybackStatsSyncCounterSnapshot,
+    identityKey: String
+): Map<String, List<SyncPlaybackCounterShard>> {
+    return snapshot.dailyShardsByBucketKey
+        .filterKeys { key -> identityKeyFromDailyCounterKey(key) == identityKey }
+}
+
+private fun PlaybackStatEntity.toDomain(): TrackStat {
+    return TrackStat(
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        albumId = albumId,
+        coverUrl = coverUrl,
+        durationMs = durationMs,
+        totalListenMs = totalListenMs,
+        playCount = playCount,
+        lastPlayedAt = lastPlayedAt,
+        firstPlayedAt = firstPlayedAt,
+        mediaUri = mediaUri,
+        localFilePath = localFilePath,
+        localFileName = localFileName,
+        customName = customName,
+        customArtist = customArtist,
+        customCoverUrl = customCoverUrl,
+        identityKey = identityKey
+    )
+}
+
+private fun PlaybackStatBucketEntity.toDomain(): PlaybackStatBucket {
+    return PlaybackStatBucket(
+        dayStartAt = dayStartAt,
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        albumId = albumId,
+        coverUrl = coverUrl,
+        durationMs = durationMs,
+        totalListenMs = totalListenMs,
+        playCount = playCount,
+        lastPlayedAt = lastPlayedAt,
+        firstPlayedAt = firstPlayedAt,
+        mediaUri = mediaUri,
+        localFilePath = localFilePath,
+        localFileName = localFileName,
+        customName = customName,
+        customArtist = customArtist,
+        customCoverUrl = customCoverUrl,
+        identityKey = identityKey
+    )
+}
+
+private fun PlaybackStatCounterShardEntity.toDomain(): SyncPlaybackCounterShard {
+    return SyncPlaybackCounterShard(
+        deviceId = deviceId,
+        epochStartedAt = epochStartedAt,
+        totalListenMs = totalListenMs,
+        playCount = playCount,
+        firstPlayedAt = firstPlayedAt,
+        lastPlayedAt = lastPlayedAt
+    )
+}
+
+private fun PlaybackStatDailyCounterShardEntity.toDomain(): SyncPlaybackCounterShard {
+    return SyncPlaybackCounterShard(
+        deviceId = deviceId,
+        epochStartedAt = epochStartedAt,
+        totalListenMs = totalListenMs,
+        playCount = playCount,
+        firstPlayedAt = firstPlayedAt,
+        lastPlayedAt = lastPlayedAt
+    )
+}
+
+private fun SyncPlaybackCounterShard.toTrackEntity(
+    identityKey: String
+): PlaybackStatCounterShardEntity {
+    return PlaybackStatCounterShardEntity(
+        identityKey = identityKey,
+        deviceId = deviceId,
+        epochStartedAt = epochStartedAt,
+        totalListenMs = totalListenMs,
+        playCount = playCount,
+        firstPlayedAt = firstPlayedAt,
+        lastPlayedAt = lastPlayedAt
+    )
+}
+
+private fun SyncPlaybackCounterShard.toDailyEntity(
+    dayStartAt: Long,
+    identityKey: String
+): PlaybackStatDailyCounterShardEntity {
+    return PlaybackStatDailyCounterShardEntity(
+        dayStartAt = dayStartAt,
+        identityKey = identityKey,
+        deviceId = deviceId,
+        epochStartedAt = epochStartedAt,
+        totalListenMs = totalListenMs,
+        playCount = playCount,
+        firstPlayedAt = firstPlayedAt,
+        lastPlayedAt = lastPlayedAt
+    )
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaylistUsageRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaylistUsageRoomStore.kt
@@ -25,7 +25,24 @@ internal class PlaylistUsageRoomStore(
         entries: List<UsageEntry>,
         now: Long = System.currentTimeMillis()
     ) {
-        replaceAll(entries, now)
+        database.withTransaction {
+            val cutoverState = database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value
+            if (cutoverState == ROOM_PRIMARY_STATE) {
+                return@withTransaction
+            }
+            database.playlistUsageDao().deleteAllCounterShards()
+            database.playlistUsageDao().deleteAllEntries()
+            database.playlistUsageDao().upsertEntries(entries.map(UsageEntry::toEntity))
+            database.playlistUsageDao().upsertCounterShards(
+                entries.flatMap { entry ->
+                    SyncPlaybackStatMapper.normalizeCounterShards(entry.counterShards)
+                        .map { shard -> shard.toEntity(entry.usageKey()) }
+                }
+            )
+            markRoomPrimary(now)
+        }
     }
 
     suspend fun writeIncremental(

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaylistUsageRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaylistUsageRoomStore.kt
@@ -77,12 +77,6 @@ internal class PlaylistUsageRoomStore(
         }
     }
 
-    suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
-        database.syncMetadataDao().upsertMigrationMetadata(
-            metadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
-        )
-    }
-
     private suspend fun readEntries(): List<UsageEntry> {
         val shardsByKey = database.playlistUsageDao()
             .getCounterShards()
@@ -149,6 +143,5 @@ internal class PlaylistUsageRoomStore(
         const val CUTOVER_STATE_METADATA_KEY = "playlist_usage_cutover_state"
         const val IMPORT_SCHEMA_METADATA_KEY = "playlist_usage_import_schema"
         const val ROOM_PRIMARY_STATE = "room_primary"
-        const val LEGACY_JSON_STATE = "legacy_json"
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaylistUsageRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/PlaylistUsageRoomStore.kt
@@ -1,0 +1,154 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import androidx.room.withTransaction
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.toEntity
+import moe.ouom.neriplayer.data.playlist.usage.UsageEntry
+import moe.ouom.neriplayer.data.playlist.usage.usageKey
+import moe.ouom.neriplayer.data.sync.github.SyncPlaybackStatMapper
+import moe.ouom.neriplayer.data.sync.model.SyncPlaybackCounterShard
+
+internal class PlaylistUsageRoomStore(
+    private val database: NeriUserDataDatabase
+) {
+    suspend fun readIfRoomPrimary(): List<UsageEntry>? {
+        if (database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value != ROOM_PRIMARY_STATE
+        ) {
+            return null
+        }
+        return readEntries()
+    }
+
+    suspend fun importLegacyAndPromote(
+        entries: List<UsageEntry>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        replaceAll(entries, now)
+    }
+
+    suspend fun writeIncremental(
+        previous: List<UsageEntry>,
+        next: List<UsageEntry>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        val previousByKey = previous.associateBy(UsageEntry::usageKey)
+        val nextByKey = next.associateBy(UsageEntry::usageKey)
+        val changedKeys = (previousByKey.keys + nextByKey.keys)
+            .filter { key -> previousByKey[key] != nextByKey[key] }
+            .toSet()
+        val removedKeys = changedKeys.filter { it !in nextByKey }
+        val changedEntries = next.filter { it.usageKey() in changedKeys }
+        database.withTransaction {
+            deleteKeys(removedKeys)
+            changedKeys
+                .filter { it in nextByKey }
+                .chunked(500)
+                .forEach { chunk ->
+                    database.playlistUsageDao().deleteCounterShards(chunk)
+                }
+            database.playlistUsageDao().upsertEntries(changedEntries.map(UsageEntry::toEntity))
+            database.playlistUsageDao().upsertCounterShards(
+                changedEntries.flatMap { entry ->
+                    SyncPlaybackStatMapper.normalizeCounterShards(entry.counterShards)
+                        .map { shard -> shard.toEntity(entry.usageKey()) }
+                }
+            )
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun replaceAll(
+        entries: List<UsageEntry>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            database.playlistUsageDao().deleteAllCounterShards()
+            database.playlistUsageDao().deleteAllEntries()
+            database.playlistUsageDao().upsertEntries(entries.map(UsageEntry::toEntity))
+            database.playlistUsageDao().upsertCounterShards(
+                entries.flatMap { entry ->
+                    SyncPlaybackStatMapper.normalizeCounterShards(entry.counterShards)
+                        .map { shard -> shard.toEntity(entry.usageKey()) }
+                }
+            )
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
+        )
+    }
+
+    private suspend fun readEntries(): List<UsageEntry> {
+        val shardsByKey = database.playlistUsageDao()
+            .getCounterShards()
+            .groupBy { it.usageKey }
+            .mapValues { (_, shards) ->
+                shards.map { shard ->
+                    SyncPlaybackCounterShard(
+                        deviceId = shard.deviceId,
+                        epochStartedAt = shard.epochStartedAt,
+                        playCount = shard.playCount,
+                        firstPlayedAt = shard.firstPlayedAt,
+                        lastPlayedAt = shard.lastPlayedAt
+                    )
+                }
+            }
+        return database.playlistUsageDao().getEntries().map { entry ->
+            UsageEntry(
+                id = entry.id,
+                name = entry.name,
+                picUrl = entry.picUrl,
+                trackCount = entry.trackCount,
+                source = entry.source,
+                lastOpened = entry.lastOpened,
+                openCount = entry.openCount,
+                firstOpened = entry.firstOpened,
+                counterBaseOpenCount = entry.counterBaseOpenCount,
+                counterShards = shardsByKey[entry.usageKey].orEmpty(),
+                fid = entry.fid,
+                mid = entry.mid,
+                browseId = entry.browseId,
+                playlistId = entry.playlistId,
+                subtype = entry.subtype,
+                subtitle = entry.subtitle
+            )
+        }
+    }
+
+    private suspend fun deleteKeys(keys: List<String>) {
+        keys.chunked(500).forEach { chunk ->
+            if (chunk.isNotEmpty()) {
+                database.playlistUsageDao().deleteCounterShards(chunk)
+                database.playlistUsageDao().deleteEntries(chunk)
+            }
+        }
+    }
+
+    private suspend fun markRoomPrimary(now: Long) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(CUTOVER_STATE_METADATA_KEY, ROOM_PRIMARY_STATE, now)
+        )
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(IMPORT_SCHEMA_METADATA_KEY, "1", now)
+        )
+    }
+
+    private fun metadata(key: String, value: String, now: Long) =
+        moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity(
+            key = key,
+            value = value,
+            updatedAt = now
+        )
+
+    companion object {
+        const val CUTOVER_STATE_METADATA_KEY = "playlist_usage_cutover_state"
+        const val IMPORT_SCHEMA_METADATA_KEY = "playlist_usage_import_schema"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+        const val LEGACY_JSON_STATE = "legacy_json"
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/TrafficStatsRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/TrafficStatsRoomStore.kt
@@ -24,7 +24,17 @@ internal class TrafficStatsRoomStore(
         buckets: List<TrafficStatsBucket>,
         now: Long = System.currentTimeMillis()
     ) {
-        replaceAll(buckets, now)
+        database.withTransaction {
+            val cutoverState = database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value
+            if (cutoverState == ROOM_PRIMARY_STATE) {
+                return@withTransaction
+            }
+            database.trafficStatsDao().deleteAll()
+            database.trafficStatsDao().upsert(buckets.map(TrafficStatsBucket::toEntity))
+            markRoomPrimary(now)
+        }
     }
 
     suspend fun replaceAll(

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/TrafficStatsRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/TrafficStatsRoomStore.kt
@@ -1,0 +1,99 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import androidx.room.withTransaction
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.TrafficStatsBucketEntity
+import moe.ouom.neriplayer.data.local.database.entity.toDomain
+import moe.ouom.neriplayer.data.local.database.entity.toEntity
+import moe.ouom.neriplayer.data.traffic.TrafficStatsBucket
+
+internal class TrafficStatsRoomStore(
+    private val database: NeriUserDataDatabase
+) {
+    suspend fun readIfRoomPrimary(): List<TrafficStatsBucket>? {
+        if (database.syncMetadataDao()
+                .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
+                ?.value != ROOM_PRIMARY_STATE
+        ) {
+            return null
+        }
+        return database.trafficStatsDao().getAll().map(TrafficStatsBucketEntity::toDomain)
+    }
+
+    suspend fun importLegacyAndPromote(
+        buckets: List<TrafficStatsBucket>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        replaceAll(buckets, now)
+    }
+
+    suspend fun replaceAll(
+        buckets: List<TrafficStatsBucket>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        database.withTransaction {
+            database.trafficStatsDao().deleteAll()
+            database.trafficStatsDao().upsert(buckets.map(TrafficStatsBucket::toEntity))
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun writeIncremental(
+        previous: List<TrafficStatsBucket>,
+        next: List<TrafficStatsBucket>,
+        now: Long = System.currentTimeMillis()
+    ) {
+        val previousByDay = previous.associateBy(TrafficStatsBucket::dayStartAt)
+        val nextByDay = next.associateBy(TrafficStatsBucket::dayStartAt)
+        val changedDays = (previousByDay.keys + nextByDay.keys)
+            .filter { day -> previousByDay[day] != nextByDay[day] }
+            .toSet()
+        database.withTransaction {
+            val dao = database.trafficStatsDao()
+            changedDays.toList().chunked(500).forEach { chunk ->
+                if (chunk.isNotEmpty()) dao.delete(chunk)
+            }
+            dao.upsert(
+                next.filter { it.dayStartAt in changedDays }
+                    .map(TrafficStatsBucket::toEntity)
+            )
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun clear(now: Long = System.currentTimeMillis()) {
+        database.withTransaction {
+            database.trafficStatsDao().deleteAll()
+            markRoomPrimary(now)
+        }
+    }
+
+    suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
+        )
+    }
+
+    private suspend fun markRoomPrimary(now: Long) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(CUTOVER_STATE_METADATA_KEY, ROOM_PRIMARY_STATE, now)
+        )
+        database.syncMetadataDao().upsertMigrationMetadata(
+            metadata(IMPORT_SCHEMA_METADATA_KEY, "1", now)
+        )
+    }
+
+    private fun metadata(key: String, value: String, now: Long) =
+        moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity(
+            key = key,
+            value = value,
+            updatedAt = now
+        )
+
+    companion object {
+        const val CUTOVER_STATE_METADATA_KEY = "traffic_stats_cutover_state"
+        const val IMPORT_SCHEMA_METADATA_KEY = "traffic_stats_import_schema"
+        const val ROOM_PRIMARY_STATE = "room_primary"
+        const val LEGACY_JSON_STATE = "legacy_json"
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/TrafficStatsRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/TrafficStatsRoomStore.kt
@@ -68,12 +68,6 @@ internal class TrafficStatsRoomStore(
         }
     }
 
-    suspend fun markLegacyJsonPrimary(now: Long = System.currentTimeMillis()) {
-        database.syncMetadataDao().upsertMigrationMetadata(
-            metadata(CUTOVER_STATE_METADATA_KEY, LEGACY_JSON_STATE, now)
-        )
-    }
-
     private suspend fun markRoomPrimary(now: Long) {
         database.syncMetadataDao().upsertMigrationMetadata(
             metadata(CUTOVER_STATE_METADATA_KEY, ROOM_PRIMARY_STATE, now)
@@ -94,6 +88,5 @@ internal class TrafficStatsRoomStore(
         const val CUTOVER_STATE_METADATA_KEY = "traffic_stats_cutover_state"
         const val IMPORT_SCHEMA_METADATA_KEY = "traffic_stats_import_schema"
         const val ROOM_PRIMARY_STATE = "room_primary"
-        const val LEGACY_JSON_STATE = "legacy_json"
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepository.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -44,6 +45,9 @@ import moe.ouom.neriplayer.R
 import moe.ouom.neriplayer.core.api.netease.NeteaseClient
 import moe.ouom.neriplayer.core.api.search.MusicPlatform
 import moe.ouom.neriplayer.data.local.audioimport.LocalAudioImportManager
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.LocalPlaylistRoomShadowImportStatus
+import moe.ouom.neriplayer.data.local.database.store.LocalPlaylistRoomStore
 import moe.ouom.neriplayer.data.local.media.LocalSongSupport
 import moe.ouom.neriplayer.data.local.playlist.model.DISPLAY_ORDER_SONG_ORDER_VERSION
 import moe.ouom.neriplayer.data.local.playlist.model.LocalPlaylist
@@ -73,6 +77,7 @@ import java.io.IOException
 import java.security.MessageDigest
 import java.util.Collections
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicLong
 
 data class LocalPlaylistSongAddResult(
     val addedSongs: List<SongItem>
@@ -102,10 +107,13 @@ class LocalPlaylistRepository private constructor(
     private val loadSynchronously: Boolean = false,
     private val storage: LocalPlaylistStorage = LocalPlaylistFileStorage(file, context.filesDir),
     private val providedSyncMutationStore: LocalPlaylistSyncMutationStore? = null,
-    private val providedAutoSyncTrigger: (() -> Unit)? = null
+    private val providedAutoSyncTrigger: (() -> Unit)? = null,
+    private val roomStore: LocalPlaylistRoomStore? = null
 ) {
     private val gson = Gson()
     private val playlistCommitMutex = Mutex()
+    private val legacyProjectionMutex = Mutex()
+    private val legacyProjectionGeneration = AtomicLong(0L)
     private val syncStorage by lazy { SecureTokenStorage(context) }
     private val syncMutationStore by lazy {
         providedSyncMutationStore ?: SecureLocalPlaylistSyncMutationStore(syncStorage)
@@ -171,12 +179,13 @@ class LocalPlaylistRepository private constructor(
     private val initializationScope by lazy {
         CoroutineScope(SupervisorJob() + Dispatchers.IO)
     }
+    @Volatile
+    private var roomStorageEnabled = roomStore != null
 
     private data class PlaylistLoadResult(
         val playlists: List<LocalPlaylist>,
         val migrationRequired: Boolean,
-        val allowMigrationWrite: Boolean,
-        val committedPrimaryText: String?
+        val allowMigrationWrite: Boolean
     )
 
     private data class ParsedPlaylistCandidate(
@@ -218,8 +227,47 @@ class LocalPlaylistRepository private constructor(
     }
 
     private fun loadFromDisk() {
+        val roomPrimary = readRoomPrimary()
+        if (roomPrimary != null) {
+            recoverPendingSyncMutation(
+                committedDomainDigest = LocalPlaylistRoomStore.domainDigest(roomPrimary)
+            )
+            _playlists.value = roomPrimary
+            _playlistCount.value = roomPrimary.size
+            return
+        }
+
         val loadResult = readStoredPlaylists()
-        recoverPendingSyncMutation(loadResult.committedPrimaryText)
+        val committedPlaylists = loadResult.playlists
+        val committedDomainDigest = LocalPlaylistRoomStore.domainDigest(committedPlaylists)
+        recoverPendingSyncMutation(committedDomainDigest)
+
+        if (roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            val imported = runCatching {
+                runBlocking {
+                    activeRoomStore.importLegacyAndPromote(
+                        playlists = committedPlaylists,
+                        sourceDigest = committedDomainDigest
+                    )
+                }
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                NPLogger.e(
+                    "LocalPlaylistRepo",
+                    "Failed to promote legacy playlists to Room; JSON remains authoritative",
+                    error
+                )
+            }.getOrNull()
+            if (imported?.status == LocalPlaylistRoomShadowImportStatus.SKIPPED_NOT_EQUIVALENT) {
+                roomStorageEnabled = false
+                NPLogger.w(
+                    "LocalPlaylistRepo",
+                    "Room mapper is not equivalent; keep legacy playlist storage"
+                )
+            }
+        }
+
         if (loadResult.migrationRequired && loadResult.allowMigrationWrite) {
             runCatching {
                 persistToDisk(loadResult.playlists)
@@ -229,6 +277,25 @@ class LocalPlaylistRepository private constructor(
         }
         _playlists.value = loadResult.playlists
         _playlistCount.value = loadResult.playlists.size
+    }
+
+    private fun readRoomPrimary(): List<LocalPlaylist>? {
+        if (!roomStorageEnabled || roomStore == null) {
+            return null
+        }
+        val activeRoomStore = roomStore
+        return runCatching {
+            runBlocking {
+                activeRoomStore.readIfRoomPrimary()
+            }
+        }.onFailure { error ->
+            roomStorageEnabled = false
+            NPLogger.e(
+                "LocalPlaylistRepo",
+                "Failed to read Room playlists; falling back to legacy storage",
+                error
+            )
+        }.getOrNull()
     }
 
     private fun readStoredPlaylists(): PlaylistLoadResult {
@@ -255,8 +322,7 @@ class LocalPlaylistRepository private constructor(
             return PlaylistLoadResult(
                 playlists = primaryParsed.normalized,
                 migrationRequired = primaryParsed.normalized != primaryParsed.decoded,
-                allowMigrationWrite = true,
-                committedPrimaryText = primaryText
+                allowMigrationWrite = true
             )
         }
 
@@ -269,8 +335,7 @@ class LocalPlaylistRepository private constructor(
         return PlaylistLoadResult(
             playlists = normalized,
             migrationRequired = normalized.isNotEmpty(),
-            allowMigrationWrite = allowMigrationWrite,
-            committedPrimaryText = null
+            allowMigrationWrite = allowMigrationWrite
         )
     }
 
@@ -309,8 +374,7 @@ class LocalPlaylistRepository private constructor(
         return PlaylistLoadResult(
             playlists = backupParsed.normalized,
             migrationRequired = backupParsed.normalized != backupParsed.decoded,
-            allowMigrationWrite = repairSucceeded,
-            committedPrimaryText = backupText.takeIf { repairSucceeded }
+            allowMigrationWrite = repairSucceeded
         )
     }
 
@@ -466,14 +530,19 @@ class LocalPlaylistRepository private constructor(
         replaceBackupOnNextWrite = false
     }
 
-    private suspend fun <T> commitPlaylistMutation(block: () -> T): T {
+    private suspend fun <T> commitPlaylistMutation(block: suspend () -> T): T {
         return withContext(Dispatchers.IO) {
             requireInitialized()
-            playlistCommitMutex.withLock(action = block)
+            playlistCommitMutex.lock()
+            try {
+                block()
+            } finally {
+                playlistCommitMutex.unlock()
+            }
         }
     }
 
-    private fun publishLocked(
+    private suspend fun publishLocked(
         playlists: List<LocalPlaylist>,
         triggerSync: Boolean = true,
         syncMutation: LocalPlaylistSyncMutation = LocalPlaylistSyncMutation(),
@@ -491,24 +560,65 @@ class LocalPlaylistRepository private constructor(
             return
         }
 
-        val currentPrimaryText = storage.readPrimary()
-        val serialized = if (stateChanged || currentPrimaryText == null) {
-            gson.toJson(normalized)
+        val currentDomainDigest = LocalPlaylistRoomStore.domainDigest(_playlists.value)
+        val nextDomainDigest = LocalPlaylistRoomStore.domainDigest(normalized)
+        val legacyPrimaryText = if (!roomStorageEnabled) {
+            storage.readPrimary()
         } else {
-            currentPrimaryText
+            null
         }
         val pendingOutbox = preparePendingSyncMutationUpdate(
-            currentPrimaryText = currentPrimaryText,
-            nextPrimaryDigest = primaryDigest(serialized),
+            currentDomainDigest = currentDomainDigest,
+            legacyPrimaryText = legacyPrimaryText,
+            nextDomainDigest = nextDomainDigest,
             syncMutation = syncMutation
         )
         // 没有墓碑要提交时可以先推进版本, 含墓碑的变更由存储层和版本一起提交
         if (markLocalMutation && syncMutation.isEmpty && pendingOutbox == null) {
             syncMutationStore.markSyncMutation()
         }
-        writePendingSyncMutation(pendingOutbox)
-        if (stateChanged || currentPrimaryText == null) {
-            persistToDisk(normalized, serialized)
+        val roomWasEnabledBeforeOutbox = roomStorageEnabled
+        if (pendingOutbox != null || !syncMutation.isEmpty) {
+            writePendingSyncMutation(pendingOutbox)
+        }
+        var committedToRoom = false
+        var roomFallbackRequired = roomWasEnabledBeforeOutbox && !roomStorageEnabled
+        if (stateChanged && roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            runCatching {
+                activeRoomStore.writeIncremental(
+                    previous = _playlists.value,
+                    next = normalized,
+                    sourceDigest = nextDomainDigest
+                )
+            }.onSuccess {
+                committedToRoom = true
+            }.onFailure { error ->
+                roomFallbackRequired = true
+                roomStorageEnabled = false
+                NPLogger.e(
+                    "LocalPlaylistRepo",
+                    "Room playlist commit failed; falling back to legacy JSON",
+                    error
+                )
+            }
+        }
+        if (stateChanged && !committedToRoom) {
+            persistToDisk(normalized)
+            val fallbackRoomStore = roomStore
+            if (roomFallbackRequired && fallbackRoomStore != null) {
+                runCatching {
+                    fallbackRoomStore.markLegacyJsonPrimary(nextDomainDigest)
+                }.onFailure { error ->
+                    NPLogger.e(
+                        "LocalPlaylistRepo",
+                        "Failed to mark legacy JSON fallback state in Room",
+                        error
+                    )
+                }
+            }
+        } else if (committedToRoom) {
+            enqueueLegacyProjection(normalized)
         }
         if (stateChanged) {
             _playlists.value = normalized
@@ -531,48 +641,73 @@ class LocalPlaylistRepository private constructor(
         }
     }
 
-    private fun recoverPendingSyncMutation(committedPrimaryText: String?) {
+    private fun enqueueLegacyProjection(playlists: List<LocalPlaylist>) {
+        val generation = legacyProjectionGeneration.incrementAndGet()
+        initializationScope.launch {
+            legacyProjectionMutex.withLock {
+                if (generation != legacyProjectionGeneration.get()) {
+                    return@withLock
+                }
+                runCatching {
+                    persistToDisk(playlists)
+                }.onFailure { error ->
+                    NPLogger.e(
+                        "LocalPlaylistRepo",
+                        "Room committed but legacy JSON projection failed",
+                        error
+                    )
+                }
+            }
+        }
+    }
+
+    private fun recoverPendingSyncMutation(committedDomainDigest: String) {
         runCatching {
-            flushPendingSyncMutation(committedPrimaryText)
+            runBlocking {
+                flushPendingSyncMutation(committedDomainDigest)
+            }
         }.onFailure { error ->
             NPLogger.e("LocalPlaylistRepo", "Failed to replay playlist sync mutation", error)
         }
     }
 
-    private fun flushPendingSyncMutation(primaryText: String? = storage.readPrimary()): Boolean {
-        val pendingText = storage.readPendingSyncMutation() ?: return false
-        val committedOutbox = decodeCommittedSyncMutationOutbox(pendingText, primaryText)
+    private suspend fun flushPendingSyncMutation(committedDomainDigest: String): Boolean {
+        val committedOutbox = readPendingSyncMutationOutbox(
+            committedDomainDigest = committedDomainDigest,
+            legacyPrimaryText = storage.readPrimary()
+        )
         if (committedOutbox == null) {
-            storage.clearPendingSyncMutation()
+            clearPendingSyncMutation()
             _syncMutationPending.value = false
             return false
-        }
-        if (gson.toJson(committedOutbox) != pendingText) {
-            storage.writePendingSyncMutation(gson.toJson(committedOutbox))
         }
         return settlePendingSyncMutation(committedOutbox, triggerSync = false)
     }
 
-    private fun preparePendingSyncMutationUpdate(
-        currentPrimaryText: String?,
-        nextPrimaryDigest: String,
+    private suspend fun preparePendingSyncMutationUpdate(
+        currentDomainDigest: String,
+        legacyPrimaryText: String?,
+        nextDomainDigest: String,
         syncMutation: LocalPlaylistSyncMutation
     ): LocalPlaylistSyncMutationOutbox? {
-        val committedMutations = storage.readPendingSyncMutation()
-            ?.let { decodeCommittedSyncMutationOutbox(it, currentPrimaryText) }
+        val committedMutations = readPendingSyncMutationOutbox(
+            committedDomainDigest = currentDomainDigest,
+            legacyPrimaryText = legacyPrimaryText
+        )
             ?.mutations
             .orEmpty()
         if (committedMutations.isEmpty() && syncMutation.isEmpty) {
             return null
         }
 
-        val nextMutation = syncMutation.withExpectedPrimaryDigest(nextPrimaryDigest)
+        val nextMutation = syncMutation.withExpectedPrimaryDigest(nextDomainDigest)
         return LocalPlaylistSyncMutationOutbox(committedMutations + nextMutation)
     }
 
     private fun decodeCommittedSyncMutationOutbox(
         text: String,
-        primaryText: String?
+        committedDomainDigest: String,
+        legacyPrimaryText: String?
     ): LocalPlaylistSyncMutationOutbox? {
         val outbox = runCatching {
             val root = JSONObject(text)
@@ -589,11 +724,23 @@ class LocalPlaylistRepository private constructor(
             NPLogger.e("LocalPlaylistRepo", "Discarding corrupt playlist sync mutation", error)
             return null
         }
-        if (outbox.mutations.isEmpty() || primaryText == null) return null
+        return trimCommittedSyncMutationOutbox(
+            outbox = outbox,
+            committedDomainDigest = committedDomainDigest,
+            legacyPrimaryText = legacyPrimaryText
+        )
+    }
 
-        val committedDigest = primaryDigest(primaryText)
+    private fun trimCommittedSyncMutationOutbox(
+        outbox: LocalPlaylistSyncMutationOutbox,
+        committedDomainDigest: String,
+        legacyPrimaryText: String?
+    ): LocalPlaylistSyncMutationOutbox? {
+        if (outbox.mutations.isEmpty()) return null
+        val legacyDigest = legacyPrimaryText?.let(::primaryDigest)
         val committedIndex = outbox.mutations.indexOfLast { mutation ->
-            mutation.expectedPrimaryDigest == committedDigest
+            mutation.expectedPrimaryDigest == committedDomainDigest ||
+                mutation.expectedPrimaryDigest == legacyDigest
         }
         if (committedIndex < 0) return null
         return LocalPlaylistSyncMutationOutbox(
@@ -601,7 +748,60 @@ class LocalPlaylistRepository private constructor(
         )
     }
 
-    private fun writePendingSyncMutation(outbox: LocalPlaylistSyncMutationOutbox?) {
+    private suspend fun readPendingSyncMutationOutbox(
+        committedDomainDigest: String,
+        legacyPrimaryText: String?
+    ): LocalPlaylistSyncMutationOutbox? {
+        if (roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            val roomOutbox = runCatching {
+                activeRoomStore.readPendingSyncMutationOutbox()
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                NPLogger.e(
+                    "LocalPlaylistRepo",
+                    "Failed to read Room sync outbox; falling back to legacy outbox",
+                    error
+                )
+            }.getOrNull()
+            if (roomOutbox != null) {
+                return trimCommittedSyncMutationOutbox(
+                    outbox = roomOutbox,
+                    committedDomainDigest = committedDomainDigest,
+                    legacyPrimaryText = legacyPrimaryText
+                )
+            }
+        }
+
+        val pendingText = storage.readPendingSyncMutation() ?: return null
+        return decodeCommittedSyncMutationOutbox(
+            text = pendingText,
+            committedDomainDigest = committedDomainDigest,
+            legacyPrimaryText = legacyPrimaryText
+        )
+    }
+
+    private suspend fun writePendingSyncMutation(outbox: LocalPlaylistSyncMutationOutbox?) {
+        if (roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            val roomWriteSucceeded = runCatching {
+                if (outbox == null) {
+                    activeRoomStore.clearPendingSyncMutationOutbox()
+                } else {
+                    activeRoomStore.writePendingSyncMutationOutbox(outbox)
+                }
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                NPLogger.e(
+                    "LocalPlaylistRepo",
+                    "Failed to write Room sync outbox; falling back to legacy outbox",
+                    error
+                )
+            }.isSuccess
+            if (roomWriteSucceeded) {
+                return
+            }
+        }
         if (outbox == null) {
             storage.clearPendingSyncMutation()
         } else {
@@ -609,7 +809,21 @@ class LocalPlaylistRepository private constructor(
         }
     }
 
-    private fun settlePendingSyncMutation(
+    private suspend fun clearPendingSyncMutation() {
+        if (roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            try {
+                activeRoomStore.clearPendingSyncMutationOutbox()
+            } catch (error: Exception) {
+                roomStorageEnabled = false
+                NPLogger.e("LocalPlaylistRepo", "Failed to clear Room sync outbox", error)
+                throw IOException("Failed to clear Room sync outbox", error)
+            }
+        }
+        storage.clearPendingSyncMutation()
+    }
+
+    private suspend fun settlePendingSyncMutation(
         outbox: LocalPlaylistSyncMutationOutbox,
         triggerSync: Boolean
     ): Boolean {
@@ -623,7 +837,7 @@ class LocalPlaylistRepository private constructor(
             if ((triggerSync || hasSyncMutation) && autoSyncEnabled && !scheduleAutoSync()) {
                 throw IOException("Failed to schedule playlist sync mutation")
             }
-            storage.clearPendingSyncMutation()
+            clearPendingSyncMutation()
             _syncMutationPending.value = false
             return hasSyncMutation
         } catch (error: Exception) {
@@ -1448,7 +1662,7 @@ class LocalPlaylistRepository private constructor(
         }
     }
 
-    private fun addStampedSongsToPlaylistLocked(
+    private suspend fun addStampedSongsToPlaylistLocked(
         playlistId: Long,
         songs: List<SongItem>,
         now: Long,
@@ -2822,7 +3036,13 @@ class LocalPlaylistRepository private constructor(
 
         fun getInstance(context: Context): LocalPlaylistRepository {
             return INSTANCE ?: synchronized(this) {
-                INSTANCE ?: LocalPlaylistRepository(context.applicationContext).also { INSTANCE = it }
+                val appContext = context.applicationContext
+                INSTANCE ?: LocalPlaylistRepository(
+                    context = appContext,
+                    roomStore = LocalPlaylistRoomStore(
+                        database = NeriUserDataDatabase.getInstance(appContext)
+                    )
+                ).also { INSTANCE = it }
             }
         }
 
@@ -2834,7 +3054,8 @@ class LocalPlaylistRepository private constructor(
             loadSynchronously: Boolean = true,
             storage: LocalPlaylistStorage = LocalPlaylistFileStorage(file, context.filesDir),
             syncMutationStore: LocalPlaylistSyncMutationStore? = null,
-            autoSyncTrigger: (() -> Unit)? = null
+            autoSyncTrigger: (() -> Unit)? = null,
+            roomStore: LocalPlaylistRoomStore? = null
         ): LocalPlaylistRepository {
             return LocalPlaylistRepository(
                 context = context,
@@ -2845,7 +3066,8 @@ class LocalPlaylistRepository private constructor(
                 storage = storage,
                 providedSyncMutationStore =
                     syncMutationStore ?: InMemoryLocalPlaylistSyncMutationStore(),
-                providedAutoSyncTrigger = autoSyncTrigger
+                providedAutoSyncTrigger = autoSyncTrigger,
+                roomStore = roomStore
             )
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepository.kt
@@ -30,10 +30,12 @@ import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -187,6 +189,9 @@ class LocalPlaylistRepository private constructor(
     }
     @Volatile
     private var roomStorageEnabled = roomStore != null
+    private var roomRecoveryBaseline: List<LocalPlaylist>? = null
+    private var roomRecoveryJob: Job? = null
+    private var roomReadFailed = false
 
     private data class PlaylistLoadResult(
         val playlists: List<LocalPlaylist>,
@@ -250,7 +255,9 @@ class LocalPlaylistRepository private constructor(
         recoverPendingSyncMutation(committedDomainDigest)
 
         var roomPromotedDuringLoad = false
-        if (roomStorageEnabled && roomStore != null) {
+        if (roomReadFailed) {
+            roomRecoveryBaseline = committedPlaylists
+        } else if (roomStorageEnabled && roomStore != null) {
             val activeRoomStore = roomStore
             val imported = runCatching {
                 runBlocking {
@@ -261,9 +268,10 @@ class LocalPlaylistRepository private constructor(
                 }
             }.onFailure { error ->
                 roomStorageEnabled = false
+                roomRecoveryBaseline = committedPlaylists
                 NPLogger.e(
                     "LocalPlaylistRepo",
-                    "Failed to promote legacy playlists to Room; JSON remains authoritative",
+                    "Failed to promote legacy playlists to Room; waiting for recovery",
                     error
                 )
             }.getOrNull()
@@ -282,7 +290,8 @@ class LocalPlaylistRepository private constructor(
         if (
             shouldRewriteLegacyPlaylistsAfterInitialLoad(
                 migrationRequired = loadResult.migrationRequired,
-                allowMigrationWrite = loadResult.allowMigrationWrite,
+                allowMigrationWrite = loadResult.allowMigrationWrite &&
+                    roomRecoveryBaseline == null,
                 roomPromotedDuringLoad = roomPromotedDuringLoad
             )
         ) {
@@ -294,6 +303,7 @@ class LocalPlaylistRepository private constructor(
         }
         _playlists.value = loadResult.playlists
         _playlistCount.value = loadResult.playlists.size
+        scheduleRoomRecovery()
     }
 
     private fun readRoomPrimary(): List<LocalPlaylist>? {
@@ -306,14 +316,14 @@ class LocalPlaylistRepository private constructor(
                 activeRoomStore.readIfRoomPrimary()
             }
         }.onFailure { error ->
+            roomStorageEnabled = false
+            roomReadFailed = true
             NPLogger.e(
                 "LocalPlaylistRepo",
-                "Failed to read Room playlists; refusing to overwrite Room from legacy JSON",
+                "Failed to read Room playlists; using legacy snapshot until recovery",
                 error
             )
-        }.getOrElse { error ->
-            throw IOException("Failed to read Room playlists", error)
-        }
+        }.getOrNull()
     }
 
     private fun readStoredPlaylists(): PlaylistLoadResult {
@@ -580,7 +590,7 @@ class LocalPlaylistRepository private constructor(
 
         val currentDomainDigest = LocalPlaylistRoomStore.domainDigest(_playlists.value)
         val nextDomainDigest = LocalPlaylistRoomStore.domainDigest(normalized)
-        val legacyPrimaryText = if (!roomStorageEnabled) {
+        val legacyPrimaryText = if (!roomStorageEnabled && roomRecoveryBaseline == null) {
             storage.readPrimary()
         } else {
             null
@@ -610,16 +620,29 @@ class LocalPlaylistRepository private constructor(
             }.onSuccess {
                 committedToRoom = true
             }.onFailure { error ->
+                roomStorageEnabled = false
+                if (roomRecoveryBaseline == null) {
+                    roomRecoveryBaseline = _playlists.value
+                }
+                _playlists.value = normalized
+                _playlistCount.value = normalized.size
+                scheduleRoomRecovery()
                 NPLogger.e(
                     "LocalPlaylistRepo",
-                    "Room playlist commit failed; keeping JSON migration data read-only",
+                    "Room playlist commit failed; keeping mutation in memory until recovery",
                     error
                 )
                 throw IOException("Failed to persist local playlists in Room", error)
             }
         }
         if (stateChanged && !committedToRoom) {
-            persistToDisk(normalized)
+            if (roomRecoveryBaseline == null) {
+                persistToDisk(normalized)
+            } else {
+                _playlists.value = normalized
+                _playlistCount.value = normalized.size
+                scheduleRoomRecovery()
+            }
         }
         if (stateChanged) {
             _playlists.value = normalized
@@ -640,6 +663,87 @@ class LocalPlaylistRepository private constructor(
         } else if (triggerSync && autoSyncEnabled) {
             scheduleAutoSync()
         }
+    }
+
+    private fun scheduleRoomRecovery() {
+        if (roomStorageEnabled || roomStore == null || roomRecoveryBaseline == null) {
+            return
+        }
+        if (roomRecoveryJob?.isActive == true) return
+        roomRecoveryJob = initializationScope.launch {
+            delay(ROOM_RETRY_DELAY_MS)
+            roomRecoveryJob = null
+            recoverRoomStorage()
+        }
+    }
+
+    private suspend fun recoverRoomStorage() {
+        val activeRoomStore = roomStore ?: return
+        var mapperNotEquivalent = false
+        val recovered = playlistCommitMutex.withLock {
+            val baseline = roomRecoveryBaseline ?: return@withLock null
+            runCatching {
+                val current = _playlists.value
+                val roomSnapshot = runCatching {
+                    activeRoomStore.readIfRoomPrimary()
+                }.getOrElse { error ->
+                    throw IOException("Failed to read Room playlists during recovery", error)
+                }
+                if (roomSnapshot == null) {
+                    val imported = activeRoomStore.importShadowSnapshotIfChanged(
+                        playlists = current,
+                        sourceDigest = LocalPlaylistRoomStore.domainDigest(current)
+                    )
+                    when (imported.status) {
+                        LocalPlaylistRoomShadowImportStatus.IMPORTED -> current
+                        LocalPlaylistRoomShadowImportStatus.SKIPPED_UNCHANGED -> {
+                            activeRoomStore.readIfRoomPrimary()
+                                ?: throw IOException(
+                                    "Room primary marker disappeared during recovery"
+                                )
+                        }
+
+                        LocalPlaylistRoomShadowImportStatus.SKIPPED_NOT_EQUIVALENT -> {
+                            mapperNotEquivalent = true
+                            null
+                        }
+                    }
+                } else {
+                    val merged = mergeLocalPlaylistRoomRecovery(
+                        roomSnapshot = roomSnapshot,
+                        recoveryBaseline = baseline,
+                        currentSnapshot = current
+                    )
+                    activeRoomStore.writeIncremental(
+                        previous = roomSnapshot,
+                        next = merged,
+                        sourceDigest = LocalPlaylistRoomStore.domainDigest(merged)
+                    )
+                    merged
+                }
+            }.onFailure { error ->
+                NPLogger.e(
+                    "LocalPlaylistRepo",
+                    "Failed to recover Room playlists without replaying JSON",
+                    error
+                )
+            }.getOrNull()?.also { merged ->
+                roomStorageEnabled = true
+                roomRecoveryBaseline = null
+                _playlists.value = merged
+                _playlistCount.value = merged.size
+            }
+        }
+        if (recovered == null) {
+            if (mapperNotEquivalent) {
+                roomRecoveryBaseline = null
+            } else {
+                scheduleRoomRecovery()
+            }
+            return
+        }
+        LegacyJsonCleanupScheduler.schedule(context, "local-playlist-room-recovery")
+        recoverPendingSyncMutation(LocalPlaylistRoomStore.domainDigest(recovered))
     }
 
     private fun recoverPendingSyncMutation(committedDomainDigest: String) {
@@ -3014,6 +3118,7 @@ class LocalPlaylistRepository private constructor(
 
     companion object {
         const val MAX_PLAYLIST_NAME_LENGTH = 10
+        private const val ROOM_RETRY_DELAY_MS = 15_000L
         private const val LOCAL_METADATA_REFRESH_BATCH_SIZE = 48
         private const val LOCAL_METADATA_REFRESH_PARALLELISM = 4
         private const val NETEASE_ALBUM_PREFIX = "Netease"
@@ -3061,4 +3166,18 @@ class LocalPlaylistRepository private constructor(
             )
         }
     }
+}
+
+internal fun mergeLocalPlaylistRoomRecovery(
+    roomSnapshot: List<LocalPlaylist>,
+    recoveryBaseline: List<LocalPlaylist>,
+    currentSnapshot: List<LocalPlaylist>
+): List<LocalPlaylist> {
+    return moe.ouom.neriplayer.data.local.database.mergeRoomRecoverySnapshot(
+        roomSnapshot = roomSnapshot,
+        recoveryBaseline = recoveryBaseline,
+        currentSnapshot = currentSnapshot,
+        keyOf = LocalPlaylist::id,
+        mergeLocalChange = { _, current -> current }
+    )
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepository.kt
@@ -306,13 +306,14 @@ class LocalPlaylistRepository private constructor(
                 activeRoomStore.readIfRoomPrimary()
             }
         }.onFailure { error ->
-            roomStorageEnabled = false
             NPLogger.e(
                 "LocalPlaylistRepo",
-                "Failed to read Room playlists; falling back to legacy storage",
+                "Failed to read Room playlists; refusing to overwrite Room from legacy JSON",
                 error
             )
-        }.getOrNull()
+        }.getOrElse { error ->
+            throw IOException("Failed to read Room playlists", error)
+        }
     }
 
     private fun readStoredPlaylists(): PlaylistLoadResult {
@@ -594,12 +595,10 @@ class LocalPlaylistRepository private constructor(
         if (markLocalMutation && syncMutation.isEmpty && pendingOutbox == null) {
             syncMutationStore.markSyncMutation()
         }
-        val roomWasEnabledBeforeOutbox = roomStorageEnabled
         if (pendingOutbox != null || !syncMutation.isEmpty) {
             writePendingSyncMutation(pendingOutbox)
         }
-        var committedToRoom = false
-        var roomFallbackRequired = roomWasEnabledBeforeOutbox && !roomStorageEnabled
+        var committedToRoom = !stateChanged
         if (stateChanged && roomStorageEnabled && roomStore != null) {
             val activeRoomStore = roomStore
             runCatching {
@@ -611,29 +610,16 @@ class LocalPlaylistRepository private constructor(
             }.onSuccess {
                 committedToRoom = true
             }.onFailure { error ->
-                roomFallbackRequired = true
-                roomStorageEnabled = false
                 NPLogger.e(
                     "LocalPlaylistRepo",
-                    "Room playlist commit failed; falling back to legacy JSON",
+                    "Room playlist commit failed; keeping JSON migration data read-only",
                     error
                 )
+                throw IOException("Failed to persist local playlists in Room", error)
             }
         }
         if (stateChanged && !committedToRoom) {
             persistToDisk(normalized)
-            val fallbackRoomStore = roomStore
-            if (roomFallbackRequired && fallbackRoomStore != null) {
-                runCatching {
-                    fallbackRoomStore.markLegacyJsonPrimary(nextDomainDigest)
-                }.onFailure { error ->
-                    NPLogger.e(
-                        "LocalPlaylistRepo",
-                        "Failed to mark legacy JSON fallback state in Room",
-                        error
-                    )
-                }
-            }
         }
         if (stateChanged) {
             _playlists.value = normalized
@@ -752,12 +738,12 @@ class LocalPlaylistRepository private constructor(
             val roomOutbox = runCatching {
                 activeRoomStore.readPendingSyncMutationOutbox()
             }.onFailure { error ->
-                roomStorageEnabled = false
                 NPLogger.e(
                     "LocalPlaylistRepo",
-                    "Failed to read Room sync outbox; falling back to legacy outbox",
+                    "Failed to read Room sync outbox",
                     error
                 )
+                throw IOException("Failed to read Room sync outbox", error)
             }.getOrNull()
             if (roomOutbox != null) {
                 return trimCommittedSyncMutationOutbox(
@@ -765,6 +751,15 @@ class LocalPlaylistRepository private constructor(
                     committedDomainDigest = committedDomainDigest,
                     legacyPrimaryText = legacyPrimaryText
                 )
+            }
+            val roomPrimary = runCatching { activeRoomStore.isRoomPrimary() }
+                .onFailure { error ->
+                    NPLogger.e("LocalPlaylistRepo", "Failed to read Room primary marker", error)
+                    throw IOException("Failed to read Room primary marker", error)
+                }
+                .getOrDefault(false)
+            if (roomPrimary) {
+                return null
             }
         }
 
@@ -786,12 +781,12 @@ class LocalPlaylistRepository private constructor(
                     activeRoomStore.writePendingSyncMutationOutbox(outbox)
                 }
             }.onFailure { error ->
-                roomStorageEnabled = false
                 NPLogger.e(
                     "LocalPlaylistRepo",
-                    "Failed to write Room sync outbox; falling back to legacy outbox",
+                    "Failed to write Room sync outbox",
                     error
                 )
+                throw IOException("Failed to write Room sync outbox", error)
             }.isSuccess
             if (roomWriteSucceeded) {
                 return
@@ -810,10 +805,10 @@ class LocalPlaylistRepository private constructor(
             try {
                 activeRoomStore.clearPendingSyncMutationOutbox()
             } catch (error: Exception) {
-                roomStorageEnabled = false
                 NPLogger.e("LocalPlaylistRepo", "Failed to clear Room sync outbox", error)
                 throw IOException("Failed to clear Room sync outbox", error)
             }
+            return
         }
         storage.clearPendingSyncMutation()
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepository.kt
@@ -77,7 +77,6 @@ import java.io.IOException
 import java.security.MessageDigest
 import java.util.Collections
 import java.util.Locale
-import java.util.concurrent.atomic.AtomicLong
 
 data class LocalPlaylistSongAddResult(
     val addedSongs: List<SongItem>
@@ -112,8 +111,6 @@ class LocalPlaylistRepository private constructor(
 ) {
     private val gson = Gson()
     private val playlistCommitMutex = Mutex()
-    private val legacyProjectionMutex = Mutex()
-    private val legacyProjectionGeneration = AtomicLong(0L)
     private val syncStorage by lazy { SecureTokenStorage(context) }
     private val syncMutationStore by lazy {
         providedSyncMutationStore ?: SecureLocalPlaylistSyncMutationStore(syncStorage)
@@ -617,8 +614,6 @@ class LocalPlaylistRepository private constructor(
                     )
                 }
             }
-        } else if (committedToRoom) {
-            enqueueLegacyProjection(normalized)
         }
         if (stateChanged) {
             _playlists.value = normalized
@@ -638,26 +633,6 @@ class LocalPlaylistRepository private constructor(
             if (!settled) return
         } else if (triggerSync && autoSyncEnabled) {
             scheduleAutoSync()
-        }
-    }
-
-    private fun enqueueLegacyProjection(playlists: List<LocalPlaylist>) {
-        val generation = legacyProjectionGeneration.incrementAndGet()
-        initializationScope.launch {
-            legacyProjectionMutex.withLock {
-                if (generation != legacyProjectionGeneration.get()) {
-                    return@withLock
-                }
-                runCatching {
-                    persistToDisk(playlists)
-                }.onFailure { error ->
-                    NPLogger.e(
-                        "LocalPlaylistRepo",
-                        "Room committed but legacy JSON projection failed",
-                        error
-                    )
-                }
-            }
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepository.kt
@@ -97,6 +97,14 @@ data class LocalPlaylistDeleteResult(
     val index: Int
 )
 
+internal fun shouldRewriteLegacyPlaylistsAfterInitialLoad(
+    migrationRequired: Boolean,
+    allowMigrationWrite: Boolean,
+    roomPromotedDuringLoad: Boolean
+): Boolean {
+    return migrationRequired && allowMigrationWrite && !roomPromotedDuringLoad
+}
+
 class LocalPlaylistRepository private constructor(
     private val context: Context,
     file: File = File(context.filesDir, "local_playlists.json"),
@@ -241,6 +249,7 @@ class LocalPlaylistRepository private constructor(
         val committedDomainDigest = LocalPlaylistRoomStore.domainDigest(committedPlaylists)
         recoverPendingSyncMutation(committedDomainDigest)
 
+        var roomPromotedDuringLoad = false
         if (roomStorageEnabled && roomStore != null) {
             val activeRoomStore = roomStore
             val imported = runCatching {
@@ -265,11 +274,18 @@ class LocalPlaylistRepository private constructor(
                     "Room mapper is not equivalent; keep legacy playlist storage"
                 )
             } else if (imported?.status == LocalPlaylistRoomShadowImportStatus.IMPORTED) {
+                roomPromotedDuringLoad = true
                 LegacyJsonCleanupScheduler.schedule(context, "local-playlist-import")
             }
         }
 
-        if (loadResult.migrationRequired && loadResult.allowMigrationWrite) {
+        if (
+            shouldRewriteLegacyPlaylistsAfterInitialLoad(
+                migrationRequired = loadResult.migrationRequired,
+                allowMigrationWrite = loadResult.allowMigrationWrite,
+                roomPromotedDuringLoad = roomPromotedDuringLoad
+            )
+        ) {
             runCatching {
                 persistToDisk(loadResult.playlists)
             }.onFailure { error ->

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepository.kt
@@ -48,6 +48,7 @@ import moe.ouom.neriplayer.data.local.audioimport.LocalAudioImportManager
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.store.LocalPlaylistRoomShadowImportStatus
 import moe.ouom.neriplayer.data.local.database.store.LocalPlaylistRoomStore
+import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.data.local.media.LocalSongSupport
 import moe.ouom.neriplayer.data.local.playlist.model.DISPLAY_ORDER_SONG_ORDER_VERSION
 import moe.ouom.neriplayer.data.local.playlist.model.LocalPlaylist
@@ -226,6 +227,7 @@ class LocalPlaylistRepository private constructor(
     private fun loadFromDisk() {
         val roomPrimary = readRoomPrimary()
         if (roomPrimary != null) {
+            LegacyJsonCleanupScheduler.schedule(context, "local-playlist-room-load")
             recoverPendingSyncMutation(
                 committedDomainDigest = LocalPlaylistRoomStore.domainDigest(roomPrimary)
             )
@@ -262,6 +264,8 @@ class LocalPlaylistRepository private constructor(
                     "LocalPlaylistRepo",
                     "Room mapper is not equivalent; keep legacy playlist storage"
                 )
+            } else if (imported?.status == LocalPlaylistRoomShadowImportStatus.IMPORTED) {
+                LegacyJsonCleanupScheduler.schedule(context, "local-playlist-import")
             }
         }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliArchiveCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliArchiveCacheRepository.kt
@@ -25,9 +25,15 @@ package moe.ouom.neriplayer.data.platform.bili
 
 import android.content.Context
 import com.google.gson.Gson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import java.io.File
 import java.util.Locale
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRecord
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRoomStore
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheTrackRecord
 
 data class CachedBiliArchiveVideo(
     val id: Long,
@@ -52,17 +58,35 @@ internal fun biliArchiveCacheFileName(mediaId: Long, kind: String): String {
     return "${kind.lowercase(Locale.ROOT)}_$mediaId.json"
 }
 
-class BiliArchiveCacheRepository(context: Context) {
-    private val appContext = context.applicationContext
+class BiliArchiveCacheRepository private constructor(
+    private val roomStore: PlatformPlaylistCacheRoomStore,
+    private val cacheDir: File
+) {
     private val gson = Gson()
-    private val cacheDir = File(appContext.filesDir, CACHE_DIR_NAME)
+
+    constructor(context: Context) : this(
+        roomStore = PlatformPlaylistCacheRoomStore(
+            NeriUserDataDatabase.getInstance(context.applicationContext)
+        ),
+        cacheDir = File(context.applicationContext.filesDir, CACHE_DIR_NAME)
+    )
+
+    internal constructor(
+        context: Context,
+        database: NeriUserDataDatabase,
+        cacheDir: File = File(context.applicationContext.filesDir, CACHE_DIR_NAME)
+    ) : this(
+        roomStore = PlatformPlaylistCacheRoomStore(database),
+        cacheDir = cacheDir
+    )
 
     fun read(mediaId: Long, kind: String): BiliArchiveContentCache? {
+        val cacheKey = cacheKey(mediaId, kind)
+        readRoom(cacheKey)?.toBiliArchiveCache()?.let { return it }
         val file = cacheFile(mediaId, kind)
         if (!file.exists()) return null
         return runCatching {
-            gson.fromJson(file.readText(Charsets.UTF_8), BiliArchiveContentCache::class.java)
-                ?.takeIf { it.mediaId == mediaId && it.kind == kind }
+            readLegacyFile(file, mediaId, kind)?.also(::saveRoomAndDeleteLegacy)
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to read Bili archive cache: mediaId=$mediaId, kind=$kind", error)
         }.getOrNull()
@@ -70,14 +94,8 @@ class BiliArchiveCacheRepository(context: Context) {
 
     fun save(cache: BiliArchiveContentCache) {
         runCatching {
-            cacheDir.mkdirs()
-            val file = cacheFile(cache.mediaId, cache.kind)
-            val tmp = File(cacheDir, "${file.name}.tmp")
-            tmp.writeText(gson.toJson(cache), Charsets.UTF_8)
-            if (!tmp.renameTo(file)) {
-                file.writeText(gson.toJson(cache), Charsets.UTF_8)
-                tmp.delete()
-            }
+            saveRoom(cache)
+            deleteLegacyFile(cacheFile(cache.mediaId, cache.kind))
         }.onFailure { error ->
             NPLogger.w(
                 TAG,
@@ -89,9 +107,89 @@ class BiliArchiveCacheRepository(context: Context) {
 
     fun clear(mediaId: Long, kind: String) {
         runCatching {
+            clearRoom(cacheKey(mediaId, kind))
             cacheFile(mediaId, kind).delete()
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to clear Bili archive cache: mediaId=$mediaId, kind=$kind", error)
+        }
+    }
+
+    fun importLegacyCaches() {
+        val files = cacheDir.listFiles { file ->
+            file.isFile && file.name.endsWith(".json")
+        }.orEmpty()
+        files.forEach { file ->
+            runCatching {
+                readLegacyFile(
+                    file = file,
+                    expectedMediaId = null,
+                    expectedKind = null
+                )?.also { cache -> saveRoomIfNewerAndDeleteLegacy(cache, file) }
+            }.onFailure { error ->
+                NPLogger.w(TAG, "Failed to import Bili archive cache: file=${file.name}", error)
+            }
+        }
+    }
+
+    private fun readRoom(cacheKey: String): PlatformPlaylistCacheRecord? {
+        return runBlocking(Dispatchers.IO) {
+            roomStore.read(PLATFORM, cacheKey)
+        }
+    }
+
+    private fun saveRoom(cache: BiliArchiveContentCache) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.replace(cache.toRecord())
+        }
+    }
+
+    private fun saveRoomIfNewer(cache: BiliArchiveContentCache) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.replaceIfNewer(cache.toRecord())
+        }
+    }
+
+    private fun clearRoom(cacheKey: String) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.clear(PLATFORM, cacheKey)
+        }
+    }
+
+    private fun saveRoomAndDeleteLegacy(cache: BiliArchiveContentCache) {
+        saveRoom(cache)
+        deleteLegacyFile(cacheFile(cache.mediaId, cache.kind))
+    }
+
+    private fun saveRoomIfNewerAndDeleteLegacy(
+        cache: BiliArchiveContentCache,
+        file: File
+    ) {
+        saveRoomIfNewer(cache)
+        deleteLegacyFile(file)
+    }
+
+    private fun readLegacyFile(
+        file: File,
+        expectedMediaId: Long?,
+        expectedKind: String?
+    ): BiliArchiveContentCache? {
+        return gson.fromJson(file.readText(Charsets.UTF_8), BiliArchiveContentCache::class.java)
+            ?.takeIf { cache ->
+                (expectedMediaId == null || cache.mediaId == expectedMediaId) &&
+                    (expectedKind == null || cache.kind == expectedKind)
+            }
+    }
+
+    private fun deleteLegacyFile(file: File) {
+        if (file.exists() && !file.delete()) {
+            NPLogger.w(TAG, "Failed to delete legacy Bili archive cache: file=${file.name}")
+        }
+        deleteCacheDirIfEmpty()
+    }
+
+    private fun deleteCacheDirIfEmpty() {
+        if (cacheDir.isDirectory && cacheDir.listFiles().orEmpty().isEmpty()) {
+            cacheDir.delete()
         }
     }
 
@@ -99,8 +197,59 @@ class BiliArchiveCacheRepository(context: Context) {
         return File(cacheDir, biliArchiveCacheFileName(mediaId, kind))
     }
 
+    private fun cacheKey(mediaId: Long, kind: String): String {
+        return "${kind.lowercase(Locale.ROOT)}:$mediaId"
+    }
+
+    private fun BiliArchiveContentCache.toRecord(): PlatformPlaylistCacheRecord {
+        return PlatformPlaylistCacheRecord(
+            platform = PLATFORM,
+            cacheKey = cacheKey(mediaId, kind),
+            sourceId = mediaId,
+            kind = kind,
+            trackCount = videos.size,
+            totalCount = totalCount,
+            hasMore = hasMore,
+            savedAtMs = savedAtMs,
+            tracks = videos.map { video ->
+                PlatformPlaylistCacheTrackRecord(
+                    itemId = video.id,
+                    itemKey = video.bvid,
+                    name = video.title,
+                    artist = video.uploader,
+                    durationMs = video.durationSec.toLong() * MILLIS_PER_SECOND,
+                    coverUrl = video.coverUrl,
+                    uploaderMid = video.uploaderMid
+                )
+            }
+        )
+    }
+
+    private fun PlatformPlaylistCacheRecord.toBiliArchiveCache(): BiliArchiveContentCache {
+        return BiliArchiveContentCache(
+            mediaId = sourceId ?: cacheKey.substringAfter(':').toLong(),
+            kind = kind.orEmpty(),
+            totalCount = totalCount,
+            hasMore = hasMore == true,
+            videos = tracks.map { track ->
+                CachedBiliArchiveVideo(
+                    id = track.itemId ?: 0L,
+                    bvid = track.itemKey.orEmpty(),
+                    title = track.name,
+                    uploader = track.artist,
+                    uploaderMid = track.uploaderMid ?: 0L,
+                    coverUrl = track.coverUrl.orEmpty(),
+                    durationSec = (track.durationMs / MILLIS_PER_SECOND).toInt()
+                )
+            },
+            savedAtMs = savedAtMs
+        )
+    }
+
     private companion object {
+        const val PLATFORM = "bili_archive"
         const val TAG = "BiliArchiveCache"
         const val CACHE_DIR_NAME = "bili_archive_cache"
+        const val MILLIS_PER_SECOND = 1_000L
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliArchiveCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliArchiveCacheRepository.kt
@@ -83,7 +83,9 @@ class BiliArchiveCacheRepository internal constructor(
 
     fun read(mediaId: Long, kind: String): BiliArchiveContentCache? {
         val cacheKey = cacheKey(mediaId, kind)
-        readRoom(cacheKey)?.let { return it }
+        val roomResult = readRoom(cacheKey)
+        if (roomResult.isFailure) return null
+        roomResult.getOrNull()?.let { return it }
         val file = cacheFile(mediaId, kind)
         if (!file.exists()) return null
         return runCatching {
@@ -121,14 +123,14 @@ class BiliArchiveCacheRepository internal constructor(
         }
     }
 
-    private fun readRoom(cacheKey: String): BiliArchiveContentCache? {
+    private fun readRoom(cacheKey: String): Result<BiliArchiveContentCache?> {
         return runCatching {
             runBlocking(Dispatchers.IO) {
                 roomStore.read(PLATFORM, cacheKey)
             }?.toBiliArchiveCache()
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to read Bili archive cache from Room: cacheKey=$cacheKey", error)
-        }.getOrNull()
+        }
     }
 
     private fun saveRoom(cache: BiliArchiveContentCache): Boolean {

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliArchiveCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliArchiveCacheRepository.kt
@@ -33,6 +33,7 @@ import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRecord
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRoomStore
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheStore
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheTrackRecord
 
 data class CachedBiliArchiveVideo(
@@ -58,8 +59,8 @@ internal fun biliArchiveCacheFileName(mediaId: Long, kind: String): String {
     return "${kind.lowercase(Locale.ROOT)}_$mediaId.json"
 }
 
-class BiliArchiveCacheRepository private constructor(
-    private val roomStore: PlatformPlaylistCacheRoomStore,
+class BiliArchiveCacheRepository internal constructor(
+    private val roomStore: PlatformPlaylistCacheStore,
     private val cacheDir: File
 ) {
     private val gson = Gson()
@@ -82,7 +83,7 @@ class BiliArchiveCacheRepository private constructor(
 
     fun read(mediaId: Long, kind: String): BiliArchiveContentCache? {
         val cacheKey = cacheKey(mediaId, kind)
-        readRoom(cacheKey)?.toBiliArchiveCache()?.let { return it }
+        readRoom(cacheKey)?.let { return it }
         val file = cacheFile(mediaId, kind)
         if (!file.exists()) return null
         return runCatching {
@@ -93,25 +94,14 @@ class BiliArchiveCacheRepository private constructor(
     }
 
     fun save(cache: BiliArchiveContentCache) {
-        runCatching {
-            saveRoom(cache)
+        if (saveRoom(cache)) {
             deleteLegacyFile(cacheFile(cache.mediaId, cache.kind))
-        }.onFailure { error ->
-            NPLogger.w(
-                TAG,
-                "Failed to save Bili archive cache: mediaId=${cache.mediaId}, kind=${cache.kind}",
-                error
-            )
         }
     }
 
     fun clear(mediaId: Long, kind: String) {
-        runCatching {
-            clearRoom(cacheKey(mediaId, kind))
-            cacheFile(mediaId, kind).delete()
-        }.onFailure { error ->
-            NPLogger.w(TAG, "Failed to clear Bili archive cache: mediaId=$mediaId, kind=$kind", error)
-        }
+        clearRoom(cacheKey(mediaId, kind))
+        deleteLegacyFile(cacheFile(mediaId, kind))
     }
 
     fun importLegacyCaches() {
@@ -131,41 +121,69 @@ class BiliArchiveCacheRepository private constructor(
         }
     }
 
-    private fun readRoom(cacheKey: String): PlatformPlaylistCacheRecord? {
-        return runBlocking(Dispatchers.IO) {
-            roomStore.read(PLATFORM, cacheKey)
-        }
+    private fun readRoom(cacheKey: String): BiliArchiveContentCache? {
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.read(PLATFORM, cacheKey)
+            }?.toBiliArchiveCache()
+        }.onFailure { error ->
+            NPLogger.w(TAG, "Failed to read Bili archive cache from Room: cacheKey=$cacheKey", error)
+        }.getOrNull()
     }
 
-    private fun saveRoom(cache: BiliArchiveContentCache) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.replace(cache.toRecord())
-        }
+    private fun saveRoom(cache: BiliArchiveContentCache): Boolean {
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.replace(cache.toRecord())
+            }
+            true
+        }.onFailure { error ->
+            NPLogger.w(
+                TAG,
+                "Failed to save Bili archive cache to Room: mediaId=${cache.mediaId}, kind=${cache.kind}",
+                error
+            )
+        }.getOrDefault(false)
     }
 
-    private fun saveRoomIfNewer(cache: BiliArchiveContentCache) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.replaceIfNewer(cache.toRecord())
-        }
+    private fun saveRoomIfNewer(cache: BiliArchiveContentCache): Boolean {
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.replaceIfNewer(cache.toRecord())
+            }
+            true
+        }.onFailure { error ->
+            NPLogger.w(
+                TAG,
+                "Failed to import Bili archive cache into Room: mediaId=${cache.mediaId}, kind=${cache.kind}",
+                error
+            )
+        }.getOrDefault(false)
     }
 
     private fun clearRoom(cacheKey: String) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.clear(PLATFORM, cacheKey)
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.clear(PLATFORM, cacheKey)
+            }
+        }.onFailure { error ->
+            NPLogger.w(TAG, "Failed to clear Bili archive cache from Room: cacheKey=$cacheKey", error)
         }
     }
 
     private fun saveRoomAndDeleteLegacy(cache: BiliArchiveContentCache) {
-        saveRoom(cache)
-        deleteLegacyFile(cacheFile(cache.mediaId, cache.kind))
+        if (saveRoom(cache)) {
+            deleteLegacyFile(cacheFile(cache.mediaId, cache.kind))
+        }
     }
 
     private fun saveRoomIfNewerAndDeleteLegacy(
         cache: BiliArchiveContentCache,
         file: File
     ) {
-        saveRoomIfNewer(cache)
-        deleteLegacyFile(file)
+        if (saveRoomIfNewer(cache)) {
+            deleteLegacyFile(file)
+        }
     }
 
     private fun readLegacyFile(

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliFavoriteFolderCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliFavoriteFolderCacheRepository.kt
@@ -77,7 +77,9 @@ class BiliFavoriteFolderCacheRepository internal constructor(
 
     fun read(mediaId: Long): BiliFavoriteFolderContentCache? {
         val cacheKey = mediaId.toString()
-        readRoom(cacheKey)?.let { return it }
+        val roomResult = readRoom(cacheKey)
+        if (roomResult.isFailure) return null
+        roomResult.getOrNull()?.let { return it }
         val file = cacheFile(mediaId)
         if (!file.exists()) return null
         return runCatching {
@@ -112,14 +114,14 @@ class BiliFavoriteFolderCacheRepository internal constructor(
         }
     }
 
-    private fun readRoom(cacheKey: String): BiliFavoriteFolderContentCache? {
+    private fun readRoom(cacheKey: String): Result<BiliFavoriteFolderContentCache?> {
         return runCatching {
             runBlocking(Dispatchers.IO) {
                 roomStore.read(PLATFORM, cacheKey)
             }?.toBiliFavoriteCache()
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to read Bili favorite cache from Room: cacheKey=$cacheKey", error)
-        }.getOrNull()
+        }
     }
 
     private fun saveRoom(cache: BiliFavoriteFolderContentCache): Boolean {

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliFavoriteFolderCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliFavoriteFolderCacheRepository.kt
@@ -31,6 +31,7 @@ import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRecord
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRoomStore
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheStore
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheTrackRecord
 import java.io.File
 
@@ -52,8 +53,8 @@ data class BiliFavoriteFolderContentCache(
     val savedAtMs: Long = System.currentTimeMillis()
 )
 
-class BiliFavoriteFolderCacheRepository private constructor(
-    private val roomStore: PlatformPlaylistCacheRoomStore,
+class BiliFavoriteFolderCacheRepository internal constructor(
+    private val roomStore: PlatformPlaylistCacheStore,
     private val cacheDir: File
 ) {
     private val gson = Gson()
@@ -76,7 +77,7 @@ class BiliFavoriteFolderCacheRepository private constructor(
 
     fun read(mediaId: Long): BiliFavoriteFolderContentCache? {
         val cacheKey = mediaId.toString()
-        readRoom(cacheKey)?.toBiliFavoriteCache()?.let { return it }
+        readRoom(cacheKey)?.let { return it }
         val file = cacheFile(mediaId)
         if (!file.exists()) return null
         return runCatching {
@@ -87,21 +88,14 @@ class BiliFavoriteFolderCacheRepository private constructor(
     }
 
     fun save(cache: BiliFavoriteFolderContentCache) {
-        runCatching {
-            saveRoom(cache)
+        if (saveRoom(cache)) {
             deleteLegacyFile(cacheFile(cache.mediaId))
-        }.onFailure { error ->
-            NPLogger.w(TAG, "Failed to save Bili favorite cache: mediaId=${cache.mediaId}", error)
         }
     }
 
     fun clear(mediaId: Long) {
-        runCatching {
-            clearRoom(mediaId.toString())
-            cacheFile(mediaId).delete()
-        }.onFailure { error ->
-            NPLogger.w(TAG, "Failed to clear Bili favorite cache: mediaId=$mediaId", error)
-        }
+        clearRoom(mediaId.toString())
+        deleteLegacyFile(cacheFile(mediaId))
     }
 
     fun importLegacyCaches() {
@@ -118,41 +112,69 @@ class BiliFavoriteFolderCacheRepository private constructor(
         }
     }
 
-    private fun readRoom(cacheKey: String): PlatformPlaylistCacheRecord? {
-        return runBlocking(Dispatchers.IO) {
-            roomStore.read(PLATFORM, cacheKey)
-        }
+    private fun readRoom(cacheKey: String): BiliFavoriteFolderContentCache? {
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.read(PLATFORM, cacheKey)
+            }?.toBiliFavoriteCache()
+        }.onFailure { error ->
+            NPLogger.w(TAG, "Failed to read Bili favorite cache from Room: cacheKey=$cacheKey", error)
+        }.getOrNull()
     }
 
-    private fun saveRoom(cache: BiliFavoriteFolderContentCache) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.replace(cache.toRecord())
-        }
+    private fun saveRoom(cache: BiliFavoriteFolderContentCache): Boolean {
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.replace(cache.toRecord())
+            }
+            true
+        }.onFailure { error ->
+            NPLogger.w(
+                TAG,
+                "Failed to save Bili favorite cache to Room: mediaId=${cache.mediaId}",
+                error
+            )
+        }.getOrDefault(false)
     }
 
-    private fun saveRoomIfNewer(cache: BiliFavoriteFolderContentCache) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.replaceIfNewer(cache.toRecord())
-        }
+    private fun saveRoomIfNewer(cache: BiliFavoriteFolderContentCache): Boolean {
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.replaceIfNewer(cache.toRecord())
+            }
+            true
+        }.onFailure { error ->
+            NPLogger.w(
+                TAG,
+                "Failed to import Bili favorite cache into Room: mediaId=${cache.mediaId}",
+                error
+            )
+        }.getOrDefault(false)
     }
 
     private fun clearRoom(cacheKey: String) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.clear(PLATFORM, cacheKey)
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.clear(PLATFORM, cacheKey)
+            }
+        }.onFailure { error ->
+            NPLogger.w(TAG, "Failed to clear Bili favorite cache from Room: cacheKey=$cacheKey", error)
         }
     }
 
     private fun saveRoomAndDeleteLegacy(cache: BiliFavoriteFolderContentCache) {
-        saveRoom(cache)
-        deleteLegacyFile(cacheFile(cache.mediaId))
+        if (saveRoom(cache)) {
+            deleteLegacyFile(cacheFile(cache.mediaId))
+        }
     }
 
     private fun saveRoomIfNewerAndDeleteLegacy(
         cache: BiliFavoriteFolderContentCache,
         file: File
     ) {
-        saveRoomIfNewer(cache)
-        deleteLegacyFile(file)
+        if (saveRoomIfNewer(cache)) {
+            deleteLegacyFile(file)
+        }
     }
 
     private fun readLegacyFile(

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliFavoriteFolderCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliFavoriteFolderCacheRepository.kt
@@ -25,7 +25,13 @@ package moe.ouom.neriplayer.data.platform.bili
 
 import android.content.Context
 import com.google.gson.Gson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRecord
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRoomStore
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheTrackRecord
 import java.io.File
 
 data class CachedBiliFavoriteVideo(
@@ -46,17 +52,35 @@ data class BiliFavoriteFolderContentCache(
     val savedAtMs: Long = System.currentTimeMillis()
 )
 
-class BiliFavoriteFolderCacheRepository(context: Context) {
-    private val appContext = context.applicationContext
+class BiliFavoriteFolderCacheRepository private constructor(
+    private val roomStore: PlatformPlaylistCacheRoomStore,
+    private val cacheDir: File
+) {
     private val gson = Gson()
-    private val cacheDir = File(appContext.filesDir, CACHE_DIR_NAME)
+
+    constructor(context: Context) : this(
+        roomStore = PlatformPlaylistCacheRoomStore(
+            NeriUserDataDatabase.getInstance(context.applicationContext)
+        ),
+        cacheDir = File(context.applicationContext.filesDir, CACHE_DIR_NAME)
+    )
+
+    internal constructor(
+        context: Context,
+        database: NeriUserDataDatabase,
+        cacheDir: File = File(context.applicationContext.filesDir, CACHE_DIR_NAME)
+    ) : this(
+        roomStore = PlatformPlaylistCacheRoomStore(database),
+        cacheDir = cacheDir
+    )
 
     fun read(mediaId: Long): BiliFavoriteFolderContentCache? {
+        val cacheKey = mediaId.toString()
+        readRoom(cacheKey)?.toBiliFavoriteCache()?.let { return it }
         val file = cacheFile(mediaId)
         if (!file.exists()) return null
         return runCatching {
-            gson.fromJson(file.readText(Charsets.UTF_8), BiliFavoriteFolderContentCache::class.java)
-                ?.takeIf { it.mediaId == mediaId }
+            readLegacyFile(file, mediaId)?.also(::saveRoomAndDeleteLegacy)
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to read Bili favorite cache: mediaId=$mediaId", error)
         }.getOrNull()
@@ -64,14 +88,8 @@ class BiliFavoriteFolderCacheRepository(context: Context) {
 
     fun save(cache: BiliFavoriteFolderContentCache) {
         runCatching {
-            cacheDir.mkdirs()
-            val file = cacheFile(cache.mediaId)
-            val tmp = File(cacheDir, "${file.name}.tmp")
-            tmp.writeText(gson.toJson(cache), Charsets.UTF_8)
-            if (!tmp.renameTo(file)) {
-                file.writeText(gson.toJson(cache), Charsets.UTF_8)
-                tmp.delete()
-            }
+            saveRoom(cache)
+            deleteLegacyFile(cacheFile(cache.mediaId))
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to save Bili favorite cache: mediaId=${cache.mediaId}", error)
         }
@@ -79,9 +97,82 @@ class BiliFavoriteFolderCacheRepository(context: Context) {
 
     fun clear(mediaId: Long) {
         runCatching {
+            clearRoom(mediaId.toString())
             cacheFile(mediaId).delete()
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to clear Bili favorite cache: mediaId=$mediaId", error)
+        }
+    }
+
+    fun importLegacyCaches() {
+        val files = cacheDir.listFiles { file ->
+            file.isFile && file.name.endsWith(".json")
+        }.orEmpty()
+        files.forEach { file ->
+            runCatching {
+                readLegacyFile(file, expectedMediaId = null)
+                    ?.also { cache -> saveRoomIfNewerAndDeleteLegacy(cache, file) }
+            }.onFailure { error ->
+                NPLogger.w(TAG, "Failed to import Bili favorite cache: file=${file.name}", error)
+            }
+        }
+    }
+
+    private fun readRoom(cacheKey: String): PlatformPlaylistCacheRecord? {
+        return runBlocking(Dispatchers.IO) {
+            roomStore.read(PLATFORM, cacheKey)
+        }
+    }
+
+    private fun saveRoom(cache: BiliFavoriteFolderContentCache) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.replace(cache.toRecord())
+        }
+    }
+
+    private fun saveRoomIfNewer(cache: BiliFavoriteFolderContentCache) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.replaceIfNewer(cache.toRecord())
+        }
+    }
+
+    private fun clearRoom(cacheKey: String) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.clear(PLATFORM, cacheKey)
+        }
+    }
+
+    private fun saveRoomAndDeleteLegacy(cache: BiliFavoriteFolderContentCache) {
+        saveRoom(cache)
+        deleteLegacyFile(cacheFile(cache.mediaId))
+    }
+
+    private fun saveRoomIfNewerAndDeleteLegacy(
+        cache: BiliFavoriteFolderContentCache,
+        file: File
+    ) {
+        saveRoomIfNewer(cache)
+        deleteLegacyFile(file)
+    }
+
+    private fun readLegacyFile(
+        file: File,
+        expectedMediaId: Long?
+    ): BiliFavoriteFolderContentCache? {
+        return gson.fromJson(file.readText(Charsets.UTF_8), BiliFavoriteFolderContentCache::class.java)
+            ?.takeIf { cache -> expectedMediaId == null || cache.mediaId == expectedMediaId }
+    }
+
+    private fun deleteLegacyFile(file: File) {
+        if (file.exists() && !file.delete()) {
+            NPLogger.w(TAG, "Failed to delete legacy Bili favorite cache: file=${file.name}")
+        }
+        deleteCacheDirIfEmpty()
+    }
+
+    private fun deleteCacheDirIfEmpty() {
+        if (cacheDir.isDirectory && cacheDir.listFiles().orEmpty().isEmpty()) {
+            cacheDir.delete()
         }
     }
 
@@ -89,8 +180,53 @@ class BiliFavoriteFolderCacheRepository(context: Context) {
         return File(cacheDir, "media_$mediaId.json")
     }
 
+    private fun BiliFavoriteFolderContentCache.toRecord(): PlatformPlaylistCacheRecord {
+        return PlatformPlaylistCacheRecord(
+            platform = PLATFORM,
+            cacheKey = mediaId.toString(),
+            sourceId = mediaId,
+            trackCount = videos.size,
+            totalCount = totalCount,
+            signaturePrimary = latestPageSignature,
+            savedAtMs = savedAtMs,
+            tracks = videos.map { video ->
+                PlatformPlaylistCacheTrackRecord(
+                    itemId = video.id,
+                    itemKey = video.bvid,
+                    name = video.title,
+                    artist = video.uploader,
+                    durationMs = video.durationSec.toLong() * MILLIS_PER_SECOND,
+                    coverUrl = video.coverUrl,
+                    uploaderMid = video.uploaderMid
+                )
+            }
+        )
+    }
+
+    private fun PlatformPlaylistCacheRecord.toBiliFavoriteCache(): BiliFavoriteFolderContentCache {
+        return BiliFavoriteFolderContentCache(
+            mediaId = sourceId ?: cacheKey.toLong(),
+            latestPageSignature = signaturePrimary.orEmpty(),
+            totalCount = totalCount,
+            videos = tracks.map { track ->
+                CachedBiliFavoriteVideo(
+                    id = track.itemId ?: 0L,
+                    bvid = track.itemKey.orEmpty(),
+                    title = track.name,
+                    uploader = track.artist,
+                    uploaderMid = track.uploaderMid ?: 0L,
+                    coverUrl = track.coverUrl.orEmpty(),
+                    durationSec = (track.durationMs / MILLIS_PER_SECOND).toInt()
+                )
+            },
+            savedAtMs = savedAtMs
+        )
+    }
+
     private companion object {
+        const val PLATFORM = "bili_favorite"
         const val TAG = "BiliFavoriteCache"
         const val CACHE_DIR_NAME = "bili_favorite_cache"
+        const val MILLIS_PER_SECOND = 1_000L
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliVideoSkipRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliVideoSkipRepository.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -19,6 +20,8 @@ import kotlinx.serialization.json.Json
 import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.mergeRoomRecoverySnapshot
+import moe.ouom.neriplayer.data.local.database.store.BiliVideoSkipRoomImportStatus
 import moe.ouom.neriplayer.data.local.database.store.BiliVideoSkipRoomSnapshot
 import moe.ouom.neriplayer.data.local.database.store.BiliVideoSkipRoomStore
 import moe.ouom.neriplayer.data.sync.github.GitHubSyncWorker
@@ -232,6 +235,11 @@ class BiliVideoSkipRepository private constructor(context: Context) {
     )
     private val rulesFile = File(appContext.filesDir, RULES_FILE_NAME)
     private val draftsFile = File(appContext.filesDir, DRAFTS_FILE_NAME)
+    @Volatile
+    private var roomStorageEnabled = true
+    private var roomRecoveryBaseline: BiliVideoSkipRoomSnapshot? = null
+    private var roomRecoveryJob: Job? = null
+    private var pendingSyncAfterRecovery = false
     private val initialSnapshot = runBlocking(Dispatchers.IO) {
         loadInitialSnapshot()
     }
@@ -242,6 +250,10 @@ class BiliVideoSkipRepository private constructor(context: Context) {
 
     val rules: StateFlow<List<BiliVideoSkipRule>> = _rules.asStateFlow()
     val drafts: StateFlow<List<BiliVideoSkipDraft>> = _drafts.asStateFlow()
+
+    init {
+        scheduleRoomRecovery()
+    }
 
     fun snapshot(): List<BiliVideoSkipRule> = _rules.value
 
@@ -337,9 +349,25 @@ class BiliVideoSkipRepository private constructor(context: Context) {
             val updatedRules = normalizeBiliVideoSkipRules(
                 _rules.value.filterNot { it.target == normalizedTarget } + updatedRule
             )
-            roomStore.replaceRules(updatedRules)
+            val persisted = runCatching {
+                if (!roomStorageEnabled) return@runCatching false
+                roomStore.replaceRules(updatedRules)
+                true
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                roomRecoveryBaseline = roomRecoveryBaseline ?: BiliVideoSkipRoomSnapshot(
+                    rules = _rules.value,
+                    drafts = _drafts.value
+                )
+                NPLogger.w(TAG, "Failed to persist Bili skip rules; keeping memory state", error)
+            }.getOrDefault(false)
             _rules.value = updatedRules
-            markMutationAndScheduleSync()
+            if (persisted) {
+                markMutationAndScheduleSync()
+            } else {
+                pendingSyncAfterRecovery = true
+                scheduleRoomRecovery()
+            }
             true
         }
     }
@@ -354,22 +382,36 @@ class BiliVideoSkipRepository private constructor(context: Context) {
             }
             val normalizedRules = normalizeBiliVideoSkipRules(rules)
             if (_rules.value == normalizedRules) return@withLock true
-            roomStore.replaceRules(normalizedRules)
+            val persisted = runCatching {
+                if (!roomStorageEnabled) return@runCatching false
+                roomStore.replaceRules(normalizedRules)
+                true
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                roomRecoveryBaseline = roomRecoveryBaseline ?: BiliVideoSkipRoomSnapshot(
+                    rules = _rules.value,
+                    drafts = _drafts.value
+                )
+                NPLogger.w(TAG, "Failed to persist synced Bili skip rules", error)
+            }.getOrDefault(false)
             _rules.value = normalizedRules
+            if (!persisted) {
+                scheduleRoomRecovery()
+            }
             true
         }
     }
 
     private suspend fun loadInitialSnapshot(): BiliVideoSkipRoomSnapshot {
-        val roomPrimary = runCatching { roomStore.isRoomPrimary() }
+        val roomSnapshotResult = runCatching { roomStore.readIfRoomPrimary() }
             .onFailure { error ->
+                roomStorageEnabled = false
                 NPLogger.w(TAG, "Failed to read Bili skip Room marker", error)
             }
-            .getOrDefault(false)
-        if (roomPrimary) {
+        val roomSnapshot = roomSnapshotResult.getOrNull()
+        if (roomSnapshot != null) {
             LegacyJsonCleanupScheduler.schedule(appContext, "bili-skip-room-load")
-            return roomStore.readIfRoomPrimary()
-                ?: BiliVideoSkipRoomSnapshot(emptyList(), emptyList())
+            return roomSnapshot
         }
 
         val legacyRules = readLegacyRulesOrNull()
@@ -377,18 +419,25 @@ class BiliVideoSkipRepository private constructor(context: Context) {
         val shouldImportLegacyFiles = legacyRules != null &&
             legacyDrafts != null &&
             (rulesFile.exists() || draftsFile.exists())
-        if (shouldImportLegacyFiles) {
+        if (shouldImportLegacyFiles && roomStorageEnabled) {
             runCatching {
-                roomStore.importLegacyAndPromote(legacyRules, legacyDrafts)
-                LegacyJsonCleanupScheduler.schedule(appContext, "bili-skip-import")
+                val result = roomStore.importLegacyAndPromote(legacyRules, legacyDrafts)
+                if (result.status == BiliVideoSkipRoomImportStatus.IMPORTED) {
+                    LegacyJsonCleanupScheduler.schedule(appContext, "bili-skip-import")
+                }
             }.onFailure { error ->
+                roomStorageEnabled = false
                 NPLogger.w(TAG, "Failed to import Bili skip JSON into Room", error)
             }
         }
-        return BiliVideoSkipRoomSnapshot(
+        val snapshot = BiliVideoSkipRoomSnapshot(
             rules = legacyRules.orEmpty(),
             drafts = legacyDrafts.orEmpty()
         )
+        if (!roomStorageEnabled) {
+            roomRecoveryBaseline = snapshot
+        }
+        return snapshot
     }
 
     private fun readLegacyRulesOrNull(): List<BiliVideoSkipRule>? {
@@ -421,12 +470,92 @@ class BiliVideoSkipRepository private constructor(context: Context) {
                 val snapshot = synchronized(draftsStateLock) {
                     _drafts.value.takeIf { draftsStateVersion == expectedStateVersion }
                 } ?: return@withLock
-                roomStore.replaceDrafts(snapshot)
+                if (!roomStorageEnabled) {
+                    pendingSyncAfterRecovery = true
+                    scheduleRoomRecovery()
+                    return@withLock
+                }
+                runCatching {
+                    roomStore.replaceDrafts(snapshot)
+                }.onFailure { error ->
+                    roomStorageEnabled = false
+                    roomRecoveryBaseline = roomRecoveryBaseline ?: BiliVideoSkipRoomSnapshot(
+                        rules = _rules.value,
+                        drafts = _drafts.value
+                    )
+                    pendingSyncAfterRecovery = true
+                    NPLogger.w(TAG, "Failed to persist Bili skip drafts", error)
+                    scheduleRoomRecovery()
+                }
             }
         } catch (error: CancellationException) {
             throw error
         } catch (error: Exception) {
             NPLogger.w(TAG, "Failed to persist Bili video skip drafts", error)
+        }
+    }
+
+    private fun scheduleRoomRecovery() {
+        if (roomStorageEnabled || roomRecoveryBaseline == null) return
+        if (roomRecoveryJob?.isActive == true) return
+        roomRecoveryJob = draftsPersistenceScope.launch {
+            delay(ROOM_RETRY_DELAY_MS)
+            roomRecoveryJob = null
+            recoverRoomStorage()
+        }
+    }
+
+    private suspend fun recoverRoomStorage() {
+        val baseline = roomRecoveryBaseline ?: return
+        val recovered = mutex.withLock {
+            runCatching {
+                val current = BiliVideoSkipRoomSnapshot(
+                    rules = _rules.value,
+                    drafts = _drafts.value
+                )
+                val roomSnapshot = roomStore.readIfRoomPrimary()
+                if (roomSnapshot == null) {
+                    val imported = roomStore.importLegacyAndPromote(
+                        rules = current.rules,
+                        drafts = current.drafts
+                    )
+                    if (imported.status == BiliVideoSkipRoomImportStatus.IMPORTED) {
+                        current
+                    } else {
+                        val primary = roomStore.readIfRoomPrimary()
+                            ?: return@runCatching null
+                        mergeBiliVideoSkipRoomRecovery(
+                            roomSnapshot = primary,
+                            recoveryBaseline = baseline,
+                            currentSnapshot = current
+                        )
+                    }
+                } else {
+                    val merged = mergeBiliVideoSkipRoomRecovery(
+                        roomSnapshot = roomSnapshot,
+                        recoveryBaseline = baseline,
+                        currentSnapshot = current
+                    )
+                    roomStore.replaceAll(merged.rules, merged.drafts)
+                    merged
+                }
+            }.onFailure { error ->
+                NPLogger.w(TAG, "Failed to recover Bili skip Room state", error)
+            }.getOrNull()?.also { merged ->
+                roomStorageEnabled = true
+                roomRecoveryBaseline = null
+                _rules.value = merged.rules
+                _drafts.value = merged.drafts
+            }
+        }
+        if (recovered == null) {
+            scheduleRoomRecovery()
+            return
+        }
+        LegacyJsonCleanupScheduler.schedule(appContext, "bili-skip-room-recovery")
+        if (pendingSyncAfterRecovery) {
+            pendingSyncAfterRecovery = false
+            markMutationAndScheduleSync()
         }
     }
 
@@ -459,6 +588,7 @@ class BiliVideoSkipRepository private constructor(context: Context) {
 
     companion object {
         const val TAG = "BiliVideoSkipRepo"
+        private const val ROOM_RETRY_DELAY_MS = 15_000L
         const val RULES_FILE_NAME = "bili_video_skip_rules.json"
         const val DRAFTS_FILE_NAME = "bili_video_skip_drafts.json"
 
@@ -471,4 +601,26 @@ class BiliVideoSkipRepository private constructor(context: Context) {
             }
         }
     }
+}
+
+internal fun mergeBiliVideoSkipRoomRecovery(
+    roomSnapshot: BiliVideoSkipRoomSnapshot,
+    recoveryBaseline: BiliVideoSkipRoomSnapshot,
+    currentSnapshot: BiliVideoSkipRoomSnapshot
+): BiliVideoSkipRoomSnapshot {
+    val rules = mergeRoomRecoverySnapshot(
+        roomSnapshot = roomSnapshot.rules,
+        recoveryBaseline = recoveryBaseline.rules,
+        currentSnapshot = currentSnapshot.rules,
+        keyOf = { rule -> rule.target.stableKey() },
+        mergeLocalChange = { _, current -> current }
+    )
+    val drafts = mergeRoomRecoverySnapshot(
+        roomSnapshot = roomSnapshot.drafts,
+        recoveryBaseline = recoveryBaseline.drafts,
+        currentSnapshot = currentSnapshot.drafts,
+        keyOf = { draft -> draft.target.stableKey() },
+        mergeLocalChange = { _, current -> current }
+    )
+    return BiliVideoSkipRoomSnapshot(rules = rules, drafts = drafts)
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliVideoSkipRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliVideoSkipRepository.kt
@@ -15,9 +15,9 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.store.BiliVideoSkipRoomSnapshot
 import moe.ouom.neriplayer.data.local.database.store.BiliVideoSkipRoomStore
@@ -318,11 +318,10 @@ class BiliVideoSkipRepository private constructor(context: Context) {
         mutex.withLock {
             val previous = _rules.value.firstOrNull { it.target == normalizedTarget }
             val deleted = normalizedIntervals.isEmpty()
-            if (
-                previous != null &&
-                    previous.isDeleted == deleted &&
+            val hasSameSnapshot =
+                previous != null && previous.isDeleted == deleted &&
                     previous.intervals == normalizedIntervals
-            ) {
+            if (hasSameSnapshot) {
                 return@withLock false
             }
             if (previous == null && deleted) {
@@ -368,19 +367,20 @@ class BiliVideoSkipRepository private constructor(context: Context) {
             }
             .getOrDefault(false)
         if (roomPrimary) {
+            LegacyJsonCleanupScheduler.schedule(appContext, "bili-skip-room-load")
             return roomStore.readIfRoomPrimary()
                 ?: BiliVideoSkipRoomSnapshot(emptyList(), emptyList())
         }
 
         val legacyRules = readLegacyRulesOrNull()
         val legacyDrafts = readLegacyDraftsOrNull()
-        if (
-            legacyRules != null &&
+        val shouldImportLegacyFiles = legacyRules != null &&
             legacyDrafts != null &&
             (rulesFile.exists() || draftsFile.exists())
-        ) {
+        if (shouldImportLegacyFiles) {
             runCatching {
                 roomStore.replaceAll(legacyRules, legacyDrafts)
+                LegacyJsonCleanupScheduler.schedule(appContext, "bili-skip-import")
             }.onFailure { error ->
                 NPLogger.w(TAG, "Failed to import Bili skip JSON into Room", error)
             }

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliVideoSkipRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliVideoSkipRepository.kt
@@ -379,7 +379,7 @@ class BiliVideoSkipRepository private constructor(context: Context) {
             (rulesFile.exists() || draftsFile.exists())
         if (shouldImportLegacyFiles) {
             runCatching {
-                roomStore.replaceAll(legacyRules, legacyDrafts)
+                roomStore.importLegacyAndPromote(legacyRules, legacyDrafts)
                 LegacyJsonCleanupScheduler.schedule(appContext, "bili-skip-import")
             }.onFailure { error ->
                 NPLogger.w(TAG, "Failed to import Bili skip JSON into Room", error)

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliVideoSkipRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/bili/BiliVideoSkipRepository.kt
@@ -10,18 +10,20 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.BiliVideoSkipRoomSnapshot
+import moe.ouom.neriplayer.data.local.database.store.BiliVideoSkipRoomStore
 import moe.ouom.neriplayer.data.sync.github.GitHubSyncWorker
 import moe.ouom.neriplayer.data.sync.github.SecureTokenStorage
 import moe.ouom.neriplayer.data.sync.webdav.WebDavSyncWorker
-import moe.ouom.neriplayer.util.io.writeTextAtomically
 import java.io.File
 
 const val MAX_BILI_VIDEO_SKIP_INTERVALS = 100
@@ -225,10 +227,16 @@ class BiliVideoSkipRepository private constructor(context: Context) {
     private val draftsMutex = Mutex()
     private val draftsStateLock = Any()
     private val draftsPersistenceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val roomStore = BiliVideoSkipRoomStore(
+        NeriUserDataDatabase.getInstance(appContext)
+    )
     private val rulesFile = File(appContext.filesDir, RULES_FILE_NAME)
     private val draftsFile = File(appContext.filesDir, DRAFTS_FILE_NAME)
-    private val _rules = MutableStateFlow(readRules())
-    private val _drafts = MutableStateFlow(readDrafts())
+    private val initialSnapshot = runBlocking(Dispatchers.IO) {
+        loadInitialSnapshot()
+    }
+    private val _rules = MutableStateFlow(initialSnapshot.rules)
+    private val _drafts = MutableStateFlow(initialSnapshot.drafts)
     private var draftsStateVersion = 0L
     private var draftPersistJob: Job? = null
 
@@ -330,7 +338,7 @@ class BiliVideoSkipRepository private constructor(context: Context) {
             val updatedRules = normalizeBiliVideoSkipRules(
                 _rules.value.filterNot { it.target == normalizedTarget } + updatedRule
             )
-            persistRules(updatedRules)
+            roomStore.replaceRules(updatedRules)
             _rules.value = updatedRules
             markMutationAndScheduleSync()
             true
@@ -347,13 +355,43 @@ class BiliVideoSkipRepository private constructor(context: Context) {
             }
             val normalizedRules = normalizeBiliVideoSkipRules(rules)
             if (_rules.value == normalizedRules) return@withLock true
-            persistRules(normalizedRules)
+            roomStore.replaceRules(normalizedRules)
             _rules.value = normalizedRules
             true
         }
     }
 
-    private fun readRules(): List<BiliVideoSkipRule> {
+    private suspend fun loadInitialSnapshot(): BiliVideoSkipRoomSnapshot {
+        val roomPrimary = runCatching { roomStore.isRoomPrimary() }
+            .onFailure { error ->
+                NPLogger.w(TAG, "Failed to read Bili skip Room marker", error)
+            }
+            .getOrDefault(false)
+        if (roomPrimary) {
+            return roomStore.readIfRoomPrimary()
+                ?: BiliVideoSkipRoomSnapshot(emptyList(), emptyList())
+        }
+
+        val legacyRules = readLegacyRulesOrNull()
+        val legacyDrafts = readLegacyDraftsOrNull()
+        if (
+            legacyRules != null &&
+            legacyDrafts != null &&
+            (rulesFile.exists() || draftsFile.exists())
+        ) {
+            runCatching {
+                roomStore.replaceAll(legacyRules, legacyDrafts)
+            }.onFailure { error ->
+                NPLogger.w(TAG, "Failed to import Bili skip JSON into Room", error)
+            }
+        }
+        return BiliVideoSkipRoomSnapshot(
+            rules = legacyRules.orEmpty(),
+            drafts = legacyDrafts.orEmpty()
+        )
+    }
+
+    private fun readLegacyRulesOrNull(): List<BiliVideoSkipRule>? {
         if (!rulesFile.exists()) return emptyList()
         return runCatching {
             val document = json.decodeFromString<BiliVideoSkipRulesDocument>(
@@ -362,10 +400,10 @@ class BiliVideoSkipRepository private constructor(context: Context) {
             normalizeBiliVideoSkipRules(document.rules)
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to read Bili video skip rules", error)
-        }.getOrDefault(emptyList())
+        }.getOrNull()
     }
 
-    private fun readDrafts(): List<BiliVideoSkipDraft> {
+    private fun readLegacyDraftsOrNull(): List<BiliVideoSkipDraft>? {
         if (!draftsFile.exists()) return emptyList()
         return runCatching {
             val document = json.decodeFromString<BiliVideoSkipDraftsDocument>(
@@ -374,13 +412,7 @@ class BiliVideoSkipRepository private constructor(context: Context) {
             normalizeBiliVideoSkipDrafts(document.drafts)
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to read Bili video skip drafts", error)
-        }.getOrDefault(emptyList())
-    }
-
-    private fun persistRules(rules: List<BiliVideoSkipRule>) {
-        rulesFile.writeTextAtomically(
-            json.encodeToString(BiliVideoSkipRulesDocument(rules = rules))
-        )
+        }.getOrNull()
     }
 
     private suspend fun persistDraftsIfCurrent(expectedStateVersion: Long) {
@@ -389,9 +421,7 @@ class BiliVideoSkipRepository private constructor(context: Context) {
                 val snapshot = synchronized(draftsStateLock) {
                     _drafts.value.takeIf { draftsStateVersion == expectedStateVersion }
                 } ?: return@withLock
-                draftsFile.writeTextAtomically(
-                    json.encodeToString(BiliVideoSkipDraftsDocument(drafts = snapshot))
-                )
+                roomStore.replaceDrafts(snapshot)
             }
         } catch (error: CancellationException) {
             throw error

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/netease/NeteasePlaylistCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/netease/NeteasePlaylistCacheRepository.kt
@@ -94,7 +94,9 @@ class NeteasePlaylistCacheRepository internal constructor(
 
     fun read(playlistId: Long): CachedNeteasePlaylistDetail? {
         val cacheKey = playlistId.toString()
-        readRoom(cacheKey)?.let { return it }
+        val roomResult = readRoom(cacheKey)
+        if (roomResult.isFailure) return null
+        roomResult.getOrNull()?.let { return it }
         val file = cacheFile(playlistId)
         if (!file.exists()) return null
         return runCatching {
@@ -129,14 +131,14 @@ class NeteasePlaylistCacheRepository internal constructor(
         }
     }
 
-    private fun readRoom(cacheKey: String): CachedNeteasePlaylistDetail? {
+    private fun readRoom(cacheKey: String): Result<CachedNeteasePlaylistDetail?> {
         return runCatching {
             runBlocking(Dispatchers.IO) {
                 roomStore.read(PLATFORM, cacheKey)
             }?.toNeteasePlaylistDetail()
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to read NetEase playlist cache from Room: cacheKey=$cacheKey", error)
-        }.getOrNull()
+        }
     }
 
     private fun saveRoom(cache: CachedNeteasePlaylistDetail): Boolean {

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/netease/NeteasePlaylistCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/netease/NeteasePlaylistCacheRepository.kt
@@ -33,6 +33,7 @@ import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheArtistRecord
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRecord
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRoomStore
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheStore
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheTrackRecord
 
 data class CachedNeteasePlaylistHeader(
@@ -69,8 +70,8 @@ data class CachedNeteasePlaylistDetail(
     val savedAtMs: Long = System.currentTimeMillis()
 )
 
-class NeteasePlaylistCacheRepository private constructor(
-    private val roomStore: PlatformPlaylistCacheRoomStore,
+class NeteasePlaylistCacheRepository internal constructor(
+    private val roomStore: PlatformPlaylistCacheStore,
     private val cacheDir: File
 ) {
     private val gson = Gson()
@@ -93,7 +94,7 @@ class NeteasePlaylistCacheRepository private constructor(
 
     fun read(playlistId: Long): CachedNeteasePlaylistDetail? {
         val cacheKey = playlistId.toString()
-        readRoom(cacheKey)?.toNeteasePlaylistDetail()?.let { return it }
+        readRoom(cacheKey)?.let { return it }
         val file = cacheFile(playlistId)
         if (!file.exists()) return null
         return runCatching {
@@ -104,21 +105,14 @@ class NeteasePlaylistCacheRepository private constructor(
     }
 
     fun save(cache: CachedNeteasePlaylistDetail) {
-        runCatching {
-            saveRoom(cache)
+        if (saveRoom(cache)) {
             deleteLegacyFile(cacheFile(cache.playlistId))
-        }.onFailure { error ->
-            NPLogger.w(TAG, "Failed to save NetEase playlist cache: playlistId=${cache.playlistId}", error)
         }
     }
 
     fun clear(playlistId: Long) {
-        runCatching {
-            clearRoom(playlistId.toString())
-            cacheFile(playlistId).delete()
-        }.onFailure { error ->
-            NPLogger.w(TAG, "Failed to clear NetEase playlist cache: playlistId=$playlistId", error)
-        }
+        clearRoom(playlistId.toString())
+        deleteLegacyFile(cacheFile(playlistId))
     }
 
     fun importLegacyCaches() {
@@ -135,41 +129,69 @@ class NeteasePlaylistCacheRepository private constructor(
         }
     }
 
-    private fun readRoom(cacheKey: String): PlatformPlaylistCacheRecord? {
-        return runBlocking(Dispatchers.IO) {
-            roomStore.read(PLATFORM, cacheKey)
-        }
+    private fun readRoom(cacheKey: String): CachedNeteasePlaylistDetail? {
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.read(PLATFORM, cacheKey)
+            }?.toNeteasePlaylistDetail()
+        }.onFailure { error ->
+            NPLogger.w(TAG, "Failed to read NetEase playlist cache from Room: cacheKey=$cacheKey", error)
+        }.getOrNull()
     }
 
-    private fun saveRoom(cache: CachedNeteasePlaylistDetail) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.replace(cache.toRecord())
-        }
+    private fun saveRoom(cache: CachedNeteasePlaylistDetail): Boolean {
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.replace(cache.toRecord())
+            }
+            true
+        }.onFailure { error ->
+            NPLogger.w(
+                TAG,
+                "Failed to save NetEase playlist cache to Room: playlistId=${cache.playlistId}",
+                error
+            )
+        }.getOrDefault(false)
     }
 
-    private fun saveRoomIfNewer(cache: CachedNeteasePlaylistDetail) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.replaceIfNewer(cache.toRecord())
-        }
+    private fun saveRoomIfNewer(cache: CachedNeteasePlaylistDetail): Boolean {
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.replaceIfNewer(cache.toRecord())
+            }
+            true
+        }.onFailure { error ->
+            NPLogger.w(
+                TAG,
+                "Failed to import NetEase playlist cache into Room: playlistId=${cache.playlistId}",
+                error
+            )
+        }.getOrDefault(false)
     }
 
     private fun clearRoom(cacheKey: String) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.clear(PLATFORM, cacheKey)
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.clear(PLATFORM, cacheKey)
+            }
+        }.onFailure { error ->
+            NPLogger.w(TAG, "Failed to clear NetEase playlist cache from Room: cacheKey=$cacheKey", error)
         }
     }
 
     private fun saveRoomAndDeleteLegacy(cache: CachedNeteasePlaylistDetail) {
-        saveRoom(cache)
-        deleteLegacyFile(cacheFile(cache.playlistId))
+        if (saveRoom(cache)) {
+            deleteLegacyFile(cacheFile(cache.playlistId))
+        }
     }
 
     private fun saveRoomIfNewerAndDeleteLegacy(
         cache: CachedNeteasePlaylistDetail,
         file: File
     ) {
-        saveRoomIfNewer(cache)
-        deleteLegacyFile(file)
+        if (saveRoomIfNewer(cache)) {
+            deleteLegacyFile(file)
+        }
     }
 
     private fun readLegacyFile(

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/netease/NeteasePlaylistCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/netease/NeteasePlaylistCacheRepository.kt
@@ -25,8 +25,15 @@ package moe.ouom.neriplayer.data.platform.netease
 
 import android.content.Context
 import com.google.gson.Gson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import java.io.File
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheArtistRecord
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRecord
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRoomStore
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheTrackRecord
 
 data class CachedNeteasePlaylistHeader(
     val id: Long,
@@ -62,17 +69,35 @@ data class CachedNeteasePlaylistDetail(
     val savedAtMs: Long = System.currentTimeMillis()
 )
 
-class NeteasePlaylistCacheRepository(context: Context) {
-    private val appContext = context.applicationContext
+class NeteasePlaylistCacheRepository private constructor(
+    private val roomStore: PlatformPlaylistCacheRoomStore,
+    private val cacheDir: File
+) {
     private val gson = Gson()
-    private val cacheDir = File(appContext.filesDir, CACHE_DIR_NAME)
+
+    constructor(context: Context) : this(
+        roomStore = PlatformPlaylistCacheRoomStore(
+            NeriUserDataDatabase.getInstance(context.applicationContext)
+        ),
+        cacheDir = File(context.applicationContext.filesDir, CACHE_DIR_NAME)
+    )
+
+    internal constructor(
+        context: Context,
+        database: NeriUserDataDatabase,
+        cacheDir: File = File(context.applicationContext.filesDir, CACHE_DIR_NAME)
+    ) : this(
+        roomStore = PlatformPlaylistCacheRoomStore(database),
+        cacheDir = cacheDir
+    )
 
     fun read(playlistId: Long): CachedNeteasePlaylistDetail? {
+        val cacheKey = playlistId.toString()
+        readRoom(cacheKey)?.toNeteasePlaylistDetail()?.let { return it }
         val file = cacheFile(playlistId)
         if (!file.exists()) return null
         return runCatching {
-            gson.fromJson(file.readText(Charsets.UTF_8), CachedNeteasePlaylistDetail::class.java)
-                ?.takeIf { it.playlistId == playlistId }
+            readLegacyFile(file, playlistId)?.also(::saveRoomAndDeleteLegacy)
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to read NetEase playlist cache: playlistId=$playlistId", error)
         }.getOrNull()
@@ -80,14 +105,8 @@ class NeteasePlaylistCacheRepository(context: Context) {
 
     fun save(cache: CachedNeteasePlaylistDetail) {
         runCatching {
-            cacheDir.mkdirs()
-            val file = cacheFile(cache.playlistId)
-            val tmp = File(cacheDir, "${file.name}.tmp")
-            tmp.writeText(gson.toJson(cache), Charsets.UTF_8)
-            if (!tmp.renameTo(file)) {
-                file.writeText(gson.toJson(cache), Charsets.UTF_8)
-                tmp.delete()
-            }
+            saveRoom(cache)
+            deleteLegacyFile(cacheFile(cache.playlistId))
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to save NetEase playlist cache: playlistId=${cache.playlistId}", error)
         }
@@ -95,9 +114,82 @@ class NeteasePlaylistCacheRepository(context: Context) {
 
     fun clear(playlistId: Long) {
         runCatching {
+            clearRoom(playlistId.toString())
             cacheFile(playlistId).delete()
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to clear NetEase playlist cache: playlistId=$playlistId", error)
+        }
+    }
+
+    fun importLegacyCaches() {
+        val files = cacheDir.listFiles { file ->
+            file.isFile && file.name.endsWith(".json")
+        }.orEmpty()
+        files.forEach { file ->
+            runCatching {
+                readLegacyFile(file, expectedPlaylistId = null)
+                    ?.also { cache -> saveRoomIfNewerAndDeleteLegacy(cache, file) }
+            }.onFailure { error ->
+                NPLogger.w(TAG, "Failed to import NetEase playlist cache: file=${file.name}", error)
+            }
+        }
+    }
+
+    private fun readRoom(cacheKey: String): PlatformPlaylistCacheRecord? {
+        return runBlocking(Dispatchers.IO) {
+            roomStore.read(PLATFORM, cacheKey)
+        }
+    }
+
+    private fun saveRoom(cache: CachedNeteasePlaylistDetail) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.replace(cache.toRecord())
+        }
+    }
+
+    private fun saveRoomIfNewer(cache: CachedNeteasePlaylistDetail) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.replaceIfNewer(cache.toRecord())
+        }
+    }
+
+    private fun clearRoom(cacheKey: String) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.clear(PLATFORM, cacheKey)
+        }
+    }
+
+    private fun saveRoomAndDeleteLegacy(cache: CachedNeteasePlaylistDetail) {
+        saveRoom(cache)
+        deleteLegacyFile(cacheFile(cache.playlistId))
+    }
+
+    private fun saveRoomIfNewerAndDeleteLegacy(
+        cache: CachedNeteasePlaylistDetail,
+        file: File
+    ) {
+        saveRoomIfNewer(cache)
+        deleteLegacyFile(file)
+    }
+
+    private fun readLegacyFile(
+        file: File,
+        expectedPlaylistId: Long?
+    ): CachedNeteasePlaylistDetail? {
+        return gson.fromJson(file.readText(Charsets.UTF_8), CachedNeteasePlaylistDetail::class.java)
+            ?.takeIf { cache -> expectedPlaylistId == null || cache.playlistId == expectedPlaylistId }
+    }
+
+    private fun deleteLegacyFile(file: File) {
+        if (file.exists() && !file.delete()) {
+            NPLogger.w(TAG, "Failed to delete legacy NetEase playlist cache: file=${file.name}")
+        }
+        deleteCacheDirIfEmpty()
+    }
+
+    private fun deleteCacheDirIfEmpty() {
+        if (cacheDir.isDirectory && cacheDir.listFiles().orEmpty().isEmpty()) {
+            cacheDir.delete()
         }
     }
 
@@ -105,7 +197,77 @@ class NeteasePlaylistCacheRepository(context: Context) {
         return File(cacheDir, "playlist_$playlistId.json")
     }
 
+    private fun CachedNeteasePlaylistDetail.toRecord(): PlatformPlaylistCacheRecord {
+        return PlatformPlaylistCacheRecord(
+            platform = PLATFORM,
+            cacheKey = playlistId.toString(),
+            sourceId = playlistId,
+            title = header.name,
+            coverUrl = header.coverUrl,
+            playCount = header.playCount,
+            trackCount = header.trackCount,
+            totalCount = tracks.size,
+            signaturePrimary = recentTrackSignature,
+            savedAtMs = savedAtMs,
+            tracks = tracks.map { track ->
+                PlatformPlaylistCacheTrackRecord(
+                    itemId = track.id,
+                    name = track.name,
+                    artist = track.artist,
+                    album = track.album,
+                    albumId = track.albumId,
+                    durationMs = track.durationMs,
+                    coverUrl = track.coverUrl,
+                    audioId = track.audioId,
+                    addedAt = track.addedAt,
+                    artists = track.artists.map { artist ->
+                        PlatformPlaylistCacheArtistRecord(
+                            id = artist.id,
+                            name = artist.name
+                        )
+                    }
+                )
+            }
+        )
+    }
+
+    private fun PlatformPlaylistCacheRecord.toNeteasePlaylistDetail(): CachedNeteasePlaylistDetail {
+        val playlistId = sourceId ?: cacheKey.toLong()
+        return CachedNeteasePlaylistDetail(
+            playlistId = playlistId,
+            header = CachedNeteasePlaylistHeader(
+                id = playlistId,
+                name = title.orEmpty(),
+                coverUrl = coverUrl.orEmpty(),
+                playCount = playCount ?: 0L,
+                trackCount = trackCount
+            ),
+            recentTrackSignature = signaturePrimary.orEmpty(),
+            tracks = tracks.map { track ->
+                CachedNeteasePlaylistTrack(
+                    id = track.itemId ?: 0L,
+                    name = track.name,
+                    artist = track.artist,
+                    album = track.album,
+                    albumId = track.albumId ?: 0L,
+                    durationMs = track.durationMs,
+                    coverUrl = track.coverUrl,
+                    audioId = track.audioId,
+                    artists = track.artists.map { artist ->
+                        CachedNeteaseArtist(
+                            id = artist.id,
+                            name = artist.name
+                        )
+                    },
+                    addedAt = track.addedAt
+                )
+            },
+            savedAtMs = savedAtMs
+        )
+    }
+
     private companion object {
+        const val PLATFORM = "netease"
         const val TAG = "NeteasePlaylistCache"
         const val CACHE_DIR_NAME = "netease_playlist_cache"
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/youtube/YouTubeMusicPlaylistCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/youtube/YouTubeMusicPlaylistCacheRepository.kt
@@ -31,6 +31,7 @@ import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRecord
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRoomStore
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheStore
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheTrackRecord
 import java.io.File
 import java.security.MessageDigest
@@ -57,8 +58,8 @@ data class CachedYouTubeMusicPlaylistDetail(
     val savedAtMs: Long = System.currentTimeMillis()
 )
 
-class YouTubeMusicPlaylistCacheRepository private constructor(
-    private val roomStore: PlatformPlaylistCacheRoomStore,
+class YouTubeMusicPlaylistCacheRepository internal constructor(
+    private val roomStore: PlatformPlaylistCacheStore,
     private val cacheDir: File
 ) {
     private val gson = Gson()
@@ -80,7 +81,7 @@ class YouTubeMusicPlaylistCacheRepository private constructor(
     )
 
     fun read(browseId: String): CachedYouTubeMusicPlaylistDetail? {
-        readRoom(browseId)?.toYouTubeMusicPlaylistDetail()?.let { return it }
+        readRoom(browseId)?.let { return it }
         val file = cacheFile(browseId)
         if (!file.exists()) return null
         return runCatching {
@@ -91,21 +92,14 @@ class YouTubeMusicPlaylistCacheRepository private constructor(
     }
 
     fun save(cache: CachedYouTubeMusicPlaylistDetail) {
-        runCatching {
-            saveRoom(cache)
+        if (saveRoom(cache)) {
             deleteLegacyFile(cacheFile(cache.browseId))
-        }.onFailure { error ->
-            NPLogger.w(TAG, "Failed to save YouTube Music playlist cache: browseId=${cache.browseId}", error)
         }
     }
 
     fun clear(browseId: String) {
-        runCatching {
-            clearRoom(browseId)
-            cacheFile(browseId).delete()
-        }.onFailure { error ->
-            NPLogger.w(TAG, "Failed to clear YouTube Music playlist cache: browseId=$browseId", error)
-        }
+        clearRoom(browseId)
+        deleteLegacyFile(cacheFile(browseId))
     }
 
     fun importLegacyCaches() {
@@ -122,41 +116,73 @@ class YouTubeMusicPlaylistCacheRepository private constructor(
         }
     }
 
-    private fun readRoom(browseId: String): PlatformPlaylistCacheRecord? {
-        return runBlocking(Dispatchers.IO) {
-            roomStore.read(PLATFORM, browseId)
-        }
+    private fun readRoom(browseId: String): CachedYouTubeMusicPlaylistDetail? {
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.read(PLATFORM, browseId)
+            }?.toYouTubeMusicPlaylistDetail()
+        }.onFailure { error ->
+            NPLogger.w(TAG, "Failed to read YouTube Music playlist cache from Room: browseId=$browseId", error)
+        }.getOrNull()
     }
 
-    private fun saveRoom(cache: CachedYouTubeMusicPlaylistDetail) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.replace(cache.toRecord())
-        }
+    private fun saveRoom(cache: CachedYouTubeMusicPlaylistDetail): Boolean {
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.replace(cache.toRecord())
+            }
+            true
+        }.onFailure { error ->
+            NPLogger.w(
+                TAG,
+                "Failed to save YouTube Music playlist cache to Room: browseId=${cache.browseId}",
+                error
+            )
+        }.getOrDefault(false)
     }
 
-    private fun saveRoomIfNewer(cache: CachedYouTubeMusicPlaylistDetail) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.replaceIfNewer(cache.toRecord())
-        }
+    private fun saveRoomIfNewer(cache: CachedYouTubeMusicPlaylistDetail): Boolean {
+        return runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.replaceIfNewer(cache.toRecord())
+            }
+            true
+        }.onFailure { error ->
+            NPLogger.w(
+                TAG,
+                "Failed to import YouTube Music playlist cache into Room: browseId=${cache.browseId}",
+                error
+            )
+        }.getOrDefault(false)
     }
 
     private fun clearRoom(cacheKey: String) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.clear(PLATFORM, cacheKey)
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.clear(PLATFORM, cacheKey)
+            }
+        }.onFailure { error ->
+            NPLogger.w(
+                TAG,
+                "Failed to clear YouTube Music playlist cache from Room: browseId=$cacheKey",
+                error
+            )
         }
     }
 
     private fun saveRoomAndDeleteLegacy(cache: CachedYouTubeMusicPlaylistDetail) {
-        saveRoom(cache)
-        deleteLegacyFile(cacheFile(cache.browseId))
+        if (saveRoom(cache)) {
+            deleteLegacyFile(cacheFile(cache.browseId))
+        }
     }
 
     private fun saveRoomIfNewerAndDeleteLegacy(
         cache: CachedYouTubeMusicPlaylistDetail,
         file: File
     ) {
-        saveRoomIfNewer(cache)
-        deleteLegacyFile(file)
+        if (saveRoomIfNewer(cache)) {
+            deleteLegacyFile(file)
+        }
     }
 
     private fun readLegacyFile(

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/youtube/YouTubeMusicPlaylistCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/youtube/YouTubeMusicPlaylistCacheRepository.kt
@@ -25,7 +25,13 @@ package moe.ouom.neriplayer.data.platform.youtube
 
 import android.content.Context
 import com.google.gson.Gson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRecord
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRoomStore
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheTrackRecord
 import java.io.File
 import java.security.MessageDigest
 
@@ -51,17 +57,34 @@ data class CachedYouTubeMusicPlaylistDetail(
     val savedAtMs: Long = System.currentTimeMillis()
 )
 
-class YouTubeMusicPlaylistCacheRepository(context: Context) {
-    private val appContext = context.applicationContext
+class YouTubeMusicPlaylistCacheRepository private constructor(
+    private val roomStore: PlatformPlaylistCacheRoomStore,
+    private val cacheDir: File
+) {
     private val gson = Gson()
-    private val cacheDir = File(appContext.filesDir, CACHE_DIR_NAME)
+
+    constructor(context: Context) : this(
+        roomStore = PlatformPlaylistCacheRoomStore(
+            NeriUserDataDatabase.getInstance(context.applicationContext)
+        ),
+        cacheDir = File(context.applicationContext.filesDir, CACHE_DIR_NAME)
+    )
+
+    internal constructor(
+        context: Context,
+        database: NeriUserDataDatabase,
+        cacheDir: File = File(context.applicationContext.filesDir, CACHE_DIR_NAME)
+    ) : this(
+        roomStore = PlatformPlaylistCacheRoomStore(database),
+        cacheDir = cacheDir
+    )
 
     fun read(browseId: String): CachedYouTubeMusicPlaylistDetail? {
+        readRoom(browseId)?.toYouTubeMusicPlaylistDetail()?.let { return it }
         val file = cacheFile(browseId)
         if (!file.exists()) return null
         return runCatching {
-            gson.fromJson(file.readText(Charsets.UTF_8), CachedYouTubeMusicPlaylistDetail::class.java)
-                ?.takeIf { it.browseId == browseId }
+            readLegacyFile(file, browseId)?.also(::saveRoomAndDeleteLegacy)
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to read YouTube Music playlist cache: browseId=$browseId", error)
         }.getOrNull()
@@ -69,14 +92,8 @@ class YouTubeMusicPlaylistCacheRepository(context: Context) {
 
     fun save(cache: CachedYouTubeMusicPlaylistDetail) {
         runCatching {
-            cacheDir.mkdirs()
-            val file = cacheFile(cache.browseId)
-            val tmp = File(cacheDir, "${file.name}.tmp")
-            tmp.writeText(gson.toJson(cache), Charsets.UTF_8)
-            if (!tmp.renameTo(file)) {
-                file.writeText(gson.toJson(cache), Charsets.UTF_8)
-                tmp.delete()
-            }
+            saveRoom(cache)
+            deleteLegacyFile(cacheFile(cache.browseId))
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to save YouTube Music playlist cache: browseId=${cache.browseId}", error)
         }
@@ -84,9 +101,82 @@ class YouTubeMusicPlaylistCacheRepository(context: Context) {
 
     fun clear(browseId: String) {
         runCatching {
+            clearRoom(browseId)
             cacheFile(browseId).delete()
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to clear YouTube Music playlist cache: browseId=$browseId", error)
+        }
+    }
+
+    fun importLegacyCaches() {
+        val files = cacheDir.listFiles { file ->
+            file.isFile && file.name.endsWith(".json")
+        }.orEmpty()
+        files.forEach { file ->
+            runCatching {
+                readLegacyFile(file, expectedBrowseId = null)
+                    ?.also { cache -> saveRoomIfNewerAndDeleteLegacy(cache, file) }
+            }.onFailure { error ->
+                NPLogger.w(TAG, "Failed to import YouTube Music playlist cache: file=${file.name}", error)
+            }
+        }
+    }
+
+    private fun readRoom(browseId: String): PlatformPlaylistCacheRecord? {
+        return runBlocking(Dispatchers.IO) {
+            roomStore.read(PLATFORM, browseId)
+        }
+    }
+
+    private fun saveRoom(cache: CachedYouTubeMusicPlaylistDetail) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.replace(cache.toRecord())
+        }
+    }
+
+    private fun saveRoomIfNewer(cache: CachedYouTubeMusicPlaylistDetail) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.replaceIfNewer(cache.toRecord())
+        }
+    }
+
+    private fun clearRoom(cacheKey: String) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.clear(PLATFORM, cacheKey)
+        }
+    }
+
+    private fun saveRoomAndDeleteLegacy(cache: CachedYouTubeMusicPlaylistDetail) {
+        saveRoom(cache)
+        deleteLegacyFile(cacheFile(cache.browseId))
+    }
+
+    private fun saveRoomIfNewerAndDeleteLegacy(
+        cache: CachedYouTubeMusicPlaylistDetail,
+        file: File
+    ) {
+        saveRoomIfNewer(cache)
+        deleteLegacyFile(file)
+    }
+
+    private fun readLegacyFile(
+        file: File,
+        expectedBrowseId: String?
+    ): CachedYouTubeMusicPlaylistDetail? {
+        return gson.fromJson(file.readText(Charsets.UTF_8), CachedYouTubeMusicPlaylistDetail::class.java)
+            ?.takeIf { cache -> expectedBrowseId == null || cache.browseId == expectedBrowseId }
+    }
+
+    private fun deleteLegacyFile(file: File) {
+        if (file.exists() && !file.delete()) {
+            NPLogger.w(TAG, "Failed to delete legacy YouTube Music playlist cache: file=${file.name}")
+        }
+        deleteCacheDirIfEmpty()
+    }
+
+    private fun deleteCacheDirIfEmpty() {
+        if (cacheDir.isDirectory && cacheDir.listFiles().orEmpty().isEmpty()) {
+            cacheDir.delete()
         }
     }
 
@@ -99,7 +189,58 @@ class YouTubeMusicPlaylistCacheRepository(context: Context) {
         return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
     }
 
+    private fun CachedYouTubeMusicPlaylistDetail.toRecord(): PlatformPlaylistCacheRecord {
+        return PlatformPlaylistCacheRecord(
+            platform = PLATFORM,
+            cacheKey = browseId,
+            alternateKey = playlistId,
+            title = title,
+            subtitle = subtitle,
+            creatorName = creatorName,
+            coverUrl = coverUrl,
+            trackCount = trackCount,
+            totalCount = tracks.size,
+            signaturePrimary = firstPageSignature,
+            savedAtMs = savedAtMs,
+            tracks = tracks.map { track ->
+                PlatformPlaylistCacheTrackRecord(
+                    itemKey = track.videoId,
+                    name = track.name,
+                    artist = track.artist,
+                    album = track.albumName,
+                    durationMs = track.durationMs,
+                    coverUrl = track.coverUrl
+                )
+            }
+        )
+    }
+
+    private fun PlatformPlaylistCacheRecord.toYouTubeMusicPlaylistDetail(): CachedYouTubeMusicPlaylistDetail {
+        return CachedYouTubeMusicPlaylistDetail(
+            browseId = cacheKey,
+            playlistId = alternateKey.orEmpty(),
+            title = title.orEmpty(),
+            subtitle = subtitle.orEmpty(),
+            creatorName = creatorName,
+            coverUrl = coverUrl.orEmpty(),
+            trackCount = trackCount,
+            firstPageSignature = signaturePrimary.orEmpty(),
+            tracks = tracks.map { track ->
+                CachedYouTubeMusicPlaylistTrack(
+                    videoId = track.itemKey.orEmpty(),
+                    name = track.name,
+                    artist = track.artist,
+                    albumName = track.album,
+                    durationMs = track.durationMs,
+                    coverUrl = track.coverUrl.orEmpty()
+                )
+            },
+            savedAtMs = savedAtMs
+        )
+    }
+
     private companion object {
+        const val PLATFORM = "youtube_music"
         const val TAG = "YouTubeMusicPlaylistCache"
         const val CACHE_DIR_NAME = "youtube_music_playlist_cache"
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/youtube/YouTubeMusicPlaylistCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/youtube/YouTubeMusicPlaylistCacheRepository.kt
@@ -81,7 +81,9 @@ class YouTubeMusicPlaylistCacheRepository internal constructor(
     )
 
     fun read(browseId: String): CachedYouTubeMusicPlaylistDetail? {
-        readRoom(browseId)?.let { return it }
+        val roomResult = readRoom(browseId)
+        if (roomResult.isFailure) return null
+        roomResult.getOrNull()?.let { return it }
         val file = cacheFile(browseId)
         if (!file.exists()) return null
         return runCatching {
@@ -116,14 +118,14 @@ class YouTubeMusicPlaylistCacheRepository internal constructor(
         }
     }
 
-    private fun readRoom(browseId: String): CachedYouTubeMusicPlaylistDetail? {
+    private fun readRoom(browseId: String): Result<CachedYouTubeMusicPlaylistDetail?> {
         return runCatching {
             runBlocking(Dispatchers.IO) {
                 roomStore.read(PLATFORM, browseId)
             }?.toYouTubeMusicPlaylistDetail()
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to read YouTube Music playlist cache from Room: browseId=$browseId", error)
-        }.getOrNull()
+        }
     }
 
     private fun saveRoom(cache: CachedYouTubeMusicPlaylistDetail): Boolean {

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
@@ -28,10 +28,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -47,7 +44,6 @@ import moe.ouom.neriplayer.data.sync.github.SecureTokenStorage
 import moe.ouom.neriplayer.data.sync.webdav.WebDavSyncWorker
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.core.logging.NPLogger
-import moe.ouom.neriplayer.util.io.writeTextAtomically
 import java.io.File
 
 const val FAVORITE_SOURCE_NETEASE_ARTIST = "neteaseArtist"
@@ -70,7 +66,6 @@ data class FavoritePlaylist(
 )
 
 class FavoritePlaylistRepository private constructor(private val context: Context) {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val gson = Gson()
     private val file = File(context.filesDir, "favorite_playlists.json")
     private val mutex = Mutex()
@@ -78,8 +73,6 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
     private val roomStore = FavoritePlaylistRoomStore(
         NeriUserDataDatabase.getInstance(context.applicationContext)
     )
-    @Volatile
-    private var roomStorageEnabled = true
     private val syncStorage by lazy { SecureTokenStorage(context) }
 
     private val initialSnapshots = load()
@@ -96,44 +89,48 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
         val roomFavorites = runCatching {
             runBlocking { roomStore.readIfRoomPrimary() }
         }.onFailure { error ->
-            roomStorageEnabled = false
-            NPLogger.e(TAG, "读取 Room 收藏歌单失败，回退到 JSON", error)
+            NPLogger.e(TAG, "读取 Room 收藏歌单失败，保留迁移 JSON", error)
         }.getOrNull()
         if (roomFavorites != null) {
             LegacyJsonCleanupScheduler.schedule(context, "favorite-playlist-room-load")
             return normalize(roomFavorites)
         }
 
-        val list = try {
-            if (!file.exists()) {
-                emptyList()
-            } else {
-                val type = object : TypeToken<List<FavoritePlaylist>>() {}.type
-                gson.fromJson<List<FavoritePlaylist>>(file.readText(), type).orEmpty()
+        val legacyFavorites = readLegacyFavorites()
+        if (legacyFavorites != null) {
+            val normalized = normalize(legacyFavorites)
+            val imported = runCatching {
+                runBlocking {
+                    roomStore.importLegacyAndPromote(normalized)
+                }
+                true
+            }.onFailure { error ->
+                NPLogger.e(TAG, "将收藏歌单 JSON 导入 Room 失败", error)
+            }.getOrDefault(false)
+            if (imported) {
+                LegacyJsonCleanupScheduler.schedule(context, "favorite-playlist-import")
             }
-        } catch (_: Exception) {
-            emptyList()
+            return normalized
         }
-        val normalized = normalize(list)
-        runCatching {
-            runBlocking {
-                roomStore.importLegacyAndPromote(normalized)
-            }
-            LegacyJsonCleanupScheduler.schedule(context, "favorite-playlist-import")
-            roomStorageEnabled = true
+
+        return runCatching {
+            runBlocking { roomStore.promoteExistingAndRead() }
         }.onFailure { error ->
-            roomStorageEnabled = false
-            NPLogger.e(TAG, "将收藏歌单 JSON 导入 Room 失败", error)
-        }
-        return normalized
+            NPLogger.e(TAG, "恢复现有 Room 收藏歌单失败", error)
+        }.getOrNull()?.let { favorites ->
+            LegacyJsonCleanupScheduler.schedule(context, "favorite-playlist-room-recovery")
+            normalize(favorites)
+        }.orEmpty()
     }
 
-    private fun saveToDisk(favorites: List<FavoritePlaylist>): Boolean {
+    private fun readLegacyFavorites(): List<FavoritePlaylist>? {
+        if (!file.isFile) return null
         return runCatching {
-            file.writeTextAtomically(gson.toJson(favorites))
+            val type = object : TypeToken<List<FavoritePlaylist>>() {}.type
+            gson.fromJson<List<FavoritePlaylist>>(file.readText(), type)
         }.onFailure { error ->
-            NPLogger.e(TAG, "保存收藏歌单失败", error)
-        }.isSuccess
+            NPLogger.e(TAG, "读取收藏歌单迁移 JSON 失败", error)
+        }.getOrNull()
     }
 
     private fun publishInMemory(
@@ -190,31 +187,18 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
         favorites: List<FavoritePlaylist>
     ): Boolean {
         return persistenceMutex.withLock {
-            if (roomStorageEnabled) {
-                val roomSucceeded = runCatching {
-                    roomStore.writeIncremental(
-                        previous = persistedSnapshots,
-                        next = favorites
-                    )
-                }.onFailure { error ->
-                    roomStorageEnabled = false
-                    NPLogger.e(TAG, "写入 Room 收藏歌单失败，回退到 JSON", error)
-                }.isSuccess
-                if (roomSucceeded) {
-                    persistedSnapshots = favorites
-                    return@withLock true
-                }
+            val roomSucceeded = runCatching {
+                roomStore.writeIncremental(
+                    previous = persistedSnapshots,
+                    next = favorites
+                )
+            }.onFailure { error ->
+                NPLogger.e(TAG, "写入 Room 收藏歌单失败", error)
+            }.isSuccess
+            if (roomSucceeded) {
+                persistedSnapshots = favorites
             }
-
-            val legacySucceeded = saveToDisk(favorites)
-            if (legacySucceeded) {
-                runCatching { roomStore.markLegacyJsonPrimary() }
-                    .onFailure { error ->
-                        NPLogger.e(TAG, "标记收藏歌单 JSON 回退状态失败", error)
-                    }
-            }
-            persistedSnapshots = favorites
-            legacySucceeded
+            roomSucceeded
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
@@ -84,6 +84,7 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
     private val initialSnapshots = load()
     private val _snapshots = MutableStateFlow(initialSnapshots)
     private val _favorites = MutableStateFlow(visibleFavorites(initialSnapshots))
+    private var persistedSnapshots = initialSnapshots
     val favorites: StateFlow<List<FavoritePlaylist>> = _favorites
 
     init {
@@ -188,12 +189,16 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
         return persistenceMutex.withLock {
             if (roomStorageEnabled) {
                 val roomSucceeded = runCatching {
-                    roomStore.replaceAll(favorites)
+                    roomStore.writeIncremental(
+                        previous = persistedSnapshots,
+                        next = favorites
+                    )
                 }.onFailure { error ->
                     roomStorageEnabled = false
                     NPLogger.e(TAG, "写入 Room 收藏歌单失败，回退到 JSON", error)
                 }.isSuccess
                 if (roomSucceeded) {
+                    persistedSnapshots = favorites
                     return@withLock true
                 }
             }
@@ -205,6 +210,7 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
                         NPLogger.e(TAG, "标记收藏歌单 JSON 回退状态失败", error)
                     }
             }
+            persistedSnapshots = favorites
             legacySucceeded
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.store.FavoritePlaylistRoomStore
 import moe.ouom.neriplayer.data.model.identity
@@ -99,6 +100,7 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
             NPLogger.e(TAG, "读取 Room 收藏歌单失败，回退到 JSON", error)
         }.getOrNull()
         if (roomFavorites != null) {
+            LegacyJsonCleanupScheduler.schedule(context, "favorite-playlist-room-load")
             return normalize(roomFavorites)
         }
 
@@ -117,6 +119,7 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
             runBlocking {
                 roomStore.importLegacyAndPromote(normalized)
             }
+            LegacyJsonCleanupScheduler.schedule(context, "favorite-playlist-import")
             roomStorageEnabled = true
         }.onFailure { error ->
             roomStorageEnabled = false

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
@@ -42,6 +42,8 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.mergeRoomRecoverySnapshot
+import moe.ouom.neriplayer.data.local.database.store.FavoritePlaylistRoomImportStatus
 import moe.ouom.neriplayer.data.local.database.store.FavoritePlaylistRoomStore
 import moe.ouom.neriplayer.data.model.identity
 import moe.ouom.neriplayer.data.sync.github.GitHubSyncWorker
@@ -85,19 +87,26 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
     private val _snapshots = MutableStateFlow(initialSnapshots)
     private val _favorites = MutableStateFlow(visibleFavorites(initialSnapshots))
     private var persistedSnapshots = initialSnapshots
+    @Volatile
+    private var roomStorageEnabled = true
+    private var roomRecoveryBaseline: List<FavoritePlaylist>? = null
     private var retryJob: Job? = null
     private var pendingSyncAfterPersistence = false
     val favorites: StateFlow<List<FavoritePlaylist>> = _favorites
 
     init {
         publishInMemory(initialSnapshots)
+        scheduleRoomRecovery()
     }
 
     private fun load(): List<FavoritePlaylist> {
+        var needsRoomRecovery = false
         val roomFavorites = runCatching {
             runBlocking { roomStore.readIfRoomPrimary() }
         }.onFailure { error ->
-            NPLogger.e(TAG, "读取 Room 收藏歌单失败，保留迁移 JSON", error)
+            roomStorageEnabled = false
+            needsRoomRecovery = true
+            NPLogger.e(TAG, "读取 Room 收藏歌单失败，暂时使用迁移快照", error)
         }.getOrNull()
         if (roomFavorites != null) {
             LegacyJsonCleanupScheduler.schedule(context, "favorite-playlist-room-load")
@@ -107,28 +116,62 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
         val legacyFavorites = readLegacyFavorites()
         if (legacyFavorites != null) {
             val normalized = normalize(legacyFavorites)
-            val imported = runCatching {
-                runBlocking {
-                    roomStore.importLegacyAndPromote(normalized)
+            if (roomStorageEnabled) {
+                val imported = runCatching {
+                    runBlocking {
+                        roomStore.importLegacyAndPromote(normalized)
+                    }
+                }.onFailure { error ->
+                    roomStorageEnabled = false
+                    needsRoomRecovery = true
+                    NPLogger.e(TAG, "将收藏歌单迁移到 Room 失败", error)
+                }.getOrNull()
+                when (imported?.status) {
+                    FavoritePlaylistRoomImportStatus.IMPORTED -> {
+                        LegacyJsonCleanupScheduler.schedule(
+                            context,
+                            "favorite-playlist-import"
+                        )
+                    }
+
+                    FavoritePlaylistRoomImportStatus.SKIPPED_ALREADY_PRIMARY -> {
+                        val primary = runCatching {
+                            runBlocking { roomStore.readIfRoomPrimary() }
+                        }.getOrNull()
+                        if (primary != null) {
+                            LegacyJsonCleanupScheduler.schedule(
+                                context,
+                                "favorite-playlist-room-reload"
+                            )
+                            return normalize(primary)
+                        }
+                        roomStorageEnabled = false
+                        needsRoomRecovery = true
+                    }
+
+                    null -> Unit
                 }
-                true
-            }.onFailure { error ->
-                NPLogger.e(TAG, "将收藏歌单 JSON 导入 Room 失败", error)
-            }.getOrDefault(false)
-            if (imported) {
-                LegacyJsonCleanupScheduler.schedule(context, "favorite-playlist-import")
+            }
+            if (needsRoomRecovery) {
+                roomRecoveryBaseline = normalized
             }
             return normalized
         }
 
-        return runCatching {
-            runBlocking { roomStore.promoteExistingAndRead() }
-        }.onFailure { error ->
-            NPLogger.e(TAG, "恢复现有 Room 收藏歌单失败", error)
-        }.getOrNull()?.let { favorites ->
-            LegacyJsonCleanupScheduler.schedule(context, "favorite-playlist-room-recovery")
-            normalize(favorites)
-        }.orEmpty()
+        if (roomStorageEnabled) {
+            return runCatching {
+                runBlocking { roomStore.promoteExistingAndRead() }
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                needsRoomRecovery = true
+                NPLogger.e(TAG, "恢复现有 Room 收藏歌单失败", error)
+            }.getOrNull()?.let { favorites ->
+                LegacyJsonCleanupScheduler.schedule(context, "favorite-playlist-room-recovery")
+                normalize(favorites)
+            }.orEmpty()
+        }
+        roomRecoveryBaseline = emptyList()
+        return emptyList()
     }
 
     private fun readLegacyFavorites(): List<FavoritePlaylist>? {
@@ -197,13 +240,20 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
             if (requestAutoSync) {
                 pendingSyncAfterPersistence = true
             }
+            if (!roomStorageEnabled) {
+                scheduleRoomRecovery()
+                return@withLock false
+            }
+            val previous = persistedSnapshots
             val roomSucceeded = runCatching {
                 roomStore.writeIncremental(
-                    previous = persistedSnapshots,
+                    previous = previous,
                     next = favorites
                 )
             }.onFailure { error ->
-                NPLogger.e(TAG, "写入 Room 收藏歌单失败", error)
+                roomStorageEnabled = false
+                roomRecoveryBaseline = previous
+                NPLogger.e(TAG, "写入 Room 收藏歌单失败，等待恢复", error)
             }.isSuccess
             if (roomSucceeded) {
                 persistedSnapshots = favorites
@@ -215,27 +265,75 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
                     triggerAutoSync()
                 }
             } else {
-                schedulePersistenceRetry()
+                scheduleRoomRecovery()
             }
             roomSucceeded
         }
     }
 
-    private fun schedulePersistenceRetry() {
+    private fun scheduleRoomRecovery() {
+        if (roomStorageEnabled || roomRecoveryBaseline == null) return
         if (retryJob?.isActive == true) return
         retryJob = persistenceScope.launch {
             delay(ROOM_RETRY_DELAY_MS)
-            val snapshot = _snapshots.value
-            val shouldRetry = persistenceMutex.withLock {
-                retryJob = null
-                persistedSnapshots != snapshot
+            retryJob = null
+            recoverRoomStorage()
+        }
+    }
+
+    private suspend fun recoverRoomStorage() {
+        val baseline = roomRecoveryBaseline ?: return
+        var shouldTriggerSync = false
+        val recovered = mutex.withLock {
+            persistenceMutex.withLock {
+                runCatching {
+                    val current = _snapshots.value
+                    val roomSnapshot = roomStore.readIfRoomPrimary()
+                    if (roomSnapshot == null) {
+                        val imported = roomStore.importLegacyAndPromote(current)
+                        if (imported.status == FavoritePlaylistRoomImportStatus.IMPORTED) {
+                            current
+                        } else {
+                            val primary = roomStore.readIfRoomPrimary()
+                                ?: return@runCatching null
+                            mergeFavoritePlaylistRoomRecovery(
+                                roomSnapshot = primary,
+                                recoveryBaseline = baseline,
+                                currentSnapshot = current
+                            ).let(::normalize)
+                        }
+                    } else {
+                        mergeFavoritePlaylistRoomRecovery(
+                            roomSnapshot = roomSnapshot,
+                            recoveryBaseline = baseline,
+                            currentSnapshot = current
+                        ).let { merged ->
+                            roomStore.writeIncremental(roomSnapshot, merged)
+                            normalize(merged)
+                        }
+                    }
+                }.onFailure { error ->
+                    NPLogger.e(TAG, "恢复 Room 收藏歌单失败，保留内存改动", error)
+                }.getOrNull()?.also { merged ->
+                    roomStorageEnabled = true
+                    roomRecoveryBaseline = null
+                    persistedSnapshots = merged
+                    retryJob?.cancel()
+                    retryJob = null
+                    publishInMemory(merged)
+                    shouldTriggerSync = pendingSyncAfterPersistence
+                    pendingSyncAfterPersistence = false
+                }
             }
-            if (shouldRetry) {
-                persist(
-                    favorites = snapshot,
-                    requestAutoSync = false
-                )
-            }
+        }
+        if (recovered == null) {
+            scheduleRoomRecovery()
+            return
+        }
+        LegacyJsonCleanupScheduler.schedule(context, "favorite-playlist-room-recovery")
+        if (shouldTriggerSync) {
+            syncStorage.markSyncMutation()
+            triggerAutoSync()
         }
     }
 
@@ -459,4 +557,18 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
             }
         }
     }
+}
+
+internal fun mergeFavoritePlaylistRoomRecovery(
+    roomSnapshot: List<FavoritePlaylist>,
+    recoveryBaseline: List<FavoritePlaylist>,
+    currentSnapshot: List<FavoritePlaylist>
+): List<FavoritePlaylist> {
+    return mergeRoomRecoverySnapshot(
+        roomSnapshot = roomSnapshot,
+        recoveryBaseline = recoveryBaseline,
+        currentSnapshot = currentSnapshot,
+        keyOf = { favorite -> favorite.id to favorite.source },
+        mergeLocalChange = { _, current -> current }
+    )
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
@@ -28,10 +28,15 @@ import android.annotation.SuppressLint
 import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -70,6 +75,7 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
     private val file = File(context.filesDir, "favorite_playlists.json")
     private val mutex = Mutex()
     private val persistenceMutex = Mutex()
+    private val persistenceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val roomStore = FavoritePlaylistRoomStore(
         NeriUserDataDatabase.getInstance(context.applicationContext)
     )
@@ -79,6 +85,8 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
     private val _snapshots = MutableStateFlow(initialSnapshots)
     private val _favorites = MutableStateFlow(visibleFavorites(initialSnapshots))
     private var persistedSnapshots = initialSnapshots
+    private var retryJob: Job? = null
+    private var pendingSyncAfterPersistence = false
     val favorites: StateFlow<List<FavoritePlaylist>> = _favorites
 
     init {
@@ -172,21 +180,23 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
         publishInMemory(normalized)
         if (!persist) return
 
-        val persisted = persist(normalized)
-        if (triggerSync) {
-            if (persisted) {
-                syncStorage.markSyncMutation()
-                triggerAutoSync()
-            } else {
-                NPLogger.w(TAG, "收藏歌单未成功落盘，跳过自动同步")
-            }
+        val persisted = persist(
+            favorites = normalized,
+            requestAutoSync = triggerSync
+        )
+        if (!persisted && triggerSync) {
+            NPLogger.w(TAG, "收藏歌单未成功落盘，等待 Room 重试后再同步")
         }
     }
 
     private suspend fun persist(
-        favorites: List<FavoritePlaylist>
+        favorites: List<FavoritePlaylist>,
+        requestAutoSync: Boolean
     ): Boolean {
         return persistenceMutex.withLock {
+            if (requestAutoSync) {
+                pendingSyncAfterPersistence = true
+            }
             val roomSucceeded = runCatching {
                 roomStore.writeIncremental(
                     previous = persistedSnapshots,
@@ -197,8 +207,35 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
             }.isSuccess
             if (roomSucceeded) {
                 persistedSnapshots = favorites
+                retryJob?.cancel()
+                retryJob = null
+                if (pendingSyncAfterPersistence) {
+                    pendingSyncAfterPersistence = false
+                    syncStorage.markSyncMutation()
+                    triggerAutoSync()
+                }
+            } else {
+                schedulePersistenceRetry()
             }
             roomSucceeded
+        }
+    }
+
+    private fun schedulePersistenceRetry() {
+        if (retryJob?.isActive == true) return
+        retryJob = persistenceScope.launch {
+            delay(ROOM_RETRY_DELAY_MS)
+            val snapshot = _snapshots.value
+            val shouldRetry = persistenceMutex.withLock {
+                retryJob = null
+                persistedSnapshots != snapshot
+            }
+            if (shouldRetry) {
+                persist(
+                    favorites = snapshot,
+                    requestAutoSync = false
+                )
+            }
         }
     }
 
@@ -410,6 +447,8 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
     }
 
     companion object {
+        private const val ROOM_RETRY_DELAY_MS = 15_000L
+
         @SuppressLint("StaticFieldLeak")
         @Volatile
         private var INSTANCE: FavoritePlaylistRepository? = null

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
@@ -83,15 +83,15 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
     )
     private val syncStorage by lazy { SecureTokenStorage(context) }
 
-    private val initialSnapshots = load()
-    private val _snapshots = MutableStateFlow(initialSnapshots)
-    private val _favorites = MutableStateFlow(visibleFavorites(initialSnapshots))
-    private var persistedSnapshots = initialSnapshots
     @Volatile
     private var roomStorageEnabled = true
     private var roomRecoveryBaseline: List<FavoritePlaylist>? = null
     private var retryJob: Job? = null
     private var pendingSyncAfterPersistence = false
+    private val initialSnapshots = load()
+    private val _snapshots = MutableStateFlow(initialSnapshots)
+    private val _favorites = MutableStateFlow(visibleFavorites(initialSnapshots))
+    private var persistedSnapshots = initialSnapshots
     val favorites: StateFlow<List<FavoritePlaylist>> = _favorites
 
     init {

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
@@ -28,12 +28,18 @@ import android.annotation.SuppressLint
 import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.FavoritePlaylistRoomStore
 import moe.ouom.neriplayer.data.model.identity
 import moe.ouom.neriplayer.data.sync.github.GitHubSyncWorker
 import moe.ouom.neriplayer.data.sync.github.SecureTokenStorage
@@ -63,20 +69,40 @@ data class FavoritePlaylist(
 )
 
 class FavoritePlaylistRepository private constructor(private val context: Context) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val gson = Gson()
     private val file = File(context.filesDir, "favorite_playlists.json")
     private val mutex = Mutex()
+    private val persistenceMutex = Mutex()
+    private val legacyProjectionMutex = Mutex()
+    private var legacyProjectionGeneration = 0L
+    private val roomStore = FavoritePlaylistRoomStore(
+        NeriUserDataDatabase.getInstance(context.applicationContext)
+    )
+    @Volatile
+    private var roomStorageEnabled = true
     private val syncStorage by lazy { SecureTokenStorage(context) }
 
-    private val _snapshots = MutableStateFlow<List<FavoritePlaylist>>(emptyList())
-    private val _favorites = MutableStateFlow<List<FavoritePlaylist>>(emptyList())
+    private val initialSnapshots = load()
+    private val _snapshots = MutableStateFlow(initialSnapshots)
+    private val _favorites = MutableStateFlow(visibleFavorites(initialSnapshots))
     val favorites: StateFlow<List<FavoritePlaylist>> = _favorites
 
     init {
-        loadFromDisk()
+        publishInMemory(initialSnapshots)
     }
 
-    private fun loadFromDisk() {
+    private fun load(): List<FavoritePlaylist> {
+        val roomFavorites = runCatching {
+            runBlocking { roomStore.readIfRoomPrimary() }
+        }.onFailure { error ->
+            roomStorageEnabled = false
+            NPLogger.e(TAG, "读取 Room 收藏歌单失败，回退到 JSON", error)
+        }.getOrNull()
+        if (roomFavorites != null) {
+            return normalize(roomFavorites)
+        }
+
         val list = try {
             if (!file.exists()) {
                 emptyList()
@@ -87,7 +113,17 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
         } catch (_: Exception) {
             emptyList()
         }
-        publish(list, triggerSync = false, persist = false)
+        val normalized = normalize(list)
+        runCatching {
+            runBlocking {
+                roomStore.importLegacyAndPromote(normalized)
+            }
+            roomStorageEnabled = true
+        }.onFailure { error ->
+            roomStorageEnabled = false
+            NPLogger.e(TAG, "将收藏歌单 JSON 导入 Room 失败", error)
+        }
+        return normalized
     }
 
     private fun saveToDisk(favorites: List<FavoritePlaylist>): Boolean {
@@ -98,13 +134,17 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
         }.isSuccess
     }
 
-    private fun publish(
+    private fun publishInMemory(
         favorites: List<FavoritePlaylist>,
-        triggerSync: Boolean = true,
-        persist: Boolean = true
     ) {
-        val normalized = favorites
-            .groupBy { "${it.id}_${it.source}" }
+        val normalized = normalize(favorites)
+        _snapshots.value = normalized
+        _favorites.value = visibleFavorites(normalized)
+    }
+
+    private fun normalize(favorites: List<FavoritePlaylist>): List<FavoritePlaylist> {
+        return favorites
+            .groupBy { it.id to it.source }
             .map { (_, snapshots) ->
                 snapshots.maxByOrNull { maxOf(it.modifiedAt, it.addedTime) }!!
                     .normalizeSortOrder()
@@ -112,20 +152,80 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
             .sortedWith(compareByDescending<FavoritePlaylist> { it.sortOrder }.thenByDescending {
                 maxOf(it.modifiedAt, it.addedTime)
             })
-        _snapshots.value = normalized
-        _favorites.value = normalized
+    }
+
+    private fun visibleFavorites(
+        favorites: List<FavoritePlaylist>
+    ): List<FavoritePlaylist> {
+        return favorites
             .filterNot(FavoritePlaylist::isDeleted)
             .sortedWith(compareByDescending<FavoritePlaylist> { it.sortOrder }.thenByDescending {
                 maxOf(it.modifiedAt, it.addedTime)
             })
-        // 初次从盘加载时无需把刚读到的数据原样写回, 避免每次冷启动无条件重写收藏文件
-        val persisted = if (persist) saveToDisk(normalized) else false
+    }
+
+    private suspend fun publish(
+        favorites: List<FavoritePlaylist>,
+        triggerSync: Boolean = true,
+        persist: Boolean = true
+    ) {
+        val normalized = normalize(favorites)
+        publishInMemory(normalized)
+        if (!persist) return
+
+        val persisted = persist(normalized)
         if (triggerSync) {
             if (persisted) {
                 syncStorage.markSyncMutation()
                 triggerAutoSync()
             } else {
                 NPLogger.w(TAG, "收藏歌单未成功落盘，跳过自动同步")
+            }
+        }
+    }
+
+    private suspend fun persist(
+        favorites: List<FavoritePlaylist>
+    ): Boolean {
+        return persistenceMutex.withLock {
+            if (roomStorageEnabled) {
+                val roomSucceeded = runCatching {
+                    roomStore.replaceAll(favorites)
+                }.onFailure { error ->
+                    roomStorageEnabled = false
+                    NPLogger.e(TAG, "写入 Room 收藏歌单失败，回退到 JSON", error)
+                }.isSuccess
+                if (roomSucceeded) {
+                    enqueueLegacyProjection(favorites)
+                    return@withLock true
+                }
+            }
+
+            val legacySucceeded = saveToDisk(favorites)
+            if (legacySucceeded) {
+                runCatching { roomStore.markLegacyJsonPrimary() }
+                    .onFailure { error ->
+                        NPLogger.e(TAG, "标记收藏歌单 JSON 回退状态失败", error)
+                    }
+            }
+            legacySucceeded
+        }
+    }
+
+    private fun enqueueLegacyProjection(
+        favorites: List<FavoritePlaylist>
+    ) {
+        val generation = synchronized(this) {
+            legacyProjectionGeneration += 1L
+            legacyProjectionGeneration
+        }
+        scope.launch {
+            legacyProjectionMutex.withLock {
+                val isLatest = synchronized(this@FavoritePlaylistRepository) {
+                    generation == legacyProjectionGeneration
+                }
+                if (!isLatest) return@withLock
+                saveToDisk(favorites)
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRepository.kt
@@ -74,8 +74,6 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
     private val file = File(context.filesDir, "favorite_playlists.json")
     private val mutex = Mutex()
     private val persistenceMutex = Mutex()
-    private val legacyProjectionMutex = Mutex()
-    private var legacyProjectionGeneration = 0L
     private val roomStore = FavoritePlaylistRoomStore(
         NeriUserDataDatabase.getInstance(context.applicationContext)
     )
@@ -196,7 +194,6 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
                     NPLogger.e(TAG, "写入 Room 收藏歌单失败，回退到 JSON", error)
                 }.isSuccess
                 if (roomSucceeded) {
-                    enqueueLegacyProjection(favorites)
                     return@withLock true
                 }
             }
@@ -209,24 +206,6 @@ class FavoritePlaylistRepository private constructor(private val context: Contex
                     }
             }
             legacySucceeded
-        }
-    }
-
-    private fun enqueueLegacyProjection(
-        favorites: List<FavoritePlaylist>
-    ) {
-        val generation = synchronized(this) {
-            legacyProjectionGeneration += 1L
-            legacyProjectionGeneration
-        }
-        scope.launch {
-            legacyProjectionMutex.withLock {
-                val isLatest = synchronized(this@FavoritePlaylistRepository) {
-                    generation == legacyProjectionGeneration
-                }
-                if (!isLatest) return@withLock
-                saveToDisk(favorites)
-            }
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepository.kt
@@ -1,5 +1,6 @@
 package moe.ouom.neriplayer.data.playlist.usage
 
+import android.annotation.SuppressLint
 import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -67,6 +68,7 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
     companion object {
         private const val ROOM_RETRY_DELAY_MS = 15_000L
 
+        @SuppressLint("StaticFieldLeak")
         @Volatile
         private var instance: LocalPlaylistPlaybackStatsRepository? = null
 
@@ -90,19 +92,26 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
     private val mutex = Mutex()
     @Volatile
     private var roomStorageEnabled = roomStore != null
+    private var roomRecoveryBaseline: List<LocalPlaylistPlaybackStat>? = null
     private val initialStats = loadInitialStats()
     private val _stats = MutableStateFlow(initialStats)
     private var persistedStats = initialStats
     private var retryJob: Job? = null
     val statsFlow: StateFlow<List<LocalPlaylistPlaybackStat>> = _stats
 
+    init {
+        scheduleRoomRecovery()
+    }
+
     private fun loadInitialStats(): List<LocalPlaylistPlaybackStat> {
+        var needsRoomRecovery = false
         if (roomStorageEnabled && roomStore != null) {
             val activeRoomStore = roomStore
             val roomStats = runCatching {
                 runBlocking { activeRoomStore.readIfRoomPrimary() }
             }.onFailure { error ->
                 roomStorageEnabled = false
+                needsRoomRecovery = true
                 NPLogger.e(
                     "LocalPlaylistPlaybackRepo",
                     "Failed to read Room local playlist playback stats",
@@ -125,6 +134,7 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
                 runBlocking { activeRoomStore.importLegacyAndPromote(legacyStats) }
             }.onFailure { error ->
                 roomStorageEnabled = false
+                needsRoomRecovery = true
                 NPLogger.e(
                     "LocalPlaylistPlaybackRepo",
                     "Failed to promote local playlist playback JSON to Room",
@@ -135,6 +145,9 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
                 app,
                 "local-playlist-playback-import"
             )
+        }
+        if (needsRoomRecovery) {
+            roomRecoveryBaseline = legacyStats
         }
         return legacyStats
     }
@@ -249,7 +262,11 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
             "LocalPlaylistPlaybackRepo",
             "Local playlist playback update remains in memory until Room is available."
         )
-        schedulePersistenceRetry()
+        if (roomStorageEnabled) {
+            schedulePersistenceRetry()
+        } else {
+            scheduleRoomRecovery()
+        }
     }
 
     private fun schedulePersistenceRetry() {
@@ -261,6 +278,59 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
                 persistSnapshot(_stats.value)
             }
         }
+    }
+
+    private fun scheduleRoomRecovery() {
+        if (roomStorageEnabled || roomStore == null || roomRecoveryBaseline == null ||
+            retryJob?.isActive == true
+        ) {
+            return
+        }
+        retryJob = scope.launch {
+            delay(ROOM_RETRY_DELAY_MS)
+            mutex.withLock {
+                retryJob = null
+                recoverRoomStorage()
+            }
+        }
+    }
+
+    private suspend fun recoverRoomStorage() {
+        val activeRoomStore = roomStore ?: return
+        val baseline = roomRecoveryBaseline ?: return
+        val recovered = runCatching {
+            if (activeRoomStore.readIfRoomPrimary() == null) {
+                activeRoomStore.importLegacyAndPromote(_stats.value)
+            }
+            val roomSnapshot = activeRoomStore.readIfRoomPrimary()
+                ?: return@runCatching null
+            mergeLocalPlaylistPlaybackRoomRecovery(
+                roomSnapshot = roomSnapshot,
+                recoveryBaseline = baseline,
+                currentSnapshot = _stats.value
+            ).also { merged ->
+                activeRoomStore.writeIncremental(roomSnapshot, merged)
+            }
+        }.onFailure { error ->
+            NPLogger.e(
+                "LocalPlaylistPlaybackRepo",
+                "Failed to recover Room local playlist playback stats",
+                error
+            )
+        }.getOrNull()
+        if (recovered == null) {
+            scheduleRoomRecovery()
+            return
+        }
+
+        roomStorageEnabled = true
+        roomRecoveryBaseline = null
+        persistedStats = recovered
+        _stats.value = recovered
+        LegacyJsonCleanupScheduler.schedule(
+            app,
+            "local-playlist-playback-room-recovery"
+        )
     }
 
     private fun syncCounterDeviceId(): String {
@@ -307,6 +377,39 @@ internal fun normalizeLocalPlaylistPlaybackStats(
                 bucket.toSyncBucket(stat.playlistId)
             }
         }
+    )
+    return finalized.toLocalPlaybackStats()
+}
+
+internal fun mergeLocalPlaylistPlaybackRoomRecovery(
+    roomSnapshot: List<LocalPlaylistPlaybackStat>,
+    recoveryBaseline: List<LocalPlaylistPlaybackStat>,
+    currentSnapshot: List<LocalPlaylistPlaybackStat>
+): List<LocalPlaylistPlaybackStat> {
+    val baselineById = recoveryBaseline.associateBy(LocalPlaylistPlaybackStat::playlistId)
+    val currentById = currentSnapshot.associateBy(LocalPlaylistPlaybackStat::playlistId)
+    val removedIds = baselineById.keys - currentById.keys
+    val localChanges = currentSnapshot.filter { current ->
+        current != baselineById[current.playlistId]
+    }
+    val retainedRoomStats = roomSnapshot.filter { stat -> stat.playlistId !in removedIds }
+    val finalized = SyncPlaylistUsageStatsMergePolicy.finalizeLocalPlaylistPlaybackStats(
+        stats = SyncPlaylistUsageStatsMergePolicy.mergeLocalPlaylistPlaybackStats(
+            local = retainedRoomStats.map(LocalPlaylistPlaybackStat::toSyncStat),
+            remote = localChanges.map(LocalPlaylistPlaybackStat::toSyncStat)
+        ),
+        buckets = SyncPlaylistUsageStatsMergePolicy.mergeLocalPlaylistPlaybackBuckets(
+            local = retainedRoomStats.flatMap { stat ->
+                stat.dailyPlayBuckets.orEmpty().map { bucket ->
+                    bucket.toSyncBucket(stat.playlistId)
+                }
+            },
+            remote = localChanges.flatMap { stat ->
+                stat.dailyPlayBuckets.orEmpty().map { bucket ->
+                    bucket.toSyncBucket(stat.playlistId)
+                }
+            }
+        )
     )
     return finalized.toLocalPlaybackStats()
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepository.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.store.LocalPlaylistPlaybackRoomStore
 import moe.ouom.neriplayer.core.logging.NPLogger
@@ -103,6 +104,10 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
                 )
             }.getOrNull()
             if (roomStats != null) {
+                LegacyJsonCleanupScheduler.schedule(
+                    app,
+                    "local-playlist-playback-room-load"
+                )
                 return normalizeLocalPlaylistPlaybackStats(roomStats)
             }
         }
@@ -120,6 +125,10 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
                     error
                 )
             }
+            LegacyJsonCleanupScheduler.schedule(
+                app,
+                "local-playlist-playback-import"
+            )
         }
         return legacyStats
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepository.kt
@@ -86,8 +86,6 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
     private val mutex = Mutex()
     @Volatile
     private var roomStorageEnabled = roomStore != null
-    private val legacyProjectionMutex = Mutex()
-    private var legacyProjectionGeneration = 0L
     private val _stats = MutableStateFlow(loadInitialStats())
     val statsFlow: StateFlow<List<LocalPlaylistPlaybackStat>> = _stats
 
@@ -234,7 +232,6 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
                 )
             }.isSuccess
             if (roomWriteSucceeded) {
-                enqueueLegacyProjection(next)
                 return
             }
         }
@@ -248,24 +245,6 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
                         error
                     )
                 }
-        }
-    }
-
-    private fun enqueueLegacyProjection(
-        stats: List<LocalPlaylistPlaybackStat>
-    ) {
-        val generation = synchronized(this) {
-            legacyProjectionGeneration += 1L
-            legacyProjectionGeneration
-        }
-        scope.launch {
-            legacyProjectionMutex.withLock {
-                val isLatest = synchronized(this@LocalPlaylistPlaybackStatsRepository) {
-                    generation == legacyProjectionGeneration
-                }
-                if (!isLatest) return@withLock
-                persist(stats)
-            }
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepository.kt
@@ -26,7 +26,6 @@ import moe.ouom.neriplayer.data.sync.github.SyncPlaylistUsageStatsMergePolicy
 import moe.ouom.neriplayer.data.sync.model.SyncLocalPlaylistPlaybackBucket
 import moe.ouom.neriplayer.data.sync.model.SyncLocalPlaylistPlaybackStat
 import moe.ouom.neriplayer.data.sync.model.SyncPlaybackCounterShard
-import moe.ouom.neriplayer.util.io.writeTextAtomically
 import java.io.File
 import java.util.UUID
 
@@ -87,7 +86,9 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
     private val mutex = Mutex()
     @Volatile
     private var roomStorageEnabled = roomStore != null
-    private val _stats = MutableStateFlow(loadInitialStats())
+    private val initialStats = loadInitialStats()
+    private val _stats = MutableStateFlow(initialStats)
+    private var persistedStats = initialStats
     val statsFlow: StateFlow<List<LocalPlaylistPlaybackStat>> = _stats
 
     private fun loadInitialStats(): List<LocalPlaylistPlaybackStat> {
@@ -146,7 +147,7 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
                 deviceId = syncCounterDeviceId()
             )
             _stats.value = updated
-            persistSnapshot(current, updated)
+            persistSnapshot(updated)
         }
     }
 
@@ -186,7 +187,7 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
             )
             val updated = finalized.toLocalPlaybackStats()
             _stats.value = updated
-            persistSnapshot(currentStats, updated)
+            persistSnapshot(updated)
         }
     }
 
@@ -218,43 +219,29 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
         return normalizeLocalPlaylistPlaybackStats(parsed)
     }
 
-    private fun persist(stats: List<LocalPlaylistPlaybackStat>) {
-        runCatching {
-            file.writeTextAtomically(gson.toJson(stats))
-        }
-    }
-
     private suspend fun persistSnapshot(
-        previous: List<LocalPlaylistPlaybackStat>,
         next: List<LocalPlaylistPlaybackStat>
     ) {
         if (roomStorageEnabled && roomStore != null) {
             val activeRoomStore = roomStore
             val roomWriteSucceeded = runCatching {
-                activeRoomStore.writeIncremental(previous, next)
+                activeRoomStore.writeIncremental(persistedStats, next)
             }.onFailure { error ->
-                roomStorageEnabled = false
                 NPLogger.e(
                     "LocalPlaylistPlaybackRepo",
-                    "Failed to write Room local playlist playback stats",
+                    "Failed to write Room local playlist playback stats; keeping JSON migration data read-only",
                     error
                 )
             }.isSuccess
             if (roomWriteSucceeded) {
+                persistedStats = next
                 return
             }
         }
-        persist(next)
-        roomStore?.let { fallbackStore ->
-            runCatching { fallbackStore.markLegacyJsonPrimary() }
-                .onFailure { error ->
-                    NPLogger.e(
-                        "LocalPlaylistPlaybackRepo",
-                        "Failed to mark local playlist playback JSON fallback state",
-                        error
-                    )
-                }
-        }
+        NPLogger.w(
+            "LocalPlaylistPlaybackRepo",
+            "Local playlist playback update remains in memory until Room is available."
+        )
     }
 
     private fun syncCounterDeviceId(): String {

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepository.kt
@@ -5,7 +5,9 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -63,6 +65,8 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
     private val roomStore: LocalPlaylistPlaybackRoomStore? = null
 ) {
     companion object {
+        private const val ROOM_RETRY_DELAY_MS = 15_000L
+
         @Volatile
         private var instance: LocalPlaylistPlaybackStatsRepository? = null
 
@@ -89,6 +93,7 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
     private val initialStats = loadInitialStats()
     private val _stats = MutableStateFlow(initialStats)
     private var persistedStats = initialStats
+    private var retryJob: Job? = null
     val statsFlow: StateFlow<List<LocalPlaylistPlaybackStat>> = _stats
 
     private fun loadInitialStats(): List<LocalPlaylistPlaybackStat> {
@@ -235,6 +240,8 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
             }.isSuccess
             if (roomWriteSucceeded) {
                 persistedStats = next
+                retryJob?.cancel()
+                retryJob = null
                 return
             }
         }
@@ -242,12 +249,25 @@ class LocalPlaylistPlaybackStatsRepository private constructor(
             "LocalPlaylistPlaybackRepo",
             "Local playlist playback update remains in memory until Room is available."
         )
+        schedulePersistenceRetry()
+    }
+
+    private fun schedulePersistenceRetry() {
+        if (!roomStorageEnabled || roomStore == null || retryJob?.isActive == true) return
+        retryJob = scope.launch {
+            delay(ROOM_RETRY_DELAY_MS)
+            mutex.withLock {
+                retryJob = null
+                persistSnapshot(_stats.value)
+            }
+        }
     }
 
     private fun syncCounterDeviceId(): String {
         return runCatching { syncStorage.getOrCreateDeviceId() }
             .getOrDefault(fallbackCounterDeviceId)
     }
+
 }
 
 internal fun recordLocalPlaylistPlay(

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepository.kt
@@ -3,10 +3,18 @@ package moe.ouom.neriplayer.data.playlist.usage
 import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.LocalPlaylistPlaybackRoomStore
+import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.stats.PlaybackStatsPeriod
 import moe.ouom.neriplayer.data.stats.playbackStatsDayStartAt
 import moe.ouom.neriplayer.data.stats.resolvePlaybackStatsTimeRange
@@ -50,7 +58,10 @@ data class LocalPlaylistPlaybackSyncSnapshot(
     val buckets: List<SyncLocalPlaylistPlaybackBucket>
 )
 
-class LocalPlaylistPlaybackStatsRepository private constructor(private val app: Context) {
+class LocalPlaylistPlaybackStatsRepository private constructor(
+    private val app: Context,
+    private val roomStore: LocalPlaylistPlaybackRoomStore? = null
+) {
     companion object {
         @Volatile
         private var instance: LocalPlaylistPlaybackStatsRepository? = null
@@ -58,33 +69,77 @@ class LocalPlaylistPlaybackStatsRepository private constructor(private val app: 
         fun getInstance(context: Context): LocalPlaylistPlaybackStatsRepository {
             return instance ?: synchronized(this) {
                 instance ?: LocalPlaylistPlaybackStatsRepository(
-                    context.applicationContext
+                    context.applicationContext,
+                    LocalPlaylistPlaybackRoomStore(
+                        NeriUserDataDatabase.getInstance(context.applicationContext)
+                    )
                 ).also { instance = it }
             }
         }
     }
 
     private val gson = Gson()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val file = File(app.filesDir, "local_playlist_playback_stats.json")
     private val syncStorage by lazy { SecureTokenStorage(app) }
     private val fallbackCounterDeviceId = "local-playlist-playback-${UUID.randomUUID()}"
     private val mutex = Mutex()
-    private val _stats = MutableStateFlow(loadFromDisk())
+    @Volatile
+    private var roomStorageEnabled = roomStore != null
+    private val legacyProjectionMutex = Mutex()
+    private var legacyProjectionGeneration = 0L
+    private val _stats = MutableStateFlow(loadInitialStats())
     val statsFlow: StateFlow<List<LocalPlaylistPlaybackStat>> = _stats
+
+    private fun loadInitialStats(): List<LocalPlaylistPlaybackStat> {
+        if (roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            val roomStats = runCatching {
+                runBlocking { activeRoomStore.readIfRoomPrimary() }
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                NPLogger.e(
+                    "LocalPlaylistPlaybackRepo",
+                    "Failed to read Room local playlist playback stats",
+                    error
+                )
+            }.getOrNull()
+            if (roomStats != null) {
+                return normalizeLocalPlaylistPlaybackStats(roomStats)
+            }
+        }
+
+        val legacyStats = loadFromDisk()
+        if (roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            runCatching {
+                runBlocking { activeRoomStore.importLegacyAndPromote(legacyStats) }
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                NPLogger.e(
+                    "LocalPlaylistPlaybackRepo",
+                    "Failed to promote local playlist playback JSON to Room",
+                    error
+                )
+            }
+        }
+        return legacyStats
+    }
 
     suspend fun recordPlayNow(
         playlistId: Long,
         playedAt: Long = System.currentTimeMillis()
     ) {
         mutex.withLock {
+            val current = _stats.value
             val updated = recordLocalPlaylistPlay(
-                current = _stats.value,
+                current = current,
                 playlistId = playlistId,
                 playedAt = playedAt,
                 deviceId = syncCounterDeviceId()
             )
             _stats.value = updated
-            persist(updated)
+            persistSnapshot(current, updated)
         }
     }
 
@@ -124,7 +179,7 @@ class LocalPlaylistPlaybackStatsRepository private constructor(private val app: 
             )
             val updated = finalized.toLocalPlaybackStats()
             _stats.value = updated
-            persist(updated)
+            persistSnapshot(currentStats, updated)
         }
     }
 
@@ -159,6 +214,58 @@ class LocalPlaylistPlaybackStatsRepository private constructor(private val app: 
     private fun persist(stats: List<LocalPlaylistPlaybackStat>) {
         runCatching {
             file.writeTextAtomically(gson.toJson(stats))
+        }
+    }
+
+    private suspend fun persistSnapshot(
+        previous: List<LocalPlaylistPlaybackStat>,
+        next: List<LocalPlaylistPlaybackStat>
+    ) {
+        if (roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            val roomWriteSucceeded = runCatching {
+                activeRoomStore.writeIncremental(previous, next)
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                NPLogger.e(
+                    "LocalPlaylistPlaybackRepo",
+                    "Failed to write Room local playlist playback stats",
+                    error
+                )
+            }.isSuccess
+            if (roomWriteSucceeded) {
+                enqueueLegacyProjection(next)
+                return
+            }
+        }
+        persist(next)
+        roomStore?.let { fallbackStore ->
+            runCatching { fallbackStore.markLegacyJsonPrimary() }
+                .onFailure { error ->
+                    NPLogger.e(
+                        "LocalPlaylistPlaybackRepo",
+                        "Failed to mark local playlist playback JSON fallback state",
+                        error
+                    )
+                }
+        }
+    }
+
+    private fun enqueueLegacyProjection(
+        stats: List<LocalPlaylistPlaybackStat>
+    ) {
+        val generation = synchronized(this) {
+            legacyProjectionGeneration += 1L
+            legacyProjectionGeneration
+        }
+        scope.launch {
+            legacyProjectionMutex.withLock {
+                val isLatest = synchronized(this@LocalPlaylistPlaybackStatsRepository) {
+                    generation == legacyProjectionGeneration
+                }
+                if (!isLatest) return@withLock
+                persist(stats)
+            }
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
@@ -24,6 +24,7 @@ package moe.ouom.neriplayer.data.playlist.usage
  */
 
 
+import android.annotation.SuppressLint
 import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -40,6 +41,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.mergeRoomRecoverySnapshot
 import moe.ouom.neriplayer.data.local.database.store.PlaylistUsageRoomStore
 import moe.ouom.neriplayer.data.local.playlist.model.buildLocalArtistSummaries
 import moe.ouom.neriplayer.data.local.playlist.model.LocalPlaylist
@@ -155,6 +157,7 @@ class PlaylistUsageRepository internal constructor(
         const val SOURCE_LOCAL_ARTIST = "localArtist"
         private const val ROOM_RETRY_DELAY_MS = 15_000L
 
+        @SuppressLint("StaticFieldLeak")
         @Volatile
         private var instance: PlaylistUsageRepository? = null
 
@@ -185,18 +188,37 @@ class PlaylistUsageRepository internal constructor(
     private var pendingSyncAfterPersistence = false
     @Volatile
     private var roomStorageEnabled = roomStore != null
+    private var roomRecoveryBaseline: List<UsageEntry>? = null
     private val initialEntries = load()
     private val _flow = MutableStateFlow(initialEntries)
     private var persistedEntries = initialEntries
     val frequentPlaylistsFlow: StateFlow<List<UsageEntry>> = _flow
 
+    private data class RoomRecoveryState(
+        val baseline: List<UsageEntry>,
+        val current: List<UsageEntry>,
+        val generation: Long
+    )
+
+    private data class RoomRecoveryCompletion(
+        val generation: Long,
+        val entries: List<UsageEntry>,
+        val shouldTriggerSync: Boolean
+    )
+
+    init {
+        scheduleRoomRecovery()
+    }
+
     private fun load(): List<UsageEntry> {
+        var needsRoomRecovery = false
         if (roomStorageEnabled && roomStore != null) {
             val activeRoomStore = roomStore
             val roomEntries = runCatching {
                 runBlocking { activeRoomStore.readIfRoomPrimary() }
             }.onFailure { error ->
                 roomStorageEnabled = false
+                needsRoomRecovery = true
                 NPLogger.e(
                     "PlaylistUsageRepo",
                     "Failed to read Room playlist usage; falling back to JSON",
@@ -229,6 +251,7 @@ class PlaylistUsageRepository internal constructor(
                 runBlocking { activeRoomStore.importLegacyAndPromote(normalized) }
             }.onFailure { error ->
                 roomStorageEnabled = false
+                needsRoomRecovery = true
                 NPLogger.e(
                     "PlaylistUsageRepo",
                     "Failed to promote playlist usage JSON to Room",
@@ -236,6 +259,9 @@ class PlaylistUsageRepository internal constructor(
                 )
             }
             LegacyJsonCleanupScheduler.schedule(app, "playlist-usage-import")
+        }
+        if (needsRoomRecovery) {
+            roomRecoveryBaseline = normalized
         }
         return normalized
     }
@@ -288,7 +314,11 @@ class PlaylistUsageRepository internal constructor(
                     "PlaylistUsageRepo",
                     "Playlist usage update remains in memory until Room is available."
                 )
-                schedulePersistenceRetry()
+                if (roomStorageEnabled) {
+                    schedulePersistenceRetry()
+                } else {
+                    scheduleRoomRecovery()
+                }
                 return@withLock
             }
 
@@ -326,6 +356,101 @@ class PlaylistUsageRepository internal constructor(
                 )
             }
         }
+    }
+
+    private fun scheduleRoomRecovery() {
+        if (roomStorageEnabled || roomStore == null || roomRecoveryBaseline == null) {
+            return
+        }
+        synchronized(mutationLock) {
+            if (retryJob?.isActive == true) return
+            retryJob = scope.launch {
+                delay(ROOM_RETRY_DELAY_MS)
+                recoverRoomStorage()
+            }
+        }
+    }
+
+    private suspend fun recoverRoomStorage() {
+        val activeRoomStore = roomStore ?: return
+        val recoveryState = synchronized(mutationLock) {
+            retryJob = null
+            val baseline = roomRecoveryBaseline ?: return
+            RoomRecoveryState(
+                baseline = baseline,
+                current = _flow.value,
+                generation = persistenceGeneration
+            )
+        }
+        val recovered = persistenceMutex.withLock {
+            runCatching {
+                if (activeRoomStore.readIfRoomPrimary() == null) {
+                    activeRoomStore.importLegacyAndPromote(recoveryState.current)
+                }
+                val roomSnapshot = activeRoomStore.readIfRoomPrimary()
+                    ?: return@runCatching null
+                mergeRoomRecoverySnapshot(
+                    roomSnapshot = roomSnapshot,
+                    recoveryBaseline = recoveryState.baseline,
+                    currentSnapshot = recoveryState.current,
+                    keyOf = UsageEntry::usageKey,
+                    mergeLocalChange = ::mergeRecoveredUsageEntry
+                )
+                    .let(::normalizeUsageEntries)
+                    .also { merged ->
+                        activeRoomStore.writeIncremental(roomSnapshot, merged)
+                    }
+            }.onFailure { error ->
+                NPLogger.e(
+                    "PlaylistUsageRepo",
+                    "Failed to recover Room playlist usage without replaying JSON",
+                    error
+                )
+            }.getOrNull()
+        }
+        if (recovered == null) {
+            scheduleRoomRecovery()
+            return
+        }
+
+        val followUp = synchronized(mutationLock) {
+            roomStorageEnabled = true
+            roomRecoveryBaseline = null
+            persistedEntries = recovered
+            retryJob?.cancel()
+            retryJob = null
+            val latestGeneration = persistenceGeneration
+            val latestEntries = _flow.value
+            val shouldTriggerSync = if (latestGeneration == recoveryState.generation) {
+                pendingSyncAfterPersistence.also { pendingSyncAfterPersistence = false }
+            } else {
+                false
+            }
+            RoomRecoveryCompletion(
+                generation = latestGeneration,
+                entries = latestEntries,
+                shouldTriggerSync = shouldTriggerSync
+            )
+        }
+        LegacyJsonCleanupScheduler.schedule(app, "playlist-usage-room-recovery")
+        if (followUp.generation == recoveryState.generation) {
+            if (followUp.shouldTriggerSync) {
+                triggerSync()
+            }
+        } else {
+            persistSnapshot(followUp.generation, followUp.entries)
+        }
+    }
+
+    private fun mergeRecoveredUsageEntry(
+        roomEntry: UsageEntry?,
+        localEntry: UsageEntry
+    ): UsageEntry {
+        if (roomEntry == null) return localEntry
+        return SyncPlaylistUsageStatsMergePolicy.mergePlaylistUsageStats(
+            local = listOf(roomEntry.toSyncPlaylistUsageStat()),
+            remote = listOf(localEntry.toSyncPlaylistUsageStat())
+        ).single().toUsageEntry()
     }
 
     fun recordOpen(

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
@@ -55,7 +55,6 @@ import moe.ouom.neriplayer.data.sync.model.SyncPlaylistUsageStat
 import moe.ouom.neriplayer.data.sync.model.sanitizeCoverUrlForSync
 import moe.ouom.neriplayer.data.sync.webdav.WebDavSyncWorker
 import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
-import moe.ouom.neriplayer.util.io.writeTextAtomically
 import moe.ouom.neriplayer.util.platform.LanguageManager
 import java.io.File
 import java.util.UUID
@@ -236,7 +235,10 @@ class PlaylistUsageRepository internal constructor(
         return normalized
     }
 
-    private fun saveAsync(list: List<UsageEntry>) {
+    private fun saveAsync(
+        list: List<UsageEntry>,
+        triggerSyncOnSuccess: Boolean = false
+    ) {
         val generation = synchronized(mutationLock) {
             persistenceGeneration += 1L
             persistenceGeneration
@@ -256,34 +258,24 @@ class PlaylistUsageRepository internal constructor(
                             next = list
                         )
                     }.onFailure { error ->
-                        roomStorageEnabled = false
                         NPLogger.e(
                             "PlaylistUsageRepo",
-                            "Failed to write Room playlist usage; falling back to JSON",
+                            "Failed to write Room playlist usage; keeping JSON migration data read-only",
                             error
                         )
                     }.isSuccess
                     if (roomWriteSucceeded) {
                         persistedEntries = list
+                        if (triggerSyncOnSuccess) {
+                            triggerSync()
+                        }
                         return@withLock
                     }
                 }
-
-                runCatching { file.writeTextAtomically(gson.toJson(list)) }
-                    .onFailure { error ->
-                        NPLogger.e("PlaylistUsageRepo", "Failed to persist playlist usage", error)
-                    }
-                roomStore?.let { fallbackStore ->
-                    runCatching { fallbackStore.markLegacyJsonPrimary() }
-                        .onFailure { error ->
-                            NPLogger.e(
-                                "PlaylistUsageRepo",
-                                "Failed to mark playlist usage JSON fallback state",
-                                error
-                            )
-                        }
-                }
-                persistedEntries = list
+                NPLogger.w(
+                    "PlaylistUsageRepo",
+                    "Playlist usage update remains in memory until Room is available."
+                )
             }
         }
     }
@@ -350,8 +342,7 @@ class PlaylistUsageRepository internal constructor(
             }
             normalizeUsageEntries(data).also { _flow.value = it }
         }
-        saveAsync(out)
-        triggerSync()
+        saveAsync(out, triggerSyncOnSuccess = true)
     }
 
     fun syncStats(): List<SyncPlaylistUsageStat> {
@@ -431,8 +422,7 @@ class PlaylistUsageRepository internal constructor(
 
             normalizeUsageEntries(data).also { _flow.value = it }
         }
-        saveAsync(out)
-        triggerSync()
+        saveAsync(out, triggerSyncOnSuccess = true)
     }
 
     /**

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
@@ -180,7 +180,9 @@ class PlaylistUsageRepository internal constructor(
     private var persistenceGeneration = 0L
     @Volatile
     private var roomStorageEnabled = roomStore != null
-    private val _flow = MutableStateFlow(load())
+    private val initialEntries = load()
+    private val _flow = MutableStateFlow(initialEntries)
+    private var persistedEntries = initialEntries
     val frequentPlaylistsFlow: StateFlow<List<UsageEntry>> = _flow
 
     private fun load(): List<UsageEntry> {
@@ -246,7 +248,10 @@ class PlaylistUsageRepository internal constructor(
                 if (roomStorageEnabled && roomStore != null) {
                     val activeRoomStore = roomStore
                     val roomWriteSucceeded = runCatching {
-                        activeRoomStore.replaceAll(list)
+                        activeRoomStore.writeIncremental(
+                            previous = persistedEntries,
+                            next = list
+                        )
                     }.onFailure { error ->
                         roomStorageEnabled = false
                         NPLogger.e(
@@ -256,6 +261,7 @@ class PlaylistUsageRepository internal constructor(
                         )
                     }.isSuccess
                     if (roomWriteSucceeded) {
+                        persistedEntries = list
                         return@withLock
                     }
                 }
@@ -274,6 +280,7 @@ class PlaylistUsageRepository internal constructor(
                             )
                         }
                 }
+                persistedEntries = list
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
@@ -33,6 +33,12 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.PlaylistUsageRoomStore
 import moe.ouom.neriplayer.data.local.playlist.model.buildLocalArtistSummaries
 import moe.ouom.neriplayer.data.local.playlist.model.LocalPlaylist
 import moe.ouom.neriplayer.data.local.playlist.system.FavoritesPlaylist
@@ -138,7 +144,10 @@ private fun mergeDuplicateUsageEntries(entries: List<UsageEntry>): UsageEntry {
     )
 }
 
-class PlaylistUsageRepository(private val app: Context) {
+class PlaylistUsageRepository internal constructor(
+    private val app: Context,
+    private val roomStore: PlaylistUsageRoomStore? = null
+) {
     companion object {
         const val SOURCE_LOCAL = "local"
         const val SOURCE_LOCAL_ARTIST = "localArtist"
@@ -148,7 +157,13 @@ class PlaylistUsageRepository(private val app: Context) {
 
         fun getInstance(context: Context): PlaylistUsageRepository {
             return instance ?: synchronized(this) {
-                instance ?: PlaylistUsageRepository(context.applicationContext).also {
+                val appContext = context.applicationContext
+                instance ?: PlaylistUsageRepository(
+                    app = appContext,
+                    roomStore = PlaylistUsageRoomStore(
+                        database = NeriUserDataDatabase.getInstance(appContext)
+                    )
+                ).also {
                     instance = it
                 }
             }
@@ -161,10 +176,31 @@ class PlaylistUsageRepository(private val app: Context) {
     private val syncStorage by lazy { SecureTokenStorage(app) }
     private val fallbackCounterDeviceId = "playlist-usage-${UUID.randomUUID()}"
     private val mutationLock = Any()
+    private val persistenceMutex = Mutex()
+    private var persistenceGeneration = 0L
+    @Volatile
+    private var roomStorageEnabled = roomStore != null
     private val _flow = MutableStateFlow(load())
     val frequentPlaylistsFlow: StateFlow<List<UsageEntry>> = _flow
 
     private fun load(): List<UsageEntry> {
+        if (roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            val roomEntries = runCatching {
+                runBlocking { activeRoomStore.readIfRoomPrimary() }
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                NPLogger.e(
+                    "PlaylistUsageRepo",
+                    "Failed to read Room playlist usage; falling back to JSON",
+                    error
+                )
+            }.getOrNull()
+            if (roomEntries != null) {
+                return normalizeUsageEntries(roomEntries)
+            }
+        }
+
         val list: List<UsageEntry> = try {
             if (!file.exists()) {
                 emptyList()
@@ -178,11 +214,68 @@ class PlaylistUsageRepository(private val app: Context) {
             emptyList()
         }
 
-        return normalizeUsageEntries(list)
+        val normalized = normalizeUsageEntries(list)
+        if (roomStorageEnabled && roomStore != null) {
+            val activeRoomStore = roomStore
+            runCatching {
+                runBlocking { activeRoomStore.importLegacyAndPromote(normalized) }
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                NPLogger.e(
+                    "PlaylistUsageRepo",
+                    "Failed to promote playlist usage JSON to Room",
+                    error
+                )
+            }
+        }
+        return normalized
     }
 
     private fun saveAsync(list: List<UsageEntry>) {
-        scope.launch { runCatching { file.writeTextAtomically(gson.toJson(list)) } }
+        val generation = synchronized(mutationLock) {
+            persistenceGeneration += 1L
+            persistenceGeneration
+        }
+        scope.launch {
+            persistenceMutex.withLock {
+                val isLatest = synchronized(mutationLock) {
+                    generation == persistenceGeneration
+                }
+                if (!isLatest) return@withLock
+
+                if (roomStorageEnabled && roomStore != null) {
+                    val activeRoomStore = roomStore
+                    val roomWriteSucceeded = runCatching {
+                        activeRoomStore.replaceAll(list)
+                    }.onFailure { error ->
+                        roomStorageEnabled = false
+                        NPLogger.e(
+                            "PlaylistUsageRepo",
+                            "Failed to write Room playlist usage; falling back to JSON",
+                            error
+                        )
+                    }.isSuccess
+                    if (roomWriteSucceeded) {
+                        return@withLock
+                    }
+                }
+
+                runCatching { file.writeTextAtomically(gson.toJson(list)) }
+                    .onFailure { error ->
+                        NPLogger.e("PlaylistUsageRepo", "Failed to persist playlist usage", error)
+                    }
+                roomStore?.let { fallbackStore ->
+                    runCatching { fallbackStore.markLegacyJsonPrimary() }
+                        .onFailure { error ->
+                            NPLogger.e(
+                                "PlaylistUsageRepo",
+                                "Failed to mark playlist usage JSON fallback state",
+                                error
+                            )
+                        }
+                }
+            }
+        }
     }
 
     fun recordOpen(

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
@@ -54,6 +54,7 @@ import moe.ouom.neriplayer.data.sync.model.SyncPlaybackCounterShard
 import moe.ouom.neriplayer.data.sync.model.SyncPlaylistUsageStat
 import moe.ouom.neriplayer.data.sync.model.sanitizeCoverUrlForSync
 import moe.ouom.neriplayer.data.sync.webdav.WebDavSyncWorker
+import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.util.io.writeTextAtomically
 import moe.ouom.neriplayer.util.platform.LanguageManager
 import java.io.File
@@ -199,6 +200,7 @@ class PlaylistUsageRepository internal constructor(
                 )
             }.getOrNull()
             if (roomEntries != null) {
+                LegacyJsonCleanupScheduler.schedule(app, "playlist-usage-room-load")
                 return normalizeUsageEntries(roomEntries)
             }
         }
@@ -229,6 +231,7 @@ class PlaylistUsageRepository internal constructor(
                     error
                 )
             }
+            LegacyJsonCleanupScheduler.schedule(app, "playlist-usage-import")
         }
         return normalized
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
@@ -29,7 +29,9 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -151,6 +153,7 @@ class PlaylistUsageRepository internal constructor(
     companion object {
         const val SOURCE_LOCAL = "local"
         const val SOURCE_LOCAL_ARTIST = "localArtist"
+        private const val ROOM_RETRY_DELAY_MS = 15_000L
 
         @Volatile
         private var instance: PlaylistUsageRepository? = null
@@ -178,6 +181,8 @@ class PlaylistUsageRepository internal constructor(
     private val mutationLock = Any()
     private val persistenceMutex = Mutex()
     private var persistenceGeneration = 0L
+    private var retryJob: Job? = null
+    private var pendingSyncAfterPersistence = false
     @Volatile
     private var roomStorageEnabled = roomStore != null
     private val initialEntries = load()
@@ -240,41 +245,84 @@ class PlaylistUsageRepository internal constructor(
         triggerSyncOnSuccess: Boolean = false
     ) {
         val generation = synchronized(mutationLock) {
+            if (triggerSyncOnSuccess) {
+                pendingSyncAfterPersistence = true
+            }
             persistenceGeneration += 1L
             persistenceGeneration
         }
         scope.launch {
-            persistenceMutex.withLock {
-                val isLatest = synchronized(mutationLock) {
-                    generation == persistenceGeneration
-                }
-                if (!isLatest) return@withLock
+            persistSnapshot(generation, list)
+        }
+    }
 
-                if (roomStorageEnabled && roomStore != null) {
-                    val activeRoomStore = roomStore
-                    val roomWriteSucceeded = runCatching {
-                        activeRoomStore.writeIncremental(
-                            previous = persistedEntries,
-                            next = list
-                        )
-                    }.onFailure { error ->
-                        NPLogger.e(
-                            "PlaylistUsageRepo",
-                            "Failed to write Room playlist usage; keeping JSON migration data read-only",
-                            error
-                        )
-                    }.isSuccess
-                    if (roomWriteSucceeded) {
-                        persistedEntries = list
-                        if (triggerSyncOnSuccess) {
-                            triggerSync()
-                        }
-                        return@withLock
-                    }
-                }
+    private suspend fun persistSnapshot(
+        generation: Long,
+        next: List<UsageEntry>
+    ) {
+        persistenceMutex.withLock {
+            val isLatest = synchronized(mutationLock) {
+                generation == persistenceGeneration
+            }
+            if (!isLatest) return@withLock
+
+            val activeRoomStore = roomStore
+            val roomWriteSucceeded = if (roomStorageEnabled && activeRoomStore != null) {
+                runCatching {
+                    activeRoomStore.writeIncremental(
+                        previous = persistedEntries,
+                        next = next
+                    )
+                }.onFailure { error ->
+                    NPLogger.e(
+                        "PlaylistUsageRepo",
+                        "Failed to write Room playlist usage; keeping JSON migration data read-only",
+                        error
+                    )
+                }.isSuccess
+            } else {
+                false
+            }
+            if (!roomWriteSucceeded) {
                 NPLogger.w(
                     "PlaylistUsageRepo",
                     "Playlist usage update remains in memory until Room is available."
+                )
+                schedulePersistenceRetry()
+                return@withLock
+            }
+
+            persistedEntries = next
+            val shouldTriggerSync = synchronized(mutationLock) {
+                if (generation != persistenceGeneration) {
+                    false
+                } else {
+                    retryJob?.cancel()
+                    retryJob = null
+                    pendingSyncAfterPersistence.also {
+                        pendingSyncAfterPersistence = false
+                    }
+                }
+            }
+            if (shouldTriggerSync) {
+                triggerSync()
+            }
+        }
+    }
+
+    private fun schedulePersistenceRetry() {
+        if (!roomStorageEnabled || roomStore == null) return
+        synchronized(mutationLock) {
+            if (retryJob?.isActive == true) return
+            retryJob = scope.launch {
+                delay(ROOM_RETRY_DELAY_MS)
+                val retrySnapshot = synchronized(mutationLock) {
+                    retryJob = null
+                    persistenceGeneration to _flow.value
+                }
+                persistSnapshot(
+                    generation = retrySnapshot.first,
+                    next = retrySnapshot.second
                 )
             }
         }
@@ -569,6 +617,7 @@ class PlaylistUsageRepository internal constructor(
             )
         }
     }
+
 }
 
 private fun UsageEntry.toSyncPlaylistUsageStat(): SyncPlaylistUsageStat {

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
@@ -177,7 +177,9 @@ class PlaylistUsageRepository internal constructor(
     private val fallbackCounterDeviceId = "playlist-usage-${UUID.randomUUID()}"
     private val mutationLock = Any()
     private val persistenceMutex = Mutex()
+    private val legacyProjectionMutex = Mutex()
     private var persistenceGeneration = 0L
+    private var legacyProjectionGeneration = 0L
     @Volatile
     private var roomStorageEnabled = roomStore != null
     private val _flow = MutableStateFlow(load())
@@ -256,6 +258,7 @@ class PlaylistUsageRepository internal constructor(
                         )
                     }.isSuccess
                     if (roomWriteSucceeded) {
+                        enqueueLegacyProjection(list, generation)
                         return@withLock
                     }
                 }
@@ -274,6 +277,35 @@ class PlaylistUsageRepository internal constructor(
                             )
                         }
                 }
+            }
+        }
+    }
+
+    private fun enqueueLegacyProjection(
+        list: List<UsageEntry>,
+        generation: Long
+    ) {
+        synchronized(mutationLock) {
+            legacyProjectionGeneration += 1L
+        }
+        val projectionGeneration = synchronized(mutationLock) {
+            legacyProjectionGeneration
+        }
+        scope.launch {
+            legacyProjectionMutex.withLock {
+                val isLatest = synchronized(mutationLock) {
+                    generation == persistenceGeneration &&
+                        projectionGeneration == legacyProjectionGeneration
+                }
+                if (!isLatest) return@withLock
+                runCatching { file.writeTextAtomically(gson.toJson(list)) }
+                    .onFailure { error ->
+                        NPLogger.e(
+                            "PlaylistUsageRepo",
+                            "Failed to update legacy playlist usage projection",
+                            error
+                        )
+                    }
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
@@ -177,9 +177,7 @@ class PlaylistUsageRepository internal constructor(
     private val fallbackCounterDeviceId = "playlist-usage-${UUID.randomUUID()}"
     private val mutationLock = Any()
     private val persistenceMutex = Mutex()
-    private val legacyProjectionMutex = Mutex()
     private var persistenceGeneration = 0L
-    private var legacyProjectionGeneration = 0L
     @Volatile
     private var roomStorageEnabled = roomStore != null
     private val _flow = MutableStateFlow(load())
@@ -258,7 +256,6 @@ class PlaylistUsageRepository internal constructor(
                         )
                     }.isSuccess
                     if (roomWriteSucceeded) {
-                        enqueueLegacyProjection(list, generation)
                         return@withLock
                     }
                 }
@@ -277,35 +274,6 @@ class PlaylistUsageRepository internal constructor(
                             )
                         }
                 }
-            }
-        }
-    }
-
-    private fun enqueueLegacyProjection(
-        list: List<UsageEntry>,
-        generation: Long
-    ) {
-        synchronized(mutationLock) {
-            legacyProjectionGeneration += 1L
-        }
-        val projectionGeneration = synchronized(mutationLock) {
-            legacyProjectionGeneration
-        }
-        scope.launch {
-            legacyProjectionMutex.withLock {
-                val isLatest = synchronized(mutationLock) {
-                    generation == persistenceGeneration &&
-                        projectionGeneration == legacyProjectionGeneration
-                }
-                if (!isLatest) return@withLock
-                runCatching { file.writeTextAtomically(gson.toJson(list)) }
-                    .onFailure { error ->
-                        NPLogger.e(
-                            "PlaylistUsageRepo",
-                            "Failed to update legacy playlist usage projection",
-                            error
-                        )
-                    }
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsCounterStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsCounterStore.kt
@@ -8,7 +8,6 @@ import moe.ouom.neriplayer.data.sync.model.SyncPlaybackStatBucket
 import moe.ouom.neriplayer.data.sync.github.SyncPlaybackStatMapper
 import moe.ouom.neriplayer.data.sync.model.SyncTrackStat
 import moe.ouom.neriplayer.core.logging.NPLogger
-import moe.ouom.neriplayer.util.io.writeTextAtomically
 import java.io.File
 
 data class PlaybackStatsSyncCounterSnapshot(
@@ -171,10 +170,6 @@ internal class PlaybackStatsCounterStore(
         return synchronized(lock) { state.epochStartedAt }
     }
 
-    fun persistLegacyProjection(): Boolean {
-        return persistToDisk(synchronized(lock) { state })
-    }
-
     private fun load(): PlaybackStatsCounterState {
         return try {
             if (!counterFile.exists()) return PlaybackStatsCounterState()
@@ -190,19 +185,6 @@ internal class PlaybackStatsCounterStore(
             state = nextState
         }
     }
-
-    private fun persistToDisk(nextState: PlaybackStatsCounterState): Boolean {
-        return synchronized(persistFileLock) {
-            runCatching {
-                counterFile.writeTextAtomically(gson.toJson(nextState))
-                true
-            }.onFailure { error ->
-                NPLogger.e("PlaybackStatsRepo", "Failed to persist stats counters", error)
-            }.getOrDefault(false)
-        }
-    }
-
-    private val persistFileLock = Any()
 
     private fun updateShardList(
         shards: List<SyncPlaybackCounterShard>,

--- a/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsCounterStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsCounterStore.kt
@@ -9,12 +9,6 @@ import moe.ouom.neriplayer.data.sync.github.SyncPlaybackStatMapper
 import moe.ouom.neriplayer.data.sync.model.SyncTrackStat
 import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.util.io.writeTextAtomically
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import java.io.File
 
 data class PlaybackStatsSyncCounterSnapshot(
@@ -50,12 +44,8 @@ internal class PlaybackStatsCounterStore(
         File(context.filesDir, "playback_stats_counters.json")
     }
     private val lock = Any()
-    private val persistScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val syncStorage by lazy { SecureTokenStorage(context) }
     private var state = load()
-    private var persistJob: Job? = null
-    private var persistGeneration = 0L
-    private var pendingState: PlaybackStatsCounterState? = null
 
     fun snapshot(): PlaybackStatsSyncCounterSnapshot {
         val current = synchronized(lock) { state }
@@ -103,34 +93,31 @@ internal class PlaybackStatsCounterStore(
             playedAt = playedAt
         )
 
-        persist(
+        updateState(
             current.copy(
                 trackShardsByIdentity = updatedTrackShards,
                 dailyShardsByBucketKey = updatedDailyShards
-            ),
-            immediate = false
+            )
         )
     }
 
     fun reset(epochStartedAt: Long) {
-        persist(
-            PlaybackStatsCounterState(epochStartedAt = epochStartedAt.coerceAtLeast(0L)),
-            immediate = true
+        updateState(
+            PlaybackStatsCounterState(epochStartedAt = epochStartedAt.coerceAtLeast(0L))
         )
     }
 
     fun removeTracks(keys: Set<String>) {
         if (keys.isEmpty()) return
         val current = synchronized(lock) { state }
-        persist(
+        updateState(
             current.copy(
                 trackShardsByIdentity = current.trackShardsByIdentity - keys,
                 dailyShardsByBucketKey = current.dailyShardsByBucketKey.filterKeys { key ->
                     val identityKey = key.substringAfter('|', missingDelimiterValue = key)
                     identityKey !in keys
                 }
-            ),
-            immediate = true
+            )
         )
     }
 
@@ -152,25 +139,40 @@ internal class PlaybackStatsCounterStore(
                 ) to SyncPlaybackStatMapper.normalizeCounterShards(bucket.counterShards)
             }
             .filterValues { it.isNotEmpty() }
-        persist(
+        updateState(
             PlaybackStatsCounterState(
                 epochStartedAt = epochStartedAt.coerceAtLeast(0L),
                 trackShardsByIdentity = trackShards,
                 dailyShardsByBucketKey = dailyShards
-            ),
-            immediate = true
+            )
         )
     }
 
-    suspend fun flushPendingWrites() {
-        val snapshot = synchronized(lock) {
-            persistGeneration += 1L
-            persistJob?.cancel()
-            persistJob = null
-            pendingState = null
-            state
-        }
-        persistToDisk(snapshot)
+    fun replaceFromRoom(
+        snapshot: PlaybackStatsSyncCounterSnapshot,
+        epochStartedAt: Long
+    ) {
+        val trackShards = snapshot.trackShardsByIdentity
+            .mapValues { (_, shards) -> SyncPlaybackStatMapper.normalizeCounterShards(shards) }
+            .filterValues { it.isNotEmpty() }
+        val dailyShards = snapshot.dailyShardsByBucketKey
+            .mapValues { (_, shards) -> SyncPlaybackStatMapper.normalizeCounterShards(shards) }
+            .filterValues { it.isNotEmpty() }
+        updateState(
+            PlaybackStatsCounterState(
+                epochStartedAt = epochStartedAt.coerceAtLeast(0L),
+                trackShardsByIdentity = trackShards,
+                dailyShardsByBucketKey = dailyShards
+            )
+        )
+    }
+
+    fun epochStartedAt(): Long {
+        return synchronized(lock) { state.epochStartedAt }
+    }
+
+    fun persistLegacyProjection(): Boolean {
+        return persistToDisk(synchronized(lock) { state })
     }
 
     private fun load(): PlaybackStatsCounterState {
@@ -183,53 +185,24 @@ internal class PlaybackStatsCounterStore(
         }
     }
 
-    private fun persist(nextState: PlaybackStatsCounterState, immediate: Boolean) {
+    private fun updateState(nextState: PlaybackStatsCounterState) {
         synchronized(lock) {
             state = nextState
-            pendingState = nextState
-            persistGeneration += 1L
-            persistJob?.cancel()
-            persistJob = null
-            if (immediate) {
-                pendingState = null
-            }
-            if (!immediate) {
-                val generation = persistGeneration
-                persistJob = persistScope.launch {
-                    delay(PERSIST_DEBOUNCE_MS)
-                    val snapshot = synchronized(lock) {
-                        if (generation != persistGeneration) {
-                            null
-                        } else {
-                            pendingState.also {
-                                pendingState = null
-                                persistJob = null
-                            }
-                        }
-                    }
-                    snapshot?.let { persistToDisk(it) }
-                }
-                return
-            }
         }
-        persistToDisk(nextState)
     }
 
-    private fun persistToDisk(nextState: PlaybackStatsCounterState) {
-        synchronized(persistFileLock) {
+    private fun persistToDisk(nextState: PlaybackStatsCounterState): Boolean {
+        return synchronized(persistFileLock) {
             runCatching {
                 counterFile.writeTextAtomically(gson.toJson(nextState))
+                true
             }.onFailure { error ->
                 NPLogger.e("PlaybackStatsRepo", "Failed to persist stats counters", error)
-            }
+            }.getOrDefault(false)
         }
     }
 
     private val persistFileLock = Any()
-
-    private companion object {
-        const val PERSIST_DEBOUNCE_MS = 5_000L
-    }
 
     private fun updateShardList(
         shards: List<SyncPlaybackCounterShard>,

--- a/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsRepository.kt
@@ -27,6 +27,7 @@ import moe.ouom.neriplayer.data.sync.model.SyncTrackStat
 import moe.ouom.neriplayer.data.sync.webdav.WebDavSyncWorker
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.util.io.writeTextAtomically
 import java.io.File
 
@@ -124,6 +125,7 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                 snapshot = roomSnapshot.counterSnapshot,
                 epochStartedAt = roomSnapshot.counterEpochStartedAt
             )
+            LegacyJsonCleanupScheduler.schedule(app, "playback-stats-room-load")
             return roomSnapshot.toPersistenceSnapshot()
         }
 
@@ -150,6 +152,7 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                     clearedAt = legacyState.clearedAt
                 )
             }
+            LegacyJsonCleanupScheduler.schedule(app, "playback-stats-import")
             roomStorageEnabled = true
         }.onFailure { error ->
             roomStorageEnabled = false

--- a/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsRepository.kt
@@ -89,6 +89,7 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
     private var persistGeneration = 0L
     private var pendingPersistence: PlaybackStatsPersistenceSnapshot? = null
     private var persistenceDirty = false
+    private var pendingSyncAfterPersistence = false
     private val counterStore = PlaybackStatsCounterStore(app, gson)
     private val roomStore = PlaybackStatsRoomStore(
         NeriUserDataDatabase.getInstance(app.applicationContext)
@@ -344,6 +345,8 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                 if (roomSucceeded) {
                     persistedSnapshot = snapshot
                     markPersistenceClean(expectedGeneration)
+                    cancelPendingRetry()
+                    triggerPendingSyncAfterPersistence()
                     return@withLock
                 }
             }
@@ -370,9 +373,34 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
         }
     }
 
+    private fun requestSyncAfterPersistence() {
+        synchronized(this) {
+            pendingSyncAfterPersistence = true
+        }
+    }
+
+    private fun triggerPendingSyncAfterPersistence() {
+        val shouldTrigger = synchronized(this) {
+            pendingSyncAfterPersistence.also {
+                pendingSyncAfterPersistence = false
+            }
+        }
+        if (shouldTrigger) {
+            triggerSync()
+        }
+    }
+
+    private fun cancelPendingRetry() {
+        synchronized(this) {
+            retryJob?.cancel()
+            retryJob = null
+        }
+    }
+
     fun hasPendingWrites(): Boolean {
         return synchronized(this) {
             persistenceDirty || pendingPersistence != null || persistJob?.isActive == true
+                || retryJob?.isActive == true
         }
     }
 
@@ -380,6 +408,7 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
         mutex.withLock<Unit> {
             val shouldPersist = synchronized(this@PlaybackStatsRepository) {
                 persistenceDirty || pendingPersistence != null || persistJob?.isActive == true
+                    || retryJob?.isActive == true
             }
             cancelScheduledPersistenceLocked()
             if (shouldPersist) {
@@ -521,7 +550,7 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
             )
             schedulePersistenceLocked()
             if (scheduleSync) {
-                triggerSync()
+                requestSyncAfterPersistence()
             }
         }
     }
@@ -583,8 +612,8 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                 cancelScheduledPersistenceLocked()
                 counterStore.reset(clearedAt)
                 persistenceDirty = true
+                requestSyncAfterPersistence()
                 persistSnapshot(currentPersistenceSnapshot())
-                triggerSync()
             }
         }
     }
@@ -600,8 +629,8 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                 cancelScheduledPersistenceLocked()
                 counterStore.removeTracks(keys)
                 persistenceDirty = true
+                requestSyncAfterPersistence()
                 persistSnapshot(currentPersistenceSnapshot())
-                triggerSync()
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsRepository.kt
@@ -28,7 +28,6 @@ import moe.ouom.neriplayer.data.sync.webdav.WebDavSyncWorker
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
-import moe.ouom.neriplayer.util.io.writeTextAtomically
 import java.io.File
 
 data class TrackStat(
@@ -84,9 +83,9 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
     private val dailyFile: File by lazy { File(app.filesDir, "playback_stats_daily.json") }
     private val metadataFile: File by lazy { File(app.filesDir, "playback_stats_meta.json") }
     private val mutex = Mutex()
-    private val persistFileMutex = Mutex()
     private val roomPersistenceMutex = Mutex()
     private var persistJob: Job? = null
+    private var retryJob: Job? = null
     private var persistGeneration = 0L
     private var pendingPersistence: PlaybackStatsPersistenceSnapshot? = null
     private var persistenceDirty = false
@@ -266,14 +265,10 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
     ): List<PlaybackStatBucket> {
         return try {
             if (!dailyFile.exists()) {
-                val migrated = buildLegacyDailyStats(
+                return buildLegacyDailyStats(
                     stats = stats,
                     clearedAt = clearedAt
                 )
-                if (migrated.isNotEmpty()) {
-                    persistDailyStatsToDisk(migrated)
-                }
-                return migrated
             }
             val raw = dailyFile.readText()
             val type = object : TypeToken<List<PlaybackStatBucket>>() {}.type
@@ -281,33 +276,6 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
         } catch (_: Throwable) {
             emptyList()
         }
-    }
-
-    private fun persistToDisk(list: List<TrackStat>): Boolean {
-        return runCatching {
-            file.writeTextAtomically(gson.toJson(list))
-            true
-        }.onFailure { error ->
-            NPLogger.e("PlaybackStatsRepo", "Failed to persist stats", error)
-        }.getOrDefault(false)
-    }
-
-    private fun persistDailyStatsToDisk(list: List<PlaybackStatBucket>): Boolean {
-        return runCatching {
-            dailyFile.writeTextAtomically(gson.toJson(list))
-            true
-        }.onFailure { error ->
-            NPLogger.e("PlaybackStatsRepo", "Failed to persist daily stats", error)
-        }.getOrDefault(false)
-    }
-
-    private fun persistMetadata(clearedAt: Long): Boolean {
-        return runCatching {
-            metadataFile.writeTextAtomically(gson.toJson(PlaybackStatsMetadata(clearedAt)))
-            true
-        }.onFailure { error ->
-            NPLogger.e("PlaybackStatsRepo", "Failed to persist stats metadata", error)
-        }.getOrDefault(false)
     }
 
     private fun currentPersistenceSnapshot(): PlaybackStatsPersistenceSnapshot {
@@ -367,10 +335,9 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                         clearedAt = snapshot.clearedAt
                     )
                 }.onFailure { error ->
-                    roomStorageEnabled = false
                     NPLogger.e(
                         "PlaybackStatsRepo",
-                        "Failed to write Room playback stats",
+                        "Failed to write Room playback stats; keeping JSON migration data read-only",
                         error
                     )
                 }.isSuccess
@@ -380,18 +347,17 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                     return@withLock
                 }
             }
-            val legacySucceeded = persistLegacySnapshot(snapshot)
-            if (legacySucceeded) {
-                runCatching { roomStore.markLegacyJsonPrimary() }
-                    .onFailure { error ->
-                        NPLogger.e(
-                            "PlaybackStatsRepo",
-                            "Failed to mark playback stats JSON fallback state",
-                            error
-                        )
-                    }
-                persistedSnapshot = snapshot
-                markPersistenceClean(expectedGeneration)
+            scheduleRoomRetry()
+        }
+    }
+
+    private fun scheduleRoomRetry() {
+        if (!roomStorageEnabled || retryJob?.isActive == true) return
+        retryJob = scope.launch {
+            delay(ROOM_RETRY_DELAY_MS)
+            mutex.withLock {
+                retryJob = null
+                persistSnapshot(currentPersistenceSnapshot())
             }
         }
     }
@@ -401,17 +367,6 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
             if (expectedGeneration == null || expectedGeneration == persistGeneration) {
                 persistenceDirty = false
             }
-        }
-    }
-
-    private fun persistLegacySnapshot(
-        snapshot: PlaybackStatsPersistenceSnapshot
-    ): Boolean {
-        return synchronized(persistFileMutex) {
-            persistToDisk(snapshot.stats) &&
-                persistDailyStatsToDisk(snapshot.dailyStats) &&
-                persistMetadata(snapshot.clearedAt) &&
-                counterStore.persistLegacyProjection()
         }
     }
 
@@ -744,6 +699,7 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
 
     companion object {
         private const val PERSIST_DEBOUNCE_MS = 5_000L
+        private const val ROOM_RETRY_DELAY_MS = 15_000L
 
         @SuppressLint("StaticFieldLeak")
         @Volatile

--- a/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsRepository.kt
@@ -85,8 +85,6 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
     private val mutex = Mutex()
     private val persistFileMutex = Mutex()
     private val roomPersistenceMutex = Mutex()
-    private val legacyProjectionMutex = Mutex()
-    private var legacyProjectionGeneration = 0L
     private var persistJob: Job? = null
     private var persistGeneration = 0L
     private var pendingPersistence: PlaybackStatsPersistenceSnapshot? = null
@@ -375,7 +373,6 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                 }.isSuccess
                 if (roomSucceeded) {
                     persistedSnapshot = snapshot
-                    enqueueLegacyProjection(snapshot)
                     markPersistenceClean(expectedGeneration)
                     return@withLock
                 }
@@ -412,24 +409,6 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                 persistDailyStatsToDisk(snapshot.dailyStats) &&
                 persistMetadata(snapshot.clearedAt) &&
                 counterStore.persistLegacyProjection()
-        }
-    }
-
-    private fun enqueueLegacyProjection(
-        snapshot: PlaybackStatsPersistenceSnapshot
-    ) {
-        val generation = synchronized(this) {
-            legacyProjectionGeneration += 1L
-            legacyProjectionGeneration
-        }
-        scope.launch {
-            legacyProjectionMutex.withLock {
-                val isLatest = synchronized(this@PlaybackStatsRepository) {
-                    generation == legacyProjectionGeneration
-                }
-                if (!isLatest) return@withLock
-                persistLegacySnapshot(snapshot)
-            }
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsRepository.kt
@@ -51,7 +51,7 @@ data class TrackStat(
     val identityKey: String
 )
 
-private data class PlaybackStatsPersistenceSnapshot(
+internal data class PlaybackStatsPersistenceSnapshot(
     val stats: List<TrackStat>,
     val dailyStats: List<PlaybackStatBucket>,
     val counterSnapshot: PlaybackStatsSyncCounterSnapshot,
@@ -73,6 +73,204 @@ private fun PlaybackStatsRoomSnapshot.toPersistenceSnapshot():
 private data class PlaybackStatsMetadata(
     val clearedAt: Long = 0L
 )
+
+internal fun mergePlaybackStatsRoomRecovery(
+    roomSnapshot: PlaybackStatsPersistenceSnapshot,
+    recoveryBaseline: PlaybackStatsPersistenceSnapshot,
+    currentSnapshot: PlaybackStatsPersistenceSnapshot
+): PlaybackStatsPersistenceSnapshot {
+    val effectiveClearedAt = maxOf(roomSnapshot.clearedAt, currentSnapshot.clearedAt)
+    val baselineStatsByKey = recoveryBaseline.stats.associateBy(TrackStat::identityKey)
+    val currentStatsByKey = currentSnapshot.stats.associateBy(TrackStat::identityKey)
+    val baselineDailyByKey = recoveryBaseline.dailyStats.associateBy { bucket ->
+        bucket.dayStartAt to bucket.identityKey
+    }
+    val currentDailyByKey = currentSnapshot.dailyStats.associateBy { bucket ->
+        bucket.dayStartAt to bucket.identityKey
+    }
+    val changedTrackKeys = (
+        baselineStatsByKey.keys + currentStatsByKey.keys +
+            recoveryBaseline.counterSnapshot.trackShardsByIdentity.keys +
+            currentSnapshot.counterSnapshot.trackShardsByIdentity.keys
+        ).filter { key ->
+            baselineStatsByKey[key] != currentStatsByKey[key] ||
+                recoveryBaseline.counterSnapshot.trackShards(key) !=
+                    currentSnapshot.counterSnapshot.trackShards(key)
+        }.toSet()
+    val changedDailyKeys = (
+        baselineDailyByKey.keys + currentDailyByKey.keys +
+            recoveryBaseline.counterSnapshot.dailyShardsByBucketKey.keys.map(
+                ::playbackStatsDailyKey
+            ) +
+            currentSnapshot.counterSnapshot.dailyShardsByBucketKey.keys.map(
+                ::playbackStatsDailyKey
+            )
+        ).filter { key ->
+            baselineDailyByKey[key] != currentDailyByKey[key] ||
+                recoveryBaseline.counterSnapshot.dailyShards(
+                    dayStartAt = key.first,
+                    identityKey = key.second
+                ) != currentSnapshot.counterSnapshot.dailyShards(
+                    dayStartAt = key.first,
+                    identityKey = key.second
+                )
+        }.toSet()
+    val removedTrackKeys = baselineStatsByKey.keys - currentStatsByKey.keys
+    val removedDailyKeys = baselineDailyByKey.keys - currentDailyByKey.keys
+    val roomStatsByKey = roomSnapshot.stats
+        .filter { stat ->
+            stat.identityKey !in removedTrackKeys &&
+                shouldKeepTrackStatAfterClear(stat, effectiveClearedAt)
+        }
+        .associateBy(TrackStat::identityKey)
+    val roomDailyByKey = roomSnapshot.dailyStats
+        .filter { bucket ->
+            bucket.identityKey !in removedTrackKeys &&
+                (bucket.dayStartAt to bucket.identityKey) !in removedDailyKeys &&
+                shouldKeepDailyBucketAfterClear(bucket, effectiveClearedAt)
+        }
+        .associateBy { bucket -> bucket.dayStartAt to bucket.identityKey }
+    val changedCurrentStats = currentSnapshot.stats.filter { stat ->
+        stat.identityKey in changedTrackKeys &&
+            shouldKeepTrackStatAfterClear(stat, effectiveClearedAt)
+    }
+    val changedCurrentDailyStats = currentSnapshot.dailyStats.filter { bucket ->
+        (bucket.dayStartAt to bucket.identityKey) in changedDailyKeys &&
+            bucket.identityKey !in removedTrackKeys &&
+            shouldKeepDailyBucketAfterClear(bucket, effectiveClearedAt)
+    }
+    val mergedStats = SyncPlaybackStatsMergePolicy.merge(
+        local = roomStatsByKey.values.map { stat ->
+            SyncPlaybackStatMapper.fromTrackStat(
+                stat = stat,
+                counterShards = roomSnapshot.counterSnapshot.trackShards(stat.identityKey)
+            )
+        },
+        remote = changedCurrentStats.map { stat ->
+            SyncPlaybackStatMapper.fromTrackStat(
+                stat = stat,
+                counterShards = currentSnapshot.counterSnapshot.trackShards(stat.identityKey)
+            )
+        },
+        playbackStatsClearedAt = effectiveClearedAt
+    )
+    val mergedDailyStats = SyncPlaybackStatsMergePolicy.mergeBuckets(
+        local = roomDailyByKey.values.map { bucket ->
+            SyncPlaybackStatMapper.fromPlaybackStatBucket(
+                bucket = bucket,
+                counterShards = roomSnapshot.counterSnapshot.dailyShards(
+                    dayStartAt = bucket.dayStartAt,
+                    identityKey = bucket.identityKey
+                )
+            )
+        },
+        remote = changedCurrentDailyStats.map { bucket ->
+            SyncPlaybackStatMapper.fromPlaybackStatBucket(
+                bucket = bucket,
+                counterShards = currentSnapshot.counterSnapshot.dailyShards(
+                    dayStartAt = bucket.dayStartAt,
+                    identityKey = bucket.identityKey
+                )
+            )
+        },
+        playbackStatsClearedAt = effectiveClearedAt
+    )
+    val finalized = SyncPlaybackStatsMergePolicy.finalizeMergedStats(
+        mergedStats = mergedStats,
+        mergedBuckets = mergedDailyStats
+    )
+    val recoveredStats = finalized.stats.map { merged ->
+        val source = if (merged.identityKey in changedTrackKeys) {
+            currentStatsByKey[merged.identityKey]
+        } else {
+            roomStatsByKey[merged.identityKey]
+        }
+        source?.applyRecoveredSyncCounters(merged) ?: merged.toRecoveredTrackStat()
+    }
+    val recoveredDailyStats = finalized.buckets.map { merged ->
+        val key = merged.dayStartAt to merged.identityKey
+        val source = if (key in changedDailyKeys) {
+            currentDailyByKey[key]
+        } else {
+            roomDailyByKey[key]
+        }
+        source?.let { bucket -> mergeDailyBucket(bucket, merged) }
+            ?: merged.toPlaybackStatBucket()
+    }
+    val recoveredCounterSnapshot = PlaybackStatsSyncCounterSnapshot(
+        trackShardsByIdentity = finalized.stats.mapNotNull { stat ->
+            val shards = SyncPlaybackStatMapper.normalizeCounterShards(stat.counterShards)
+            stat.identityKey.takeIf { it.isNotBlank() && shards.isNotEmpty() }?.let { key ->
+                key to shards
+            }
+        }.toMap(),
+        dailyShardsByBucketKey = finalized.buckets.mapNotNull { bucket ->
+            val shards = SyncPlaybackStatMapper.normalizeCounterShards(bucket.counterShards)
+            if (bucket.identityKey.isBlank() || shards.isEmpty()) {
+                null
+            } else {
+                PlaybackStatsSyncCounterSnapshot.dailyCounterKey(
+                    dayStartAt = bucket.dayStartAt,
+                    identityKey = bucket.identityKey
+                ) to shards
+            }
+        }.toMap()
+    )
+    val localEpochChanged = currentSnapshot.counterEpochStartedAt !=
+        recoveryBaseline.counterEpochStartedAt
+    return PlaybackStatsPersistenceSnapshot(
+        stats = recoveredStats,
+        dailyStats = recoveredDailyStats,
+        counterSnapshot = recoveredCounterSnapshot,
+        counterEpochStartedAt = maxOf(
+            roomSnapshot.counterEpochStartedAt,
+            if (localEpochChanged) currentSnapshot.counterEpochStartedAt else 0L,
+            effectiveClearedAt
+        ),
+        clearedAt = effectiveClearedAt
+    )
+}
+
+private fun playbackStatsDailyKey(counterKey: String): Pair<Long, String> {
+    val dayStartAt = counterKey.substringBefore('|').toLongOrNull() ?: 0L
+    return dayStartAt to counterKey.substringAfter('|', missingDelimiterValue = counterKey)
+}
+
+private fun SyncTrackStat.toRecoveredTrackStat(): TrackStat {
+    return TrackStat(
+        id = id,
+        name = name,
+        artist = artist,
+        album = album,
+        albumId = albumId,
+        coverUrl = coverUrl,
+        durationMs = durationMs,
+        totalListenMs = totalListenMs,
+        playCount = playCount,
+        lastPlayedAt = lastPlayedAt,
+        firstPlayedAt = firstPlayedAt,
+        mediaUri = mediaUri,
+        localFilePath = null,
+        localFileName = null,
+        customName = null,
+        customArtist = null,
+        customCoverUrl = null,
+        identityKey = identityKey
+    )
+}
+
+private fun TrackStat.applyRecoveredSyncCounters(remote: SyncTrackStat): TrackStat {
+    val useRemoteMetadata = remote.lastPlayedAt > lastPlayedAt
+    return copy(
+        totalListenMs = remote.totalListenMs,
+        playCount = remote.playCount,
+        lastPlayedAt = remote.lastPlayedAt,
+        firstPlayedAt = remote.firstPlayedAt,
+        name = if (useRemoteMetadata) remote.name else name,
+        artist = if (useRemoteMetadata) remote.artist else artist,
+        coverUrl = if (useRemoteMetadata) remote.coverUrl else coverUrl
+    )
+}
 
 private const val MIN_LISTEN_MS_FOR_PLAY_COUNT = 30_000L
 
@@ -96,6 +294,7 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
     )
     @Volatile
     private var roomStorageEnabled = true
+    private var roomRecoveryBaseline: PlaybackStatsPersistenceSnapshot? = null
     private val initialState = loadInitialState()
     private val _stats = MutableStateFlow(initialState.stats)
     private val _statsClearedAt = MutableStateFlow(initialState.clearedAt)
@@ -107,13 +306,16 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
 
     init {
         reconcileLoadedStats()
+        scheduleRoomRecovery()
     }
 
     private fun loadInitialState(): PlaybackStatsPersistenceSnapshot {
+        var needsRoomRecovery = false
         val roomSnapshot = runCatching {
             runBlocking { roomStore.readIfRoomPrimary() }
         }.onFailure { error ->
             roomStorageEnabled = false
+            needsRoomRecovery = true
             NPLogger.e(
                 "PlaybackStatsRepo",
                 "Failed to read Room playback stats",
@@ -142,25 +344,30 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
             counterEpochStartedAt = counterStore.epochStartedAt(),
             clearedAt = clearedAt
         )
-        runCatching {
-            runBlocking {
-                roomStore.importLegacyAndPromote(
-                    stats = legacyState.stats,
-                    dailyStats = legacyState.dailyStats,
-                    counterSnapshot = legacyState.counterSnapshot,
-                    counterEpochStartedAt = legacyState.counterEpochStartedAt,
-                    clearedAt = legacyState.clearedAt
+        if (roomStorageEnabled) {
+            runCatching {
+                runBlocking {
+                    roomStore.importLegacyAndPromote(
+                        stats = legacyState.stats,
+                        dailyStats = legacyState.dailyStats,
+                        counterSnapshot = legacyState.counterSnapshot,
+                        counterEpochStartedAt = legacyState.counterEpochStartedAt,
+                        clearedAt = legacyState.clearedAt
+                    )
+                }
+                LegacyJsonCleanupScheduler.schedule(app, "playback-stats-import")
+            }.onFailure { error ->
+                roomStorageEnabled = false
+                needsRoomRecovery = true
+                NPLogger.e(
+                    "PlaybackStatsRepo",
+                    "Failed to promote playback stats JSON to Room",
+                    error
                 )
             }
-            LegacyJsonCleanupScheduler.schedule(app, "playback-stats-import")
-            roomStorageEnabled = true
-        }.onFailure { error ->
-            roomStorageEnabled = false
-            NPLogger.e(
-                "PlaybackStatsRepo",
-                "Failed to promote playback stats JSON to Room",
-                error
-            )
+        }
+        if (needsRoomRecovery) {
+            roomRecoveryBaseline = legacyState
         }
         return legacyState
     }
@@ -350,7 +557,11 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                     return@withLock
                 }
             }
-            scheduleRoomRetry()
+            if (roomStorageEnabled) {
+                scheduleRoomRetry()
+            } else {
+                scheduleRoomRecovery()
+            }
         }
     }
 
@@ -363,6 +574,81 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                 persistSnapshot(currentPersistenceSnapshot())
             }
         }
+    }
+
+    private fun scheduleRoomRecovery() {
+        if (roomStorageEnabled || roomRecoveryBaseline == null || retryJob?.isActive == true) {
+            return
+        }
+        retryJob = scope.launch {
+            delay(ROOM_RETRY_DELAY_MS)
+            mutex.withLock {
+                retryJob = null
+                recoverRoomStorage()
+            }
+        }
+    }
+
+    private suspend fun recoverRoomStorage() {
+        val baseline = roomRecoveryBaseline ?: return
+        val current = currentPersistenceSnapshot()
+        val recovered = roomPersistenceMutex.withLock {
+            runCatching {
+                if (roomStore.readIfRoomPrimary() == null) {
+                    roomStore.importLegacyAndPromote(
+                        stats = current.stats,
+                        dailyStats = current.dailyStats,
+                        counterSnapshot = current.counterSnapshot,
+                        counterEpochStartedAt = current.counterEpochStartedAt,
+                        clearedAt = current.clearedAt
+                    )
+                }
+                val roomSnapshot = roomStore.readIfRoomPrimary()
+                    ?.toPersistenceSnapshot()
+                    ?: return@runCatching null
+                mergePlaybackStatsRoomRecovery(
+                    roomSnapshot = roomSnapshot,
+                    recoveryBaseline = baseline,
+                    currentSnapshot = current
+                ).also { merged ->
+                    roomStore.writeIncremental(
+                        previousStats = roomSnapshot.stats,
+                        nextStats = merged.stats,
+                        previousDailyStats = roomSnapshot.dailyStats,
+                        nextDailyStats = merged.dailyStats,
+                        previousCounterSnapshot = roomSnapshot.counterSnapshot,
+                        counterSnapshot = merged.counterSnapshot,
+                        counterEpochStartedAt = merged.counterEpochStartedAt,
+                        clearedAt = merged.clearedAt
+                    )
+                }
+            }.onFailure { error ->
+                NPLogger.e(
+                    "PlaybackStatsRepo",
+                    "Failed to recover Room playback stats without replaying JSON",
+                    error
+                )
+            }.getOrNull()
+        }
+        if (recovered == null) {
+            scheduleRoomRecovery()
+            return
+        }
+
+        roomStorageEnabled = true
+        roomRecoveryBaseline = null
+        persistedSnapshot = recovered
+        _stats.value = recovered.stats
+        _dailyStats.value = recovered.dailyStats
+        _statsClearedAt.value = recovered.clearedAt
+        counterStore.replaceFromRoom(
+            snapshot = recovered.counterSnapshot,
+            epochStartedAt = recovered.counterEpochStartedAt
+        )
+        persistenceDirty = false
+        markPersistenceClean(expectedGeneration = null)
+        LegacyJsonCleanupScheduler.schedule(app, "playback-stats-room-recovery")
+        triggerPendingSyncAfterPersistence()
     }
 
     private fun markPersistenceClean(expectedGeneration: Long?) {

--- a/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/stats/PlaybackStatsRepository.kt
@@ -14,6 +14,10 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.runBlocking
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.PlaybackStatsRoomSnapshot
+import moe.ouom.neriplayer.data.local.database.store.PlaybackStatsRoomStore
 import moe.ouom.neriplayer.data.model.stableKey
 import moe.ouom.neriplayer.data.sync.github.GitHubSyncWorker
 import moe.ouom.neriplayer.data.sync.github.SyncPlaybackStatMapper
@@ -47,6 +51,25 @@ data class TrackStat(
     val identityKey: String
 )
 
+private data class PlaybackStatsPersistenceSnapshot(
+    val stats: List<TrackStat>,
+    val dailyStats: List<PlaybackStatBucket>,
+    val counterSnapshot: PlaybackStatsSyncCounterSnapshot,
+    val counterEpochStartedAt: Long,
+    val clearedAt: Long
+)
+
+private fun PlaybackStatsRoomSnapshot.toPersistenceSnapshot():
+    PlaybackStatsPersistenceSnapshot {
+    return PlaybackStatsPersistenceSnapshot(
+        stats = stats,
+        dailyStats = dailyStats,
+        counterSnapshot = counterSnapshot,
+        counterEpochStartedAt = counterEpochStartedAt,
+        clearedAt = clearedAt
+    )
+}
+
 private data class PlaybackStatsMetadata(
     val clearedAt: Long = 0L
 )
@@ -61,20 +84,84 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
     private val metadataFile: File by lazy { File(app.filesDir, "playback_stats_meta.json") }
     private val mutex = Mutex()
     private val persistFileMutex = Mutex()
+    private val roomPersistenceMutex = Mutex()
+    private val legacyProjectionMutex = Mutex()
+    private var legacyProjectionGeneration = 0L
     private var persistJob: Job? = null
     private var persistGeneration = 0L
     private var pendingPersistence: PlaybackStatsPersistenceSnapshot? = null
     private var persistenceDirty = false
-    private val counterStore by lazy { PlaybackStatsCounterStore(app, gson) }
-    private val _stats = MutableStateFlow(loadFromDisk())
-    private val _statsClearedAt = MutableStateFlow(loadMetadata().clearedAt)
-    private val _dailyStats = MutableStateFlow(loadDailyStatsFromDisk())
+    private val counterStore = PlaybackStatsCounterStore(app, gson)
+    private val roomStore = PlaybackStatsRoomStore(
+        NeriUserDataDatabase.getInstance(app.applicationContext)
+    )
+    @Volatile
+    private var roomStorageEnabled = true
+    private val initialState = loadInitialState()
+    private val _stats = MutableStateFlow(initialState.stats)
+    private val _statsClearedAt = MutableStateFlow(initialState.clearedAt)
+    private val _dailyStats = MutableStateFlow(initialState.dailyStats)
+    private var persistedSnapshot = initialState
     val statsFlow: StateFlow<List<TrackStat>> = _stats
     val dailyStatsFlow: StateFlow<List<PlaybackStatBucket>> = _dailyStats
     val statsClearedAtFlow: StateFlow<Long> = _statsClearedAt
 
     init {
         reconcileLoadedStats()
+    }
+
+    private fun loadInitialState(): PlaybackStatsPersistenceSnapshot {
+        val roomSnapshot = runCatching {
+            runBlocking { roomStore.readIfRoomPrimary() }
+        }.onFailure { error ->
+            roomStorageEnabled = false
+            NPLogger.e(
+                "PlaybackStatsRepo",
+                "Failed to read Room playback stats",
+                error
+            )
+        }.getOrNull()
+        if (roomSnapshot != null) {
+            counterStore.replaceFromRoom(
+                snapshot = roomSnapshot.counterSnapshot,
+                epochStartedAt = roomSnapshot.counterEpochStartedAt
+            )
+            return roomSnapshot.toPersistenceSnapshot()
+        }
+
+        val clearedAt = loadMetadata().clearedAt
+        val stats = loadFromDisk()
+        val dailyStats = loadDailyStatsFromDisk(
+            stats = stats,
+            clearedAt = clearedAt
+        )
+        val legacyState = PlaybackStatsPersistenceSnapshot(
+            stats = stats,
+            dailyStats = dailyStats,
+            counterSnapshot = counterStore.snapshot(),
+            counterEpochStartedAt = counterStore.epochStartedAt(),
+            clearedAt = clearedAt
+        )
+        runCatching {
+            runBlocking {
+                roomStore.importLegacyAndPromote(
+                    stats = legacyState.stats,
+                    dailyStats = legacyState.dailyStats,
+                    counterSnapshot = legacyState.counterSnapshot,
+                    counterEpochStartedAt = legacyState.counterEpochStartedAt,
+                    clearedAt = legacyState.clearedAt
+                )
+            }
+            roomStorageEnabled = true
+        }.onFailure { error ->
+            roomStorageEnabled = false
+            NPLogger.e(
+                "PlaybackStatsRepo",
+                "Failed to promote playback stats JSON to Room",
+                error
+            )
+        }
+        return legacyState
     }
 
     private fun reconcileLoadedStats() {
@@ -109,10 +196,7 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
         scope.launch {
             mutex.withLock {
                 persistSnapshot(
-                    PlaybackStatsPersistenceSnapshot(
-                        stats = _stats.value,
-                        dailyStats = _dailyStats.value
-                    )
+                    currentPersistenceSnapshot()
                 )
             }
         }
@@ -175,12 +259,15 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
         }
     }
 
-    private fun loadDailyStatsFromDisk(): List<PlaybackStatBucket> {
+    private fun loadDailyStatsFromDisk(
+        stats: List<TrackStat>,
+        clearedAt: Long
+    ): List<PlaybackStatBucket> {
         return try {
             if (!dailyFile.exists()) {
                 val migrated = buildLegacyDailyStats(
-                    stats = _stats.value,
-                    clearedAt = _statsClearedAt.value
+                    stats = stats,
+                    clearedAt = clearedAt
                 )
                 if (migrated.isNotEmpty()) {
                     persistDailyStatsToDisk(migrated)
@@ -213,24 +300,27 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
         }.getOrDefault(false)
     }
 
-    private fun persistMetadata(clearedAt: Long) {
-        runCatching {
+    private fun persistMetadata(clearedAt: Long): Boolean {
+        return runCatching {
             metadataFile.writeTextAtomically(gson.toJson(PlaybackStatsMetadata(clearedAt)))
+            true
         }.onFailure { error ->
             NPLogger.e("PlaybackStatsRepo", "Failed to persist stats metadata", error)
-        }
+        }.getOrDefault(false)
     }
 
-    private data class PlaybackStatsPersistenceSnapshot(
-        val stats: List<TrackStat>,
-        val dailyStats: List<PlaybackStatBucket>
-    )
+    private fun currentPersistenceSnapshot(): PlaybackStatsPersistenceSnapshot {
+        return PlaybackStatsPersistenceSnapshot(
+            stats = _stats.value,
+            dailyStats = _dailyStats.value,
+            counterSnapshot = counterStore.snapshot(),
+            counterEpochStartedAt = counterStore.epochStartedAt(),
+            clearedAt = _statsClearedAt.value
+        )
+    }
 
     private fun schedulePersistenceLocked() {
-        pendingPersistence = PlaybackStatsPersistenceSnapshot(
-            stats = _stats.value,
-            dailyStats = _dailyStats.value
-        )
+        pendingPersistence = currentPersistenceSnapshot()
         persistenceDirty = true
         persistGeneration += 1L
         val generation = persistGeneration
@@ -262,14 +352,83 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
         snapshot: PlaybackStatsPersistenceSnapshot,
         expectedGeneration: Long? = null
     ) {
-        val succeeded = persistFileMutex.withLock {
-            persistToDisk(snapshot.stats) && persistDailyStatsToDisk(snapshot.dailyStats)
-        }
-        if (succeeded) {
-            synchronized(this) {
-                if (expectedGeneration == null || expectedGeneration == persistGeneration) {
-                    persistenceDirty = false
+        roomPersistenceMutex.withLock {
+            if (roomStorageEnabled) {
+                val roomSucceeded = runCatching {
+                    roomStore.writeIncremental(
+                        previousStats = persistedSnapshot.stats,
+                        nextStats = snapshot.stats,
+                        previousDailyStats = persistedSnapshot.dailyStats,
+                        nextDailyStats = snapshot.dailyStats,
+                        previousCounterSnapshot = persistedSnapshot.counterSnapshot,
+                        counterSnapshot = snapshot.counterSnapshot,
+                        counterEpochStartedAt = snapshot.counterEpochStartedAt,
+                        clearedAt = snapshot.clearedAt
+                    )
+                }.onFailure { error ->
+                    roomStorageEnabled = false
+                    NPLogger.e(
+                        "PlaybackStatsRepo",
+                        "Failed to write Room playback stats",
+                        error
+                    )
+                }.isSuccess
+                if (roomSucceeded) {
+                    persistedSnapshot = snapshot
+                    enqueueLegacyProjection(snapshot)
+                    markPersistenceClean(expectedGeneration)
+                    return@withLock
                 }
+            }
+            val legacySucceeded = persistLegacySnapshot(snapshot)
+            if (legacySucceeded) {
+                runCatching { roomStore.markLegacyJsonPrimary() }
+                    .onFailure { error ->
+                        NPLogger.e(
+                            "PlaybackStatsRepo",
+                            "Failed to mark playback stats JSON fallback state",
+                            error
+                        )
+                    }
+                persistedSnapshot = snapshot
+                markPersistenceClean(expectedGeneration)
+            }
+        }
+    }
+
+    private fun markPersistenceClean(expectedGeneration: Long?) {
+        synchronized(this) {
+            if (expectedGeneration == null || expectedGeneration == persistGeneration) {
+                persistenceDirty = false
+            }
+        }
+    }
+
+    private fun persistLegacySnapshot(
+        snapshot: PlaybackStatsPersistenceSnapshot
+    ): Boolean {
+        return synchronized(persistFileMutex) {
+            persistToDisk(snapshot.stats) &&
+                persistDailyStatsToDisk(snapshot.dailyStats) &&
+                persistMetadata(snapshot.clearedAt) &&
+                counterStore.persistLegacyProjection()
+        }
+    }
+
+    private fun enqueueLegacyProjection(
+        snapshot: PlaybackStatsPersistenceSnapshot
+    ) {
+        val generation = synchronized(this) {
+            legacyProjectionGeneration += 1L
+            legacyProjectionGeneration
+        }
+        scope.launch {
+            legacyProjectionMutex.withLock {
+                val isLatest = synchronized(this@PlaybackStatsRepository) {
+                    generation == legacyProjectionGeneration
+                }
+                if (!isLatest) return@withLock
+                persistLegacySnapshot(snapshot)
             }
         }
     }
@@ -281,20 +440,14 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
     }
 
     suspend fun flushPendingWrites() {
-        mutex.withLock {
+        mutex.withLock<Unit> {
             val shouldPersist = synchronized(this@PlaybackStatsRepository) {
                 persistenceDirty || pendingPersistence != null || persistJob?.isActive == true
             }
             cancelScheduledPersistenceLocked()
             if (shouldPersist) {
-                persistSnapshot(
-                    PlaybackStatsPersistenceSnapshot(
-                        stats = _stats.value,
-                        dailyStats = _dailyStats.value
-                    )
-                )
+                persistSnapshot(currentPersistenceSnapshot())
             }
-            counterStore.flushPendingWrites()
         }
     }
 
@@ -491,11 +644,9 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                 _dailyStats.value = emptyList()
                 _statsClearedAt.value = clearedAt
                 cancelScheduledPersistenceLocked()
-                val statsSaved = persistToDisk(emptyList())
-                val dailyStatsSaved = persistDailyStatsToDisk(emptyList())
-                persistenceDirty = !(statsSaved && dailyStatsSaved)
-                persistMetadata(clearedAt)
                 counterStore.reset(clearedAt)
+                persistenceDirty = true
+                persistSnapshot(currentPersistenceSnapshot())
                 triggerSync()
             }
         }
@@ -510,10 +661,9 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
                 _stats.value = updated
                 _dailyStats.value = updatedDailyStats
                 cancelScheduledPersistenceLocked()
-                val statsSaved = persistToDisk(updated)
-                val dailyStatsSaved = persistDailyStatsToDisk(updatedDailyStats)
-                persistenceDirty = !(statsSaved && dailyStatsSaved)
                 counterStore.removeTracks(keys)
+                persistenceDirty = true
+                persistSnapshot(currentPersistenceSnapshot())
                 triggerSync()
             }
         }
@@ -594,17 +744,15 @@ class PlaybackStatsRepository private constructor(private val app: Context) {
             }
             if (shouldUpdateClearBarrier) {
                 _statsClearedAt.value = effectiveClearedAt
-                persistMetadata(effectiveClearedAt)
             }
             cancelScheduledPersistenceLocked()
-            val statsSaved = persistToDisk(updated)
-            val dailyStatsSaved = persistDailyStatsToDisk(updatedDailyStats)
-            persistenceDirty = !(statsSaved && dailyStatsSaved)
             counterStore.replaceFromSync(
                 syncStats = finalized.stats,
                 syncDailyStats = finalized.buckets,
                 epochStartedAt = effectiveClearedAt
             )
+            persistenceDirty = true
+            persistSnapshot(currentPersistenceSnapshot())
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/storage/StorageUsageAnalyzer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/storage/StorageUsageAnalyzer.kt
@@ -384,6 +384,7 @@ private fun File.isUnder(root: File): Boolean {
 private fun platformCacheDirs(filesDir: File): List<File> {
     return listOf(
         File(filesDir, DIR_BILI_FAVORITE_CACHE),
+        File(filesDir, DIR_BILI_ARCHIVE_CACHE),
         File(filesDir, DIR_NETEASE_PLAYLIST_CACHE),
         File(filesDir, DIR_YOUTUBE_PLAYLIST_CACHE)
     )
@@ -426,6 +427,7 @@ private const val DIR_SHARED_MEDIA_EXPORTS = "shared_media_exports"
 private const val DIR_DOWNLOAD_ROOT = "NeriPlayer"
 private const val DIR_DOWNLOAD_LYRICS = "Lyrics"
 private const val DIR_BILI_FAVORITE_CACHE = "bili_favorite_cache"
+private const val DIR_BILI_ARCHIVE_CACHE = "bili_archive_cache"
 private const val DIR_NETEASE_PLAYLIST_CACHE = "netease_playlist_cache"
 private const val DIR_YOUTUBE_PLAYLIST_CACHE = "youtube_music_playlist_cache"
 private const val DIR_LOCAL_AUDIO_COVERS = "local_audio_covers"

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/CoverUrlMapper.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/CoverUrlMapper.kt
@@ -26,55 +26,31 @@ package moe.ouom.neriplayer.data.sync
 import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import moe.ouom.neriplayer.data.local.media.LocalSongSupport
-import moe.ouom.neriplayer.core.logging.NPLogger
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.CoverUrlMappingRoomStore
+import moe.ouom.neriplayer.data.local.media.LocalSongSupport
+
+private const val COVER_URL_MAPPER_TAG = "CoverUrlMapper"
 
 /**
  * 封面地址映射管理器
  * 维护本地地址和网络地址的映射关系
  * 用于同步时将本地地址转换为网络地址
  */
-class CoverUrlMapper private constructor(private val storageDir: File) {
-
-    private val gson = Gson()
-    private val file: File = File(storageDir, "cover_url_mapping.json")
-
-    // 本地地址 -> 网络地址的映射
-    private val mapping = java.util.concurrent.ConcurrentHashMap<String, String>()
+class CoverUrlMapper private constructor(
+    private val store: CoverUrlMappingStore
+) {
+    private val mapping = ConcurrentHashMap<String, String>()
 
     init {
-        loadFromDisk()
-    }
-
-    private fun loadFromDisk() {
-        try {
-            if (file.exists()) {
-                val type = object : TypeToken<Map<String, String>>() {}.type
-                val loaded = gson.fromJson<Map<String, String>>(file.readText(), type)
-                if (loaded != null) {
-                    mapping.putAll(loaded)
-                    NPLogger.d(TAG, "Loaded ${mapping.size} cover URL mappings")
-                }
-            }
-        } catch (e: Exception) {
-            NPLogger.e(TAG, "Failed to load cover URL mappings", e)
-        }
-    }
-
-    private fun saveToDisk() {
-        try {
-            val json = gson.toJson(mapping)
-            val parent = file.parentFile ?: storageDir
-            val tmp = File(parent, file.name + ".tmp")
-            tmp.writeText(json)
-            if (!tmp.renameTo(file)) {
-                file.writeText(json)
-                tmp.delete()
-            }
-        } catch (e: Exception) {
-            NPLogger.e(TAG, "Failed to save cover URL mappings", e)
-        }
+        mapping.putAll(store.load())
+        NPLogger.d(COVER_URL_MAPPER_TAG, "Loaded ${mapping.size} cover URL mappings")
     }
 
     /**
@@ -87,8 +63,8 @@ class CoverUrlMapper private constructor(private val storageDir: File) {
         if (!isLocalUrl(localUrl)) return
 
         mapping[localUrl] = networkUrl
-        saveToDisk()
-        NPLogger.d(TAG, "Saved cover mapping: $localUrl -> $networkUrl")
+        store.save(localUrl, networkUrl)
+        NPLogger.d(COVER_URL_MAPPER_TAG, "Saved cover mapping: $localUrl -> $networkUrl")
     }
 
     /**
@@ -137,8 +113,8 @@ class CoverUrlMapper private constructor(private val storageDir: File) {
 
         if (toRemove.isNotEmpty()) {
             toRemove.forEach { mapping.remove(it) }
-            saveToDisk()
-            NPLogger.d(TAG, "Cleaned up ${toRemove.size} invalid mappings")
+            store.delete(toRemove)
+            NPLogger.d(COVER_URL_MAPPER_TAG, "Cleaned up ${toRemove.size} invalid mappings")
         }
     }
 
@@ -149,16 +125,148 @@ class CoverUrlMapper private constructor(private val storageDir: File) {
     }
 
     companion object {
-        private const val TAG = "CoverUrlMapper"
+        private const val FILE_NAME = "cover_url_mapping.json"
 
         @Volatile
         private var instance: CoverUrlMapper? = null
 
         fun getInstance(context: Context): CoverUrlMapper {
-            val storageDir = context.applicationContext?.filesDir ?: context.filesDir
+            val appContext = context.applicationContext ?: context
             return instance ?: synchronized(this) {
-                instance ?: CoverUrlMapper(storageDir).also { instance = it }
+                instance ?: CoverUrlMapper(
+                    RoomCoverUrlMappingStore(appContext, FILE_NAME)
+                ).also { instance = it }
+            }
+        }
+
+        internal fun createForTest(
+            initialMappings: Map<String, String> = emptyMap()
+        ): CoverUrlMapper {
+            return CoverUrlMapper(InMemoryCoverUrlMappingStore(initialMappings))
+        }
+
+        internal fun installForTest(mapper: CoverUrlMapper?) {
+            synchronized(this) {
+                instance = mapper
             }
         }
     }
+}
+
+internal interface CoverUrlMappingStore {
+    fun load(): Map<String, String>
+
+    fun save(localUrl: String, networkUrl: String)
+
+    fun delete(localUrls: Collection<String>)
+}
+
+private class RoomCoverUrlMappingStore(
+    context: Context,
+    fileName: String
+) : CoverUrlMappingStore {
+    private val appContext = context.applicationContext ?: context
+    private val roomStore = CoverUrlMappingRoomStore(
+        NeriUserDataDatabase.getInstance(appContext)
+    )
+    private val gson = Gson()
+    private val legacyFile = File(appContext.filesDir, fileName)
+    private val legacyType = object : TypeToken<Map<String, String?>>() {}.type
+
+    @Volatile
+    private var cleanupEligible = true
+
+    override fun load(): Map<String, String> {
+        return runBlocking(Dispatchers.IO) {
+            roomStore.readIfRoomPrimary()?.also {
+                LegacyJsonCleanupScheduler.schedule(appContext, "cover-url-mapping-room-load")
+                return@runBlocking it
+            }
+
+            when (val legacy = readLegacyMappings()) {
+                is LegacyMappingLoadResult.Missing -> emptyMap()
+                is LegacyMappingLoadResult.Loaded -> {
+                    cleanupEligible = true
+                    roomStore.importLegacyAndPromote(
+                        mappings = legacy.mappings,
+                        cleanupEligible = true
+                    )
+                    LegacyJsonCleanupScheduler.schedule(appContext, "cover-url-mapping-import")
+                    legacy.mappings
+                }
+                is LegacyMappingLoadResult.Failed -> {
+                    cleanupEligible = false
+                    NPLogger.e(
+                        COVER_URL_MAPPER_TAG,
+                        "Failed to import cover URL mappings",
+                        legacy.error
+                    )
+                    emptyMap()
+                }
+            }
+        }
+    }
+
+    override fun save(localUrl: String, networkUrl: String) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.upsert(
+                localUrl = localUrl,
+                networkUrl = networkUrl,
+                cleanupEligible = cleanupEligible
+            )
+        }
+    }
+
+    override fun delete(localUrls: Collection<String>) {
+        runBlocking(Dispatchers.IO) {
+            roomStore.delete(
+                localUrls = localUrls,
+                cleanupEligible = cleanupEligible
+            )
+        }
+    }
+
+    private fun readLegacyMappings(): LegacyMappingLoadResult {
+        if (!legacyFile.exists()) return LegacyMappingLoadResult.Missing
+        return runCatching {
+            val loaded = gson.fromJson<Map<String, String?>>(
+                legacyFile.readText(Charsets.UTF_8),
+                legacyType
+            ).orEmpty()
+            val mappings = loaded.mapNotNull { (localUrl, networkUrl) ->
+                if (localUrl.isBlank() || networkUrl.isNullOrBlank()) {
+                    null
+                } else {
+                    localUrl to networkUrl
+                }
+            }.toMap()
+            LegacyMappingLoadResult.Loaded(mappings)
+        }.getOrElse { error ->
+            LegacyMappingLoadResult.Failed(error)
+        }
+    }
+}
+
+private class InMemoryCoverUrlMappingStore(
+    initialMappings: Map<String, String>
+) : CoverUrlMappingStore {
+    private val mappings = ConcurrentHashMap(initialMappings)
+
+    override fun load(): Map<String, String> = mappings.toMap()
+
+    override fun save(localUrl: String, networkUrl: String) {
+        mappings[localUrl] = networkUrl
+    }
+
+    override fun delete(localUrls: Collection<String>) {
+        localUrls.forEach(mappings::remove)
+    }
+}
+
+private sealed interface LegacyMappingLoadResult {
+    data object Missing : LegacyMappingLoadResult
+
+    data class Loaded(val mappings: Map<String, String>) : LegacyMappingLoadResult
+
+    data class Failed(val error: Throwable) : LegacyMappingLoadResult
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/CoverUrlMapper.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/CoverUrlMapper.kt
@@ -178,7 +178,19 @@ private class RoomCoverUrlMappingStore(
 
     override fun load(): Map<String, String> {
         return runBlocking(Dispatchers.IO) {
-            roomStore.readIfRoomPrimary()?.also {
+            val roomRead = runCatching { roomStore.readIfRoomPrimary() }
+                .onFailure { error ->
+                    cleanupEligible = false
+                    NPLogger.e(
+                        COVER_URL_MAPPER_TAG,
+                        "Failed to read cover URL mappings from Room",
+                        error
+                    )
+                }
+            if (roomRead.isFailure) {
+                return@runBlocking emptyMap()
+            }
+            roomRead.getOrNull()?.also {
                 LegacyJsonCleanupScheduler.schedule(appContext, "cover-url-mapping-room-load")
                 return@runBlocking it
             }
@@ -208,21 +220,29 @@ private class RoomCoverUrlMappingStore(
     }
 
     override fun save(localUrl: String, networkUrl: String) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.upsert(
-                localUrl = localUrl,
-                networkUrl = networkUrl,
-                cleanupEligible = cleanupEligible
-            )
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.upsert(
+                    localUrl = localUrl,
+                    networkUrl = networkUrl,
+                    cleanupEligible = cleanupEligible
+                )
+            }
+        }.onFailure { error ->
+            NPLogger.w(COVER_URL_MAPPER_TAG, "Failed to save cover URL mapping", error)
         }
     }
 
     override fun delete(localUrls: Collection<String>) {
-        runBlocking(Dispatchers.IO) {
-            roomStore.delete(
-                localUrls = localUrls,
-                cleanupEligible = cleanupEligible
-            )
+        runCatching {
+            runBlocking(Dispatchers.IO) {
+                roomStore.delete(
+                    localUrls = localUrls,
+                    cleanupEligible = cleanupEligible
+                )
+            }
+        }.onFailure { error ->
+            NPLogger.w(COVER_URL_MAPPER_TAG, "Failed to delete cover URL mappings", error)
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/github/GitHubSyncManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/github/GitHubSyncManager.kt
@@ -117,6 +117,11 @@ class GitHubSyncManager private constructor(context: Context) {
         }
 
         try {
+            if (!storage.isConfigured()) {
+                return@withContext Result.failure(
+                    IllegalStateException(localizedContext.getString(R.string.github_not_configured))
+                )
+            }
             val token = storage.getToken()
             val owner = storage.getRepoOwner()
             val repo = storage.getRepoName()

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SecureTokenStorage.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SecureTokenStorage.kt
@@ -113,6 +113,7 @@ class SecureTokenStorage(private val context: Context) {
     /** 保存设备ID */
     fun saveDeviceId(deviceId: String) {
         require(deviceId.isNotBlank()) { "Device ID must not be blank" }
+        check(encryptedPrefs.isDurable) { "Refusing to persist sync device state without durable storage" }
         synchronized(syncCausalTokenLock) {
             val deviceChanged = getDeviceId() != deviceId
             check(
@@ -144,6 +145,9 @@ class SecureTokenStorage(private val context: Context) {
     fun nextSyncCausalTokens(count: Int): List<SyncCausalToken> {
         require(count >= 0) { "Token count must not be negative" }
         if (count == 0) return emptyList()
+        check(encryptedPrefs.isDurable) {
+            "Refusing to allocate sync causal tokens without durable storage"
+        }
 
         return synchronized(syncCausalTokenLock) {
             val deviceId = getOrCreateDeviceId()
@@ -325,6 +329,9 @@ class SecureTokenStorage(private val context: Context) {
         clearedPlaylistDeletionIds: List<Long>,
         restoredPlaylistIds: Set<Long>
     ): Long {
+        check(encryptedPrefs.isDurable) {
+            "Refusing to persist playlist sync mutation without durable storage"
+        }
         synchronized(syncMutationLock) {
             var playlistDeletions = getPlaylistSongDeletions()
             if (addedSongDeletions.isNotEmpty()) {

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SecureTokenStorage.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SecureTokenStorage.kt
@@ -29,18 +29,16 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.annotation.SuppressLint
 import androidx.core.content.edit
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import moe.ouom.neriplayer.data.config.GitHubSyncConfigSnapshot
 import moe.ouom.neriplayer.data.model.SongIdentity
-import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.sync.DEFAULT_SYNC_AUTO_ENABLED
 import moe.ouom.neriplayer.data.sync.PlayHistoryUpdateMode
 import moe.ouom.neriplayer.data.sync.model.SyncCausalToken
 import moe.ouom.neriplayer.data.sync.model.SyncPlaylistSongDeletion
 import moe.ouom.neriplayer.data.sync.model.SyncRecentPlayDeletion
+import moe.ouom.neriplayer.util.security.RecoveringEncryptedSharedPreferences
 import java.util.UUID
 
 /**
@@ -50,7 +48,11 @@ import java.util.UUID
 class SecureTokenStorage(private val context: Context) {
     private val gson = Gson()
 
-    private val encryptedPrefs: SharedPreferences = openEncryptedPrefsWithRecovery()
+    private val encryptedPrefs = RecoveringEncryptedSharedPreferences(
+        context = context,
+        storageName = PREFS_NAME,
+        logTag = "NERI-SecureTokenStorage"
+    )
 
     companion object {
         private const val PREFS_NAME = "github_secure_prefs"
@@ -73,45 +75,6 @@ class SecureTokenStorage(private val context: Context) {
         private const val MAX_RECENT_PLAY_DELETIONS = 500
         private val syncMutationLock = Any()
         private val syncCausalTokenLock = Any()
-    }
-
-    private fun openEncryptedPrefsWithRecovery(): SharedPreferences {
-        return runCatching {
-            createEncryptedPrefs()
-        }.getOrElse { error ->
-            NPLogger.w(
-                "NERI-SecureTokenStorage",
-                "Failed to open GitHub secure prefs, clearing storage and recreating.",
-                error
-            )
-            clearEncryptedStorage()
-            createEncryptedPrefs()
-        }
-    }
-
-    private fun createEncryptedPrefs(): SharedPreferences {
-        val masterKey = MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-        return EncryptedSharedPreferences.create(
-            context,
-            PREFS_NAME,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
-    }
-
-    private fun clearEncryptedStorage() {
-        runCatching {
-            context.deleteSharedPreferences(PREFS_NAME)
-        }.onFailure { error ->
-            NPLogger.w(
-                "NERI-SecureTokenStorage",
-                "Failed to delete corrupted GitHub secure prefs file.",
-                error
-            )
-        }
     }
 
     /** 保存GitHub Token */
@@ -252,7 +215,8 @@ class SecureTokenStorage(private val context: Context) {
 
     /** 检查是否已配置 */
     fun isConfigured(): Boolean {
-        return !getToken().isNullOrEmpty() &&
+        return encryptedPrefs.isDurable &&
+               !getToken().isNullOrEmpty() &&
                !getRepoOwner().isNullOrEmpty() &&
                !getRepoName().isNullOrEmpty()
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/webdav/WebDavStorage.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/webdav/WebDavStorage.kt
@@ -3,16 +3,17 @@
 package moe.ouom.neriplayer.data.sync.webdav
 
 import android.content.Context
-import android.content.SharedPreferences
 import androidx.core.content.edit
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKey
 import moe.ouom.neriplayer.data.config.WebDavSyncConfigSnapshot
-import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.sync.DEFAULT_SYNC_AUTO_ENABLED
+import moe.ouom.neriplayer.util.security.RecoveringEncryptedSharedPreferences
 
 class WebDavStorage(private val context: Context) {
-    private val encryptedPrefs: SharedPreferences = openEncryptedPrefsWithRecovery()
+    private val encryptedPrefs = RecoveringEncryptedSharedPreferences(
+        context = context,
+        storageName = PREFS_NAME,
+        logTag = "NERI-WebDavStorage"
+    )
 
     companion object {
         private const val PREFS_NAME = "webdav_secure_prefs"
@@ -23,45 +24,6 @@ class WebDavStorage(private val context: Context) {
         private const val KEY_LAST_SYNC_TIME = "last_sync_time"
         private const val KEY_AUTO_SYNC_ENABLED = "auto_sync_enabled"
         private const val KEY_LAST_REMOTE_FINGERPRINT = "last_remote_fingerprint"
-    }
-
-    private fun openEncryptedPrefsWithRecovery(): SharedPreferences {
-        return runCatching {
-            createEncryptedPrefs()
-        }.getOrElse { error ->
-            NPLogger.w(
-                "NERI-WebDavStorage",
-                "Failed to open WebDAV secure prefs, clearing storage and recreating.",
-                error
-            )
-            clearEncryptedStorage()
-            createEncryptedPrefs()
-        }
-    }
-
-    private fun createEncryptedPrefs(): SharedPreferences {
-        val masterKey = MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-        return EncryptedSharedPreferences.create(
-            context,
-            PREFS_NAME,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
-    }
-
-    private fun clearEncryptedStorage() {
-        runCatching {
-            context.deleteSharedPreferences(PREFS_NAME)
-        }.onFailure { error ->
-            NPLogger.w(
-                "NERI-WebDavStorage",
-                "Failed to delete corrupted WebDAV secure prefs file.",
-                error
-            )
-        }
     }
 
     fun saveConfiguration(
@@ -112,7 +74,8 @@ class WebDavStorage(private val context: Context) {
         encryptedPrefs.getString(KEY_LAST_REMOTE_FINGERPRINT, null)
 
     fun isConfigured(): Boolean {
-        return !getServerUrl().isNullOrBlank() &&
+        return encryptedPrefs.isDurable &&
+            !getServerUrl().isNullOrBlank() &&
             !getUsername().isNullOrBlank() &&
             !getPassword().isNullOrBlank()
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/webdav/WebDavSyncManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/webdav/WebDavSyncManager.kt
@@ -125,6 +125,11 @@ class WebDavSyncManager private constructor(context: Context) {
         }
 
         try {
+            if (!webDavStorage.isConfigured()) {
+                return@withContext Result.failure(
+                    IllegalStateException(localizedContext.getString(R.string.webdav_not_configured))
+                )
+            }
             val remoteUrl = webDavStorage.getRemoteFileUrl()
             val username = webDavStorage.getUsername()
             val password = webDavStorage.getPassword()

--- a/app/src/main/java/moe/ouom/neriplayer/data/traffic/TrafficStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/traffic/TrafficStatsRepository.kt
@@ -19,7 +19,6 @@ import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.store.TrafficStatsRoomStore
 import moe.ouom.neriplayer.data.stats.playbackStatsDayStartAt
 import moe.ouom.neriplayer.core.logging.NPLogger
-import moe.ouom.neriplayer.util.io.writeTextAtomically
 import moe.ouom.neriplayer.data.traffic.currentTrafficNetworkType
 import java.io.File
 
@@ -40,6 +39,7 @@ class TrafficStatsRepository private constructor(
     private val _dailyStats = MutableStateFlow(initialStats)
     private var persistedStats = initialStats
     private var persistJob: Job? = null
+    private var retryJob: Job? = null
     private var persistGeneration = 0L
 
     val dailyStatsFlow: StateFlow<List<TrafficStatsBucket>> = _dailyStats
@@ -180,8 +180,11 @@ class TrafficStatsRepository private constructor(
                         next = snapshot
                     )
                 }.onFailure {
-                    roomStorageEnabled = false
-                    NPLogger.e(TAG, "Failed to write Room traffic stats", it)
+                    NPLogger.e(
+                        TAG,
+                        "Failed to write Room traffic stats; keeping JSON migration data read-only",
+                        it
+                    )
                 }.isSuccess
                 if (roomSucceeded) {
                     persistedStats = snapshot
@@ -189,26 +192,19 @@ class TrafficStatsRepository private constructor(
                     return@withLock
                 }
             }
-
-            val legacySucceeded = persistDailyStatsToDisk(snapshot)
-            if (legacySucceeded) {
-                runCatching { roomStore.markLegacyJsonPrimary() }
-                    .onFailure {
-                        NPLogger.e(TAG, "Failed to mark traffic stats JSON fallback state", it)
-                    }
-                persistedStats = snapshot
-                markPersistenceClean(expectedGeneration)
-            }
+            scheduleRetry()
         }
     }
 
-    private fun persistDailyStatsToDisk(list: List<TrafficStatsBucket>): Boolean {
-        return runCatching {
-            dailyFile.writeTextAtomically(gson.toJson(list))
-            true
-        }.onFailure {
-            NPLogger.e(TAG, "Failed to persist traffic stats", it)
-        }.getOrDefault(false)
+    private fun scheduleRetry() {
+        if (!roomStorageEnabled || retryJob?.isActive == true) return
+        retryJob = scope.launch {
+            delay(ROOM_RETRY_DELAY_MS)
+            statsMutex.withLock {
+                retryJob = null
+                persistSnapshot(_dailyStats.value)
+            }
+        }
     }
 
     private fun markPersistenceClean(expectedGeneration: Long?) {
@@ -220,6 +216,7 @@ class TrafficStatsRepository private constructor(
     companion object {
         private const val TAG = "TrafficStatsRepo"
         private const val PERSIST_DEBOUNCE_MS = 5_000L
+        private const val ROOM_RETRY_DELAY_MS = 15_000L
 
         @Volatile
         private var instance: TrafficStatsRepository? = null

--- a/app/src/main/java/moe/ouom/neriplayer/data/traffic/TrafficStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/traffic/TrafficStatsRepository.kt
@@ -13,6 +13,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.TrafficStatsRoomStore
 import moe.ouom.neriplayer.data.stats.playbackStatsDayStartAt
 import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.util.io.writeTextAtomically
@@ -25,9 +28,20 @@ class TrafficStatsRepository private constructor(
     private val gson = Gson()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val statsMutex = Mutex()
+    private val persistenceMutex = Mutex()
+    private val legacyProjectionMutex = Mutex()
+    private var legacyProjectionGeneration = 0L
     private val dailyFile: File by lazy { File(app.filesDir, "traffic_stats_daily.json") }
-    private val _dailyStats = MutableStateFlow(loadDailyStatsFromDisk())
+    private val roomStore = TrafficStatsRoomStore(
+        NeriUserDataDatabase.getInstance(app.applicationContext)
+    )
+    @Volatile
+    private var roomStorageEnabled = true
+    private val initialStats = loadInitialStats()
+    private val _dailyStats = MutableStateFlow(initialStats)
+    private var persistedStats = initialStats
     private var persistJob: Job? = null
+    private var persistGeneration = 0L
 
     val dailyStatsFlow: StateFlow<List<TrafficStatsBucket>> = _dailyStats
 
@@ -84,7 +98,8 @@ class TrafficStatsRepository private constructor(
                 persistJob?.cancel()
                 persistJob = null
                 _dailyStats.value = emptyList()
-                runCatching { dailyFile.delete() }
+                persistGeneration += 1L
+                persistSnapshot(emptyList())
             }
         }
     }
@@ -110,30 +125,109 @@ class TrafficStatsRepository private constructor(
     }
 
     private fun schedulePersistLocked(snapshot: List<TrafficStatsBucket>) {
+        persistGeneration += 1L
+        val generation = persistGeneration
         persistJob?.cancel()
         persistJob = scope.launch {
             delay(PERSIST_DEBOUNCE_MS)
-            persistDailyStatsToDisk(snapshot)
+            persistSnapshot(snapshot, generation)
         }
     }
 
-    private fun loadDailyStatsFromDisk(): List<TrafficStatsBucket> {
-        return runCatching {
-            if (!dailyFile.exists()) return emptyList()
-            val type = object : TypeToken<List<TrafficStatsBucket>>() {}.type
-            gson.fromJson<List<TrafficStatsBucket>>(dailyFile.readText(), type).orEmpty()
-                .filter { it.dayStartAt > 0L }
-                .sortedBy { it.dayStartAt }
+    private fun loadInitialStats(): List<TrafficStatsBucket> {
+        val roomStats = runCatching {
+            runBlocking { roomStore.readIfRoomPrimary() }
+        }.onFailure {
+            roomStorageEnabled = false
+            NPLogger.e(TAG, "Failed to read Room traffic stats", it)
+        }.getOrNull()
+        if (roomStats != null) return roomStats
+
+        val legacyStats = runCatching {
+            if (!dailyFile.exists()) {
+                emptyList()
+            } else {
+                val type = object : TypeToken<List<TrafficStatsBucket>>() {}.type
+                gson.fromJson<List<TrafficStatsBucket>>(dailyFile.readText(), type).orEmpty()
+                    .filter { it.dayStartAt > 0L }
+                    .sortedBy { it.dayStartAt }
+            }
         }.onFailure {
             NPLogger.e(TAG, "Failed to load traffic stats", it)
         }.getOrDefault(emptyList())
+        runCatching {
+            runBlocking { roomStore.importLegacyAndPromote(legacyStats) }
+            roomStorageEnabled = true
+        }.onFailure {
+            roomStorageEnabled = false
+            NPLogger.e(TAG, "Failed to promote traffic stats JSON to Room", it)
+        }
+        return legacyStats
     }
 
-    private fun persistDailyStatsToDisk(list: List<TrafficStatsBucket>) {
-        runCatching {
+    private suspend fun persistSnapshot(
+        snapshot: List<TrafficStatsBucket>,
+        expectedGeneration: Long? = null
+    ) {
+        persistenceMutex.withLock {
+            if (roomStorageEnabled) {
+                val roomSucceeded = runCatching {
+                    roomStore.writeIncremental(
+                        previous = persistedStats,
+                        next = snapshot
+                    )
+                }.onFailure {
+                    roomStorageEnabled = false
+                    NPLogger.e(TAG, "Failed to write Room traffic stats", it)
+                }.isSuccess
+                if (roomSucceeded) {
+                    persistedStats = snapshot
+                    enqueueLegacyProjection(snapshot)
+                    markPersistenceClean(expectedGeneration)
+                    return@withLock
+                }
+            }
+
+            val legacySucceeded = persistDailyStatsToDisk(snapshot)
+            if (legacySucceeded) {
+                runCatching { roomStore.markLegacyJsonPrimary() }
+                    .onFailure {
+                        NPLogger.e(TAG, "Failed to mark traffic stats JSON fallback state", it)
+                    }
+                persistedStats = snapshot
+                markPersistenceClean(expectedGeneration)
+            }
+        }
+    }
+
+    private fun persistDailyStatsToDisk(list: List<TrafficStatsBucket>): Boolean {
+        return runCatching {
             dailyFile.writeTextAtomically(gson.toJson(list))
+            true
         }.onFailure {
             NPLogger.e(TAG, "Failed to persist traffic stats", it)
+        }.getOrDefault(false)
+    }
+
+    private fun markPersistenceClean(expectedGeneration: Long?) {
+        if (expectedGeneration == null || expectedGeneration == persistGeneration) {
+            persistJob = null
+        }
+    }
+
+    private fun enqueueLegacyProjection(snapshot: List<TrafficStatsBucket>) {
+        val generation = synchronized(this) {
+            legacyProjectionGeneration += 1L
+            legacyProjectionGeneration
+        }
+        scope.launch {
+            legacyProjectionMutex.withLock {
+                val isLatest = synchronized(this@TrafficStatsRepository) {
+                    generation == legacyProjectionGeneration
+                }
+                if (!isLatest) return@withLock
+                persistDailyStatsToDisk(snapshot)
+            }
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/traffic/TrafficStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/traffic/TrafficStatsRepository.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import moe.ouom.neriplayer.core.startup.LegacyJsonCleanupScheduler
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.store.TrafficStatsRoomStore
 import moe.ouom.neriplayer.data.stats.playbackStatsDayStartAt
@@ -139,7 +140,10 @@ class TrafficStatsRepository private constructor(
             roomStorageEnabled = false
             NPLogger.e(TAG, "Failed to read Room traffic stats", it)
         }.getOrNull()
-        if (roomStats != null) return roomStats
+        if (roomStats != null) {
+            LegacyJsonCleanupScheduler.schedule(app, "traffic-stats-room-load")
+            return roomStats
+        }
 
         val legacyStats = runCatching {
             if (!dailyFile.exists()) {
@@ -155,6 +159,7 @@ class TrafficStatsRepository private constructor(
         }.getOrDefault(emptyList())
         runCatching {
             runBlocking { roomStore.importLegacyAndPromote(legacyStats) }
+            LegacyJsonCleanupScheduler.schedule(app, "traffic-stats-import")
             roomStorageEnabled = true
         }.onFailure {
             roomStorageEnabled = false

--- a/app/src/main/java/moe/ouom/neriplayer/data/traffic/TrafficStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/traffic/TrafficStatsRepository.kt
@@ -35,6 +35,7 @@ class TrafficStatsRepository private constructor(
     )
     @Volatile
     private var roomStorageEnabled = true
+    private var roomRecoveryBaseline: List<TrafficStatsBucket>? = null
     private val initialStats = loadInitialStats()
     private val _dailyStats = MutableStateFlow(initialStats)
     private var persistedStats = initialStats
@@ -43,6 +44,10 @@ class TrafficStatsRepository private constructor(
     private var persistGeneration = 0L
 
     val dailyStatsFlow: StateFlow<List<TrafficStatsBucket>> = _dailyStats
+
+    init {
+        scheduleRoomRecovery()
+    }
 
     fun currentNetworkType(): TrafficNetworkType = app.currentTrafficNetworkType()
 
@@ -134,10 +139,12 @@ class TrafficStatsRepository private constructor(
     }
 
     private fun loadInitialStats(): List<TrafficStatsBucket> {
+        var needsRoomRecovery = false
         val roomStats = runCatching {
             runBlocking { roomStore.readIfRoomPrimary() }
         }.onFailure {
             roomStorageEnabled = false
+            needsRoomRecovery = true
             NPLogger.e(TAG, "Failed to read Room traffic stats", it)
         }.getOrNull()
         if (roomStats != null) {
@@ -157,13 +164,18 @@ class TrafficStatsRepository private constructor(
         }.onFailure {
             NPLogger.e(TAG, "Failed to load traffic stats", it)
         }.getOrDefault(emptyList())
-        runCatching {
-            runBlocking { roomStore.importLegacyAndPromote(legacyStats) }
-            LegacyJsonCleanupScheduler.schedule(app, "traffic-stats-import")
-            roomStorageEnabled = true
-        }.onFailure {
-            roomStorageEnabled = false
-            NPLogger.e(TAG, "Failed to promote traffic stats JSON to Room", it)
+        if (roomStorageEnabled) {
+            runCatching {
+                runBlocking { roomStore.importLegacyAndPromote(legacyStats) }
+                LegacyJsonCleanupScheduler.schedule(app, "traffic-stats-import")
+            }.onFailure {
+                roomStorageEnabled = false
+                needsRoomRecovery = true
+                NPLogger.e(TAG, "Failed to promote traffic stats JSON to Room", it)
+            }
+        }
+        if (needsRoomRecovery) {
+            roomRecoveryBaseline = legacyStats
         }
         return legacyStats
     }
@@ -192,7 +204,11 @@ class TrafficStatsRepository private constructor(
                     return@withLock
                 }
             }
-            scheduleRetry()
+            if (roomStorageEnabled) {
+                scheduleRetry()
+            } else {
+                scheduleRoomRecovery()
+            }
         }
     }
 
@@ -205,6 +221,55 @@ class TrafficStatsRepository private constructor(
                 persistSnapshot(_dailyStats.value)
             }
         }
+    }
+
+    private fun scheduleRoomRecovery() {
+        if (roomStorageEnabled || roomRecoveryBaseline == null || retryJob?.isActive == true) {
+            return
+        }
+        retryJob = scope.launch {
+            delay(ROOM_RETRY_DELAY_MS)
+            statsMutex.withLock {
+                retryJob = null
+                recoverRoomStorage()
+            }
+        }
+    }
+
+    private suspend fun recoverRoomStorage() {
+        val baseline = roomRecoveryBaseline ?: return
+        val recovered = persistenceMutex.withLock {
+            runCatching {
+                if (roomStore.readIfRoomPrimary() == null) {
+                    roomStore.importLegacyAndPromote(_dailyStats.value)
+                }
+                val roomSnapshot = roomStore.readIfRoomPrimary()
+                    ?: return@runCatching null
+                mergeTrafficStatsRoomRecovery(
+                    roomSnapshot = roomSnapshot,
+                    recoveryBaseline = baseline,
+                    currentSnapshot = _dailyStats.value
+                ).also { merged ->
+                    roomStore.writeIncremental(roomSnapshot, merged)
+                }
+            }.onFailure { error ->
+                NPLogger.e(
+                    TAG,
+                    "Failed to recover Room traffic stats without replaying JSON",
+                    error
+                )
+            }.getOrNull()
+        }
+        if (recovered == null) {
+            scheduleRoomRecovery()
+            return
+        }
+
+        roomStorageEnabled = true
+        roomRecoveryBaseline = null
+        persistedStats = recovered
+        _dailyStats.value = recovered
+        LegacyJsonCleanupScheduler.schedule(app, "traffic-stats-room-recovery")
     }
 
     private fun markPersistenceClean(expectedGeneration: Long?) {
@@ -227,4 +292,84 @@ class TrafficStatsRepository private constructor(
             }
         }
     }
+}
+
+internal fun mergeTrafficStatsRoomRecovery(
+    roomSnapshot: List<TrafficStatsBucket>,
+    recoveryBaseline: List<TrafficStatsBucket>,
+    currentSnapshot: List<TrafficStatsBucket>
+): List<TrafficStatsBucket> {
+    if (currentSnapshot.isEmpty() && recoveryBaseline.isNotEmpty()) {
+        return emptyList()
+    }
+    val recovered = roomSnapshot.associateBy(TrafficStatsBucket::dayStartAt).toMutableMap()
+    val baselineByDay = recoveryBaseline.associateBy(TrafficStatsBucket::dayStartAt)
+    val currentByDay = currentSnapshot.associateBy(TrafficStatsBucket::dayStartAt)
+    (baselineByDay.keys + currentByDay.keys).forEach { dayStartAt ->
+        val baseline = baselineByDay[dayStartAt]
+        val current = currentByDay[dayStartAt]
+        when {
+            current == null && baseline != null -> recovered.remove(dayStartAt)
+            current != null && current != baseline -> {
+                recovered[dayStartAt] = mergeTrafficRecoveryBucket(
+                    room = recovered[dayStartAt],
+                    baseline = baseline,
+                    current = current
+                )
+            }
+        }
+    }
+    return recovered.values.sortedBy(TrafficStatsBucket::dayStartAt)
+}
+
+private fun mergeTrafficRecoveryBucket(
+    room: TrafficStatsBucket?,
+    baseline: TrafficStatsBucket?,
+    current: TrafficStatsBucket
+): TrafficStatsBucket {
+    if (room == null || baseline == null) return current
+    return room.copy(
+        wifiBytes = room.wifiBytes.saturatingAdd(
+            current.wifiBytes.positiveDeltaFrom(baseline.wifiBytes)
+        ),
+        mobileBytes = room.mobileBytes.saturatingAdd(
+            current.mobileBytes.positiveDeltaFrom(baseline.mobileBytes)
+        ),
+        roamingBytes = room.roamingBytes.saturatingAdd(
+            current.roamingBytes.positiveDeltaFrom(baseline.roamingBytes)
+        ),
+        playbackNetworkBytes = room.playbackNetworkBytes.saturatingAdd(
+            current.playbackNetworkBytes.positiveDeltaFrom(baseline.playbackNetworkBytes)
+        ),
+        downloadNetworkBytes = room.downloadNetworkBytes.saturatingAdd(
+            current.downloadNetworkBytes.positiveDeltaFrom(baseline.downloadNetworkBytes)
+        ),
+        cacheHitBytes = room.cacheHitBytes.saturatingAdd(
+            current.cacheHitBytes.positiveDeltaFrom(baseline.cacheHitBytes)
+        ),
+        requestCount = room.requestCount.saturatingAdd(
+            current.requestCount.positiveDeltaFrom(baseline.requestCount)
+        ),
+        cacheHitCount = room.cacheHitCount.saturatingAdd(
+            current.cacheHitCount.positiveDeltaFrom(baseline.cacheHitCount)
+        )
+    )
+}
+
+private fun Long.positiveDeltaFrom(baseline: Long): Long {
+    return coerceAtLeast(0L).minus(baseline.coerceAtLeast(0L)).coerceAtLeast(0L)
+}
+
+private fun Int.positiveDeltaFrom(baseline: Int): Int {
+    return coerceAtLeast(0).minus(baseline.coerceAtLeast(0)).coerceAtLeast(0)
+}
+
+private fun Long.saturatingAdd(delta: Long): Long {
+    val base = coerceAtLeast(0L)
+    return if (delta > Long.MAX_VALUE - base) Long.MAX_VALUE else base + delta
+}
+
+private fun Int.saturatingAdd(delta: Int): Int {
+    val base = coerceAtLeast(0)
+    return if (delta > Int.MAX_VALUE - base) Int.MAX_VALUE else base + delta
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/traffic/TrafficStatsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/traffic/TrafficStatsRepository.kt
@@ -29,8 +29,6 @@ class TrafficStatsRepository private constructor(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val statsMutex = Mutex()
     private val persistenceMutex = Mutex()
-    private val legacyProjectionMutex = Mutex()
-    private var legacyProjectionGeneration = 0L
     private val dailyFile: File by lazy { File(app.filesDir, "traffic_stats_daily.json") }
     private val roomStore = TrafficStatsRoomStore(
         NeriUserDataDatabase.getInstance(app.applicationContext)
@@ -182,7 +180,6 @@ class TrafficStatsRepository private constructor(
                 }.isSuccess
                 if (roomSucceeded) {
                     persistedStats = snapshot
-                    enqueueLegacyProjection(snapshot)
                     markPersistenceClean(expectedGeneration)
                     return@withLock
                 }
@@ -212,22 +209,6 @@ class TrafficStatsRepository private constructor(
     private fun markPersistenceClean(expectedGeneration: Long?) {
         if (expectedGeneration == null || expectedGeneration == persistGeneration) {
             persistJob = null
-        }
-    }
-
-    private fun enqueueLegacyProjection(snapshot: List<TrafficStatsBucket>) {
-        val generation = synchronized(this) {
-            legacyProjectionGeneration += 1L
-            legacyProjectionGeneration
-        }
-        scope.launch {
-            legacyProjectionMutex.withLock {
-                val isLatest = synchronized(this@TrafficStatsRepository) {
-                    generation == legacyProjectionGeneration
-                }
-                if (!isLatest) return@withLock
-                persistDailyStatsToDisk(snapshot)
-            }
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
@@ -156,6 +156,7 @@ import moe.ouom.neriplayer.core.player.effects.AudioReactive
 import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.core.player.lifecycle.recoverUsbExclusivePlaybackOnForeground
 import moe.ouom.neriplayer.core.player.lifecycle.updateUsbExclusiveForegroundState
+import moe.ouom.neriplayer.core.player.persistence.setPlaybackSourceRoute
 import moe.ouom.neriplayer.core.player.policy.usb.shouldPromptForUsbExclusiveBackgroundPermission
 import moe.ouom.neriplayer.core.player.service.AudioPlayerService
 import moe.ouom.neriplayer.data.local.media.LocalSongSupport
@@ -1439,6 +1440,11 @@ private fun NeriAppContent(
     var showNowPlaying by rememberSaveable { mutableStateOf(false) }
     var showNowPlayingLyrics by rememberSaveable { mutableStateOf(false) }
     var currentPlaybackSourceRoute by rememberSaveable { mutableStateOf<String?>(null) }
+    val persistedPlaybackSourceRoute by PlayerManager.playbackSourceRouteFlow
+        .collectAsStateWithLifecycle()
+    LaunchedEffect(persistedPlaybackSourceRoute) {
+        currentPlaybackSourceRoute = persistedPlaybackSourceRoute
+    }
     var restoreLyricsAfterAlbumBack by rememberSaveable { mutableStateOf(false) }
     var lyricsAlbumRouteObserved by rememberSaveable { mutableStateOf(false) }
     val devModeEnabled by repo.devModeEnabledFlow.collectAsStateWithLifecycle(initialValue = false)
@@ -2119,6 +2125,7 @@ private fun NeriAppContent(
         restoreLyricsAfterAlbumBack = false
         lyricsAlbumRouteObserved = false
         currentPlaybackSourceRoute = sourceRoute
+        PlayerManager.setPlaybackSourceRoute(sourceRoute)
         PlayerManager.prefetchYouTubePlayableUrlWindow(
             playlist = songs,
             startIndex = index,
@@ -2146,6 +2153,7 @@ private fun NeriAppContent(
         restoreLyricsAfterAlbumBack = false
         lyricsAlbumRouteObserved = false
         currentPlaybackSourceRoute = null
+        PlayerManager.setPlaybackSourceRoute(null)
         PlayerManager.prefetchYouTubePlayableUrlWindow(
             playlist = listOf(song),
             startIndex = 0,
@@ -2185,6 +2193,7 @@ private fun NeriAppContent(
         restoreLyricsAfterAlbumBack = false
         lyricsAlbumRouteObserved = false
         currentPlaybackSourceRoute = sourceRoute
+        PlayerManager.setPlaybackSourceRoute(sourceRoute)
         showNowPlaying = true
         NPLogger.d("NERI-App", "Playing audio from Bili video: ${videos[index].title}")
         PlayerManager.playBiliVideoAsAudio(videos, index)
@@ -2204,6 +2213,7 @@ private fun NeriAppContent(
         restoreLyricsAfterAlbumBack = false
         lyricsAlbumRouteObserved = false
         currentPlaybackSourceRoute = sourceRoute
+        PlayerManager.setPlaybackSourceRoute(sourceRoute)
         showNowPlaying = true
         NPLogger.d("NERI-App", "Playing parts from Bili video: ${videoInfo.title}")
         PlayerManager.playBiliVideoParts(videoInfo, index, coverUrl)

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/host/HomeHostScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/host/HomeHostScreen.kt
@@ -117,6 +117,15 @@ class HomeHostRuntimeState {
     var homeScrollAnchorIndexes by mutableStateOf<Map<String, Int>>(emptyMap())
 }
 
+internal fun resolveHomeUsageEntriesForDisplay(
+    currentEntries: List<UsageEntry>,
+    incomingEntries: List<UsageEntry>,
+    detailOpen: Boolean,
+    snapshotFrozen: Boolean
+): List<UsageEntry> {
+    return if (detailOpen || snapshotFrozen) currentEntries else incomingEntries
+}
+
 @Composable
 fun rememberHomeHostRuntimeState(): HomeHostRuntimeState {
     return remember { HomeHostRuntimeState() }
@@ -166,6 +175,8 @@ fun HomeHostScreen(
         mutableStateOf(null)
     }
     var skipDetailCloseAnimation by rememberSaveable { mutableStateOf(false) }
+    var homeUsageSnapshotFrozen by rememberSaveable { mutableStateOf(false) }
+    var displayedHomeUsageEntries by remember { mutableStateOf(homeUsageEntries) }
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var pendingNeteaseCoverWarmupJob by remember { mutableStateOf<Job?>(null) }
@@ -217,6 +228,7 @@ fun HomeHostScreen(
     }
 
     fun openHomeSelectedItem(item: HomeSelectedItem) {
+        homeUsageSnapshotFrozen = true
         when (item) {
             is HomeSelectedItem.Netease -> {
                 openAfterNeteaseCoverWarmup(item.playlist.picUrl, item)
@@ -235,13 +247,24 @@ fun HomeHostScreen(
     fun closeSelectedDetail() {
         cancelPendingNeteaseCoverWarmup()
         skipDetailCloseAnimation = false
+        homeUsageSnapshotFrozen = false
         selected = null
     }
 
     fun closeDeletedLocalPlaylist() {
         cancelPendingNeteaseCoverWarmup()
         skipDetailCloseAnimation = true
+        homeUsageSnapshotFrozen = false
         selected = null
+    }
+
+    LaunchedEffect(homeUsageEntries, selected, homeUsageSnapshotFrozen) {
+        displayedHomeUsageEntries = resolveHomeUsageEntriesForDisplay(
+            currentEntries = displayedHomeUsageEntries,
+            incomingEntries = homeUsageEntries,
+            detailOpen = selected != null,
+            snapshotFrozen = homeUsageSnapshotFrozen
+        )
     }
 
     LaunchedEffect(selected) {
@@ -362,7 +385,7 @@ fun HomeHostScreen(
                                 showTrendingCard = showTrendingCard,
                                 showRadarCard = showRadarCard,
                                 showRecommendedCard = showRecommendedCard,
-                                usageEntries = homeUsageEntries,
+                                usageEntries = displayedHomeUsageEntries,
                                 usageLoaded = homeUsageLoaded,
                                 offlineMode = offlineMode,
                                 gridState = gridState,
@@ -375,6 +398,7 @@ fun HomeHostScreen(
                                 onItemClick = { pl ->
                                     skipDetailCloseAnimation = false
                                     captureHomeScrollPosition()
+                                    openHomeSelectedItem(HomeSelectedItem.Netease(pl))
                                     AppContainer.launchBackgroundIo {
                                         AppContainer.playlistUsageRepo.recordOpen(
                                             id = pl.id,
@@ -384,11 +408,11 @@ fun HomeHostScreen(
                                             source = "netease"
                                         )
                                     }
-                                    openHomeSelectedItem(HomeSelectedItem.Netease(pl))
                                 },
                                 onYouTubeMusicPlaylistClick = { pl ->
                                     skipDetailCloseAnimation = false
                                     captureHomeScrollPosition()
+                                    openHomeSelectedItem(HomeSelectedItem.YouTubeMusic(pl))
                                     AppContainer.launchBackgroundIo {
                                         AppContainer.playlistUsageRepo.recordOpen(
                                             id = stableYouTubeMusicId(
@@ -402,11 +426,11 @@ fun HomeHostScreen(
                                             playlistId = pl.playlistId
                                         )
                                     }
-                                    openHomeSelectedItem(HomeSelectedItem.YouTubeMusic(pl))
                                 },
                                 onOpenRecent = { entry ->
                                     skipDetailCloseAnimation = false
                                     captureHomeScrollPosition()
+                                    openRecent(entry, ::openHomeSelectedItem)
                                     AppContainer.launchBackgroundIo {
                                         AppContainer.playlistUsageRepo.recordOpen(
                                             id = entry.id,
@@ -422,7 +446,6 @@ fun HomeHostScreen(
                                             subtitle = entry.subtitle
                                         )
                                     }
-                                    openRecent(entry, ::openHomeSelectedItem)
                                 },
                                 onSongClick = onSongClick
                             )
@@ -432,7 +455,7 @@ fun HomeHostScreen(
                             is HomeSelectedItem.NeteaseAlbumList -> {
                                 NeteaseAlbumDetailScreen(
                                     album = current.album,
-                                    onBack = { selected = null },
+                                    onBack = ::closeSelectedDetail,
                                     onSongClick = { songs, index ->
                                         onSongClickWithSourceRoute(
                                             songs,
@@ -447,7 +470,7 @@ fun HomeHostScreen(
                             is HomeSelectedItem.Netease -> {
                                 NeteasePlaylistDetailScreen(
                                     playlist = current.playlist,
-                                    onBack = { selected = null },
+                                    onBack = ::closeSelectedDetail,
                                     onSongClick = { songs, index ->
                                         onSongClickWithSourceRoute(
                                             songs,
@@ -487,7 +510,7 @@ fun HomeHostScreen(
                             is HomeSelectedItem.Bili -> {
                                 BiliPlaylistDetailScreen(
                                     playlist = current.playlist,
-                                    onBack = { selected = null },
+                                    onBack = ::closeSelectedDetail,
                                     onPlayAudio = { videos, index ->
                                         onPlayBiliAudioWithSourceRoute(
                                             videos,
@@ -510,7 +533,7 @@ fun HomeHostScreen(
                             is HomeSelectedItem.YouTubeMusic -> {
                                 YouTubeMusicPlaylistDetailScreen(
                                     playlist = current.playlist,
-                                    onBack = { selected = null },
+                                    onBack = ::closeSelectedDetail,
                                     onSongClick = onSongClick,
                                     offlineMode = offlineMode
                                 )

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/host/HomeHostScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/host/HomeHostScreen.kt
@@ -218,11 +218,17 @@ fun HomeHostScreen(
         pendingNeteaseCoverWarmupToken = token
         pendingNeteaseCoverWarmupJob?.cancel()
         pendingNeteaseCoverWarmupJob = scope.launch {
-            CoverArtColorCache.preload(context, coverUrl, offlineMode)
-            if (pendingNeteaseCoverWarmupToken == token) {
-                ensureHomeScrollPositionCaptured()
-                selected = item
-                pendingNeteaseCoverWarmupJob = null
+            try {
+                CoverArtColorCache.preload(context, coverUrl, offlineMode)
+                if (pendingNeteaseCoverWarmupToken == token) {
+                    ensureHomeScrollPositionCaptured()
+                    selected = item
+                    pendingNeteaseCoverWarmupJob = null
+                }
+            } finally {
+                if (selected == null && pendingNeteaseCoverWarmupToken == token) {
+                    homeUsageSnapshotFrozen = false
+                }
             }
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/util/security/RecoveringEncryptedSharedPreferences.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/util/security/RecoveringEncryptedSharedPreferences.kt
@@ -255,10 +255,7 @@ internal class RecoveringEncryptedSharedPreferences internal constructor(
             val editor = preferences.edit()
             actions.forEach { action -> action.apply(editor) }
             if (commit) {
-                check(editor.commit()) {
-                    "Encrypted preferences commit returned false"
-                }
-                true
+                editor.commit()
             } else {
                 editor.apply()
                 true
@@ -384,10 +381,16 @@ internal class RecoveringEncryptedSharedPreferences internal constructor(
             return this
         }
 
-        override fun commit(): Boolean = preferences.write(actions, commit = true)
+        override fun commit(): Boolean {
+            val pending = actions.toList()
+            actions.clear()
+            return preferences.write(pending, commit = true)
+        }
 
         override fun apply() {
-            preferences.write(actions, commit = false)
+            val pending = actions.toList()
+            actions.clear()
+            preferences.write(pending, commit = false)
         }
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/util/security/RecoveringEncryptedSharedPreferences.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/util/security/RecoveringEncryptedSharedPreferences.kt
@@ -1,0 +1,558 @@
+@file:Suppress("DEPRECATION")
+
+package moe.ouom.neriplayer.util.security
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import java.security.GeneralSecurityException
+import java.security.UnrecoverableKeyException
+import java.util.Locale
+import java.util.concurrent.CopyOnWriteArraySet
+import javax.crypto.BadPaddingException
+import moe.ouom.neriplayer.core.logging.NPLogger
+
+/**
+ * keeps encrypted preference corruption isolated to the affected credential store
+ */
+internal class RecoveringEncryptedSharedPreferences internal constructor(
+    private val storageName: String,
+    private val logTag: String,
+    private val opener: () -> SharedPreferences,
+    private val resetter: () -> Unit
+) : SharedPreferences {
+    constructor(
+        context: Context,
+        storageName: String,
+        logTag: String,
+        masterKeyAlias: String? = null
+    ) : this(
+        storageName = storageName,
+        logTag = logTag,
+        opener = {
+            createEncryptedPreferences(
+                context = context.applicationContext,
+                storageName = storageName,
+                masterKeyAlias = masterKeyAlias
+            )
+        },
+        resetter = {
+            context.applicationContext.deleteSharedPreferences(storageName)
+        }
+    )
+
+    private data class ActiveStore(
+        val preferences: SharedPreferences,
+        val durable: Boolean
+    )
+
+    private val recoveryLock = Any()
+    private val listeners = CopyOnWriteArraySet<SharedPreferences.OnSharedPreferenceChangeListener>()
+
+    @Volatile
+    private var activeStore: ActiveStore = openInitialStore()
+
+    val isDurable: Boolean
+        get() = activeStore.durable
+
+    override fun getAll(): MutableMap<String, *> {
+        return execute { preferences -> LinkedHashMap(preferences.all) }
+    }
+
+    override fun getString(key: String, defValue: String?): String? {
+        return execute { preferences -> preferences.getString(key, defValue) }
+    }
+
+    override fun getStringSet(
+        key: String,
+        defValues: MutableSet<String>?
+    ): MutableSet<String>? {
+        return execute { preferences -> preferences.getStringSet(key, defValues) }
+    }
+
+    override fun getInt(key: String, defValue: Int): Int {
+        return execute { preferences -> preferences.getInt(key, defValue) }
+    }
+
+    override fun getLong(key: String, defValue: Long): Long {
+        return execute { preferences -> preferences.getLong(key, defValue) }
+    }
+
+    override fun getFloat(key: String, defValue: Float): Float {
+        return execute { preferences -> preferences.getFloat(key, defValue) }
+    }
+
+    override fun getBoolean(key: String, defValue: Boolean): Boolean {
+        return execute { preferences -> preferences.getBoolean(key, defValue) }
+    }
+
+    override fun contains(key: String): Boolean {
+        return execute { preferences -> preferences.contains(key) }
+    }
+
+    override fun edit(): SharedPreferences.Editor = RecoveringEditor(this)
+
+    override fun registerOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener
+    ) {
+        listeners += listener
+        execute { preferences ->
+            preferences.registerOnSharedPreferenceChangeListener(listener)
+        }
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener
+    ) {
+        listeners -= listener
+        execute { preferences ->
+            preferences.unregisterOnSharedPreferenceChangeListener(listener)
+        }
+    }
+
+    private fun openInitialStore(): ActiveStore {
+        return runCatching(opener)
+            .fold(
+                onSuccess = { preferences -> ActiveStore(preferences, durable = true) },
+                onFailure = { error -> recover(error, "open") }
+            )
+    }
+
+    private fun recover(error: Throwable, phase: String): ActiveStore {
+        if (!isIrrecoverableCryptoFailure(error)) {
+            NPLogger.w(
+                logTag,
+                "Encrypted preferences are temporarily unavailable during $phase; " +
+                    "keeping $storageName and using memory-only credentials.",
+                error
+            )
+            return ActiveStore(MemoryOnlySharedPreferences(), durable = false)
+        }
+        return resetAndOpen(error, phase)
+    }
+
+    private fun resetAndOpen(error: Throwable, phase: String): ActiveStore {
+        NPLogger.w(
+            logTag,
+            "Encrypted preferences are unavailable during $phase; resetting only $storageName.",
+            error
+        )
+        runCatching(resetter).onFailure { resetError ->
+            NPLogger.e(
+                logTag,
+                "Failed to reset encrypted preferences: $storageName.",
+                resetError
+            )
+        }
+        return runCatching(opener)
+            .fold(
+                onSuccess = { preferences -> ActiveStore(preferences, durable = true) },
+                onFailure = { reopenError ->
+                    NPLogger.e(
+                        logTag,
+                        "Encrypted preferences remain unavailable: $storageName. " +
+                            "Using memory-only empty credentials.",
+                        reopenError
+                    )
+                    ActiveStore(MemoryOnlySharedPreferences(), durable = false)
+                }
+            )
+    }
+
+    private fun recoverAfterFailure(
+        expectedStore: ActiveStore,
+        error: Throwable
+    ): ActiveStore {
+        synchronized(recoveryLock) {
+            if (activeStore !== expectedStore) {
+                return activeStore
+            }
+            return install(recover(error, "access"))
+        }
+    }
+
+    private fun isIrrecoverableCryptoFailure(error: Throwable): Boolean {
+        var current: Throwable? = error
+        while (current != null) {
+            if (current is BadPaddingException || current is UnrecoverableKeyException) {
+                return true
+            }
+            if (isReportedDecryptionFailure(current)) return true
+            current = current.cause
+        }
+        return false
+    }
+
+    private fun isReportedDecryptionFailure(error: Throwable): Boolean {
+        if (
+            error !is GeneralSecurityException &&
+            error !is SecurityException &&
+            error.javaClass.name != "android.security.KeyStoreException"
+        ) {
+            return false
+        }
+        val message = error.message.orEmpty().lowercase(Locale.ROOT)
+        return message.contains("decrypt") ||
+            message.contains("authentication tag") ||
+            message.contains("mac verification") ||
+            message.contains("verification failed") ||
+            message.contains("keyset") ||
+            message.contains("permanently invalidated")
+    }
+
+    private fun forceMemoryOnly(
+        expectedStore: ActiveStore,
+        error: Throwable
+    ): ActiveStore {
+        synchronized(recoveryLock) {
+            if (activeStore !== expectedStore && !activeStore.durable) {
+                return activeStore
+            }
+            NPLogger.e(
+                logTag,
+                "Encrypted preferences failed after recovery: $storageName. " +
+                    "Using memory-only empty credentials.",
+                error
+            )
+            return install(ActiveStore(MemoryOnlySharedPreferences(), durable = false))
+        }
+    }
+
+    private fun install(store: ActiveStore): ActiveStore {
+        activeStore = store
+        listeners.forEach { listener ->
+            runCatching {
+                store.preferences.registerOnSharedPreferenceChangeListener(listener)
+            }.onFailure { error ->
+                NPLogger.w(
+                    logTag,
+                    "Failed to restore encrypted preference listener: $storageName.",
+                    error
+                )
+            }
+        }
+        return store
+    }
+
+    private fun <T> execute(action: (SharedPreferences) -> T): T {
+        val initialStore = activeStore
+        return try {
+            action(initialStore.preferences)
+        } catch (initialError: Exception) {
+            val recoveredStore = recoverAfterFailure(initialStore, initialError)
+            try {
+                action(recoveredStore.preferences)
+            } catch (recoveryError: Exception) {
+                val memoryStore = forceMemoryOnly(recoveredStore, recoveryError)
+                action(memoryStore.preferences)
+            }
+        }
+    }
+
+    private fun write(actions: List<EditorAction>, commit: Boolean): Boolean {
+        return execute { preferences ->
+            val editor = preferences.edit()
+            actions.forEach { action -> action.apply(editor) }
+            if (commit) {
+                check(editor.commit()) {
+                    "Encrypted preferences commit returned false"
+                }
+                true
+            } else {
+                editor.apply()
+                true
+            }
+        }
+    }
+
+    private sealed interface EditorAction {
+        fun apply(editor: SharedPreferences.Editor)
+
+        data class PutString(
+            val key: String,
+            val value: String?
+        ) : EditorAction {
+            override fun apply(editor: SharedPreferences.Editor) {
+                editor.putString(key, value)
+            }
+        }
+
+        data class PutStringSet(
+            val key: String,
+            val value: Set<String>?
+        ) : EditorAction {
+            override fun apply(editor: SharedPreferences.Editor) {
+                editor.putStringSet(key, value?.toMutableSet())
+            }
+        }
+
+        data class PutInt(
+            val key: String,
+            val value: Int
+        ) : EditorAction {
+            override fun apply(editor: SharedPreferences.Editor) {
+                editor.putInt(key, value)
+            }
+        }
+
+        data class PutLong(
+            val key: String,
+            val value: Long
+        ) : EditorAction {
+            override fun apply(editor: SharedPreferences.Editor) {
+                editor.putLong(key, value)
+            }
+        }
+
+        data class PutFloat(
+            val key: String,
+            val value: Float
+        ) : EditorAction {
+            override fun apply(editor: SharedPreferences.Editor) {
+                editor.putFloat(key, value)
+            }
+        }
+
+        data class PutBoolean(
+            val key: String,
+            val value: Boolean
+        ) : EditorAction {
+            override fun apply(editor: SharedPreferences.Editor) {
+                editor.putBoolean(key, value)
+            }
+        }
+
+        data class Remove(val key: String) : EditorAction {
+            override fun apply(editor: SharedPreferences.Editor) {
+                editor.remove(key)
+            }
+        }
+
+        data object Clear : EditorAction {
+            override fun apply(editor: SharedPreferences.Editor) {
+                editor.clear()
+            }
+        }
+    }
+
+    private class RecoveringEditor(
+        private val preferences: RecoveringEncryptedSharedPreferences
+    ) : SharedPreferences.Editor {
+        private val actions = mutableListOf<EditorAction>()
+
+        override fun putString(key: String, value: String?): SharedPreferences.Editor {
+            actions += EditorAction.PutString(key, value)
+            return this
+        }
+
+        override fun putStringSet(
+            key: String,
+            values: MutableSet<String>?
+        ): SharedPreferences.Editor {
+            actions += EditorAction.PutStringSet(key, values?.toSet())
+            return this
+        }
+
+        override fun putInt(key: String, value: Int): SharedPreferences.Editor {
+            actions += EditorAction.PutInt(key, value)
+            return this
+        }
+
+        override fun putLong(key: String, value: Long): SharedPreferences.Editor {
+            actions += EditorAction.PutLong(key, value)
+            return this
+        }
+
+        override fun putFloat(key: String, value: Float): SharedPreferences.Editor {
+            actions += EditorAction.PutFloat(key, value)
+            return this
+        }
+
+        override fun putBoolean(key: String, value: Boolean): SharedPreferences.Editor {
+            actions += EditorAction.PutBoolean(key, value)
+            return this
+        }
+
+        override fun remove(key: String): SharedPreferences.Editor {
+            actions += EditorAction.Remove(key)
+            return this
+        }
+
+        override fun clear(): SharedPreferences.Editor {
+            actions += EditorAction.Clear
+            return this
+        }
+
+        override fun commit(): Boolean = preferences.write(actions, commit = true)
+
+        override fun apply() {
+            preferences.write(actions, commit = false)
+        }
+    }
+}
+
+internal open class MemoryOnlySharedPreferences : SharedPreferences {
+    private val lock = Any()
+    private val values = linkedMapOf<String, Any>()
+    private val listeners = CopyOnWriteArraySet<SharedPreferences.OnSharedPreferenceChangeListener>()
+
+    override fun getAll(): MutableMap<String, *> = synchronized(lock) {
+        LinkedHashMap(values)
+    }
+
+    override fun getString(key: String, defValue: String?): String? = synchronized(lock) {
+        values[key] as? String ?: defValue
+    }
+
+    override fun getStringSet(
+        key: String,
+        defValues: MutableSet<String>?
+    ): MutableSet<String>? = synchronized(lock) {
+        @Suppress("UNCHECKED_CAST")
+        (values[key] as? Set<String>)?.toMutableSet() ?: defValues?.toMutableSet()
+    }
+
+    override fun getInt(key: String, defValue: Int): Int = synchronized(lock) {
+        values[key] as? Int ?: defValue
+    }
+
+    override fun getLong(key: String, defValue: Long): Long = synchronized(lock) {
+        values[key] as? Long ?: defValue
+    }
+
+    override fun getFloat(key: String, defValue: Float): Float = synchronized(lock) {
+        values[key] as? Float ?: defValue
+    }
+
+    override fun getBoolean(key: String, defValue: Boolean): Boolean = synchronized(lock) {
+        values[key] as? Boolean ?: defValue
+    }
+
+    override fun contains(key: String): Boolean = synchronized(lock) { key in values }
+
+    override fun edit(): SharedPreferences.Editor = MemoryEditor()
+
+    override fun registerOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener
+    ) {
+        listeners += listener
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(
+        listener: SharedPreferences.OnSharedPreferenceChangeListener
+    ) {
+        listeners -= listener
+    }
+
+    private inner class MemoryEditor : SharedPreferences.Editor {
+        private val updates = linkedMapOf<String, Any?>()
+        private val removals = linkedSetOf<String>()
+        private var clearRequested = false
+
+        override fun putString(key: String, value: String?): SharedPreferences.Editor {
+            updates[key] = value
+            removals -= key
+            return this
+        }
+
+        override fun putStringSet(
+            key: String,
+            values: MutableSet<String>?
+        ): SharedPreferences.Editor {
+            updates[key] = values?.toSet()
+            removals -= key
+            return this
+        }
+
+        override fun putInt(key: String, value: Int): SharedPreferences.Editor {
+            updates[key] = value
+            removals -= key
+            return this
+        }
+
+        override fun putLong(key: String, value: Long): SharedPreferences.Editor {
+            updates[key] = value
+            removals -= key
+            return this
+        }
+
+        override fun putFloat(key: String, value: Float): SharedPreferences.Editor {
+            updates[key] = value
+            removals -= key
+            return this
+        }
+
+        override fun putBoolean(key: String, value: Boolean): SharedPreferences.Editor {
+            updates[key] = value
+            removals -= key
+            return this
+        }
+
+        override fun remove(key: String): SharedPreferences.Editor {
+            updates.remove(key)
+            removals += key
+            return this
+        }
+
+        override fun clear(): SharedPreferences.Editor {
+            clearRequested = true
+            return this
+        }
+
+        override fun commit(): Boolean {
+            val changedKeys = linkedSetOf<String>()
+            synchronized(lock) {
+                if (clearRequested) {
+                    changedKeys += values.keys
+                    values.clear()
+                }
+                removals.forEach { key ->
+                    if (values.remove(key) != null) {
+                        changedKeys += key
+                    }
+                }
+                updates.forEach { (key, value) ->
+                    if (value == null) {
+                        if (values.remove(key) != null) {
+                            changedKeys += key
+                        }
+                    } else if (values[key] != value) {
+                        values[key] = value
+                        changedKeys += key
+                    }
+                }
+            }
+            changedKeys.forEach { key ->
+                listeners.forEach { listener -> listener.onSharedPreferenceChanged(this@MemoryOnlySharedPreferences, key) }
+            }
+            return true
+        }
+
+        override fun apply() {
+            commit()
+        }
+    }
+}
+
+private fun createEncryptedPreferences(
+    context: Context,
+    storageName: String,
+    masterKeyAlias: String?
+): SharedPreferences {
+    val masterKeyBuilder = if (masterKeyAlias.isNullOrBlank()) {
+        MasterKey.Builder(context)
+    } else {
+        MasterKey.Builder(context, masterKeyAlias)
+    }
+    val masterKey = masterKeyBuilder
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+    return EncryptedSharedPreferences.create(
+        context,
+        storageName,
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+}

--- a/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorageSnapshotCacheTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorageSnapshotCacheTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import moe.ouom.neriplayer.core.download.storage.snapshot.ManagedDownloadSnapshotRoomMapper
 import moe.ouom.neriplayer.data.model.SongItem
 
 class ManagedDownloadStorageSnapshotCacheTest {
@@ -111,6 +112,70 @@ class ManagedDownloadStorageSnapshotCacheTest {
         assertEquals(metadata, restored?.second?.metadataByAudioName?.get("Artist - Song.mp3"))
         assertEquals(coverEntry, restored?.second?.coverEntriesByName?.get(coverEntry.name))
         assertEquals(lyricEntry, restored?.second?.lyricEntriesByName?.get(lyricEntry.name))
+    }
+
+    @Test
+    fun `room snapshot mapper round trips entries and indexes`() {
+        val audioEntry = ManagedDownloadStorage.StoredEntry(
+            name = "Artist - Room Song.flac",
+            reference = "/music/Artist - Room Song.flac",
+            mediaUri = "file:///music/Artist%20-%20Room%20Song.flac",
+            localFilePath = "/music/Artist - Room Song.flac",
+            sizeBytes = 8192L,
+            lastModifiedMs = 123L
+        )
+        val metadataEntry = ManagedDownloadStorage.StoredEntry(
+            name = "Artist - Room Song.flac.npmeta.json",
+            reference = "/music/Artist - Room Song.flac.npmeta.json",
+            mediaUri = "file:///music/Artist%20-%20Room%20Song.flac.npmeta.json",
+            localFilePath = "/music/Artist - Room Song.flac.npmeta.json",
+            sizeBytes = 512L,
+            lastModifiedMs = 124L
+        )
+        val metadata = ManagedDownloadStorage.DownloadedAudioMetadata(
+            stableKey = "room-stable",
+            songId = 44L,
+            identityAlbum = "NeteaseAlbum",
+            name = "Room Song",
+            artist = "Artist",
+            mediaUri = "https://example.com/room.flac",
+            channelId = "netease",
+            audioId = "44",
+            durationMs = 240_000L,
+            downloadFinalized = true
+        )
+        val snapshot = ManagedDownloadStorage.DownloadLibrarySnapshot(
+            audioEntries = listOf(audioEntry),
+            audioEntriesByLookupKey = mapOf(audioEntry.reference to audioEntry),
+            metadataEntriesByAudioName = mapOf(audioEntry.name to metadataEntry),
+            metadataByAudioName = mapOf(audioEntry.name to metadata),
+            audioEntriesWithoutMetadata = emptyList(),
+            audioEntriesByStableKey = mapOf("room-stable" to listOf(audioEntry)),
+            audioEntriesBySongId = mapOf(44L to listOf(audioEntry)),
+            audioEntriesByMediaUri = mapOf("https://example.com/room.flac" to listOf(audioEntry)),
+            audioEntriesByRemoteTrackKey = mapOf("netease|44|" to listOf(audioEntry)),
+            coverEntriesByName = emptyMap(),
+            lyricEntriesByName = emptyMap(),
+            knownReferences = setOf(audioEntry.reference, metadataEntry.reference)
+        )
+        val entries = ManagedDownloadSnapshotRoomMapper.toEntryEntities("root", snapshot)
+        val restored = ManagedDownloadSnapshotRoomMapper.toSnapshot(
+            audioEntries = entries.filter {
+                it.bucket == ManagedDownloadSnapshotRoomMapper.BUCKET_AUDIO
+            },
+            metadataEntries = entries.filter {
+                it.bucket == ManagedDownloadSnapshotRoomMapper.BUCKET_METADATA
+            },
+            metadata = ManagedDownloadSnapshotRoomMapper.toMetadataEntities("root", snapshot),
+            coverEntries = emptyList(),
+            lyricEntries = emptyList()
+        )
+
+        assertEquals(snapshot.audioEntries, restored.audioEntries)
+        assertEquals(metadata, restored.metadataByAudioName[audioEntry.name])
+        assertEquals(listOf(audioEntry), restored.audioEntriesByStableKey["room-stable"])
+        assertEquals(listOf(audioEntry), restored.audioEntriesByRemoteTrackKey["netease|44|"])
+        assertTrue(restored.knownReferences.contains(metadataEntry.reference))
     }
 
     @Test

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/playlist/PlayerFavoritesControllerTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/playlist/PlayerFavoritesControllerTest.kt
@@ -7,9 +7,12 @@ import moe.ouom.neriplayer.data.local.playlist.system.FavoritesPlaylist
 import moe.ouom.neriplayer.data.model.identity
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.data.model.stableKey
+import moe.ouom.neriplayer.data.sync.CoverUrlMapper
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -19,6 +22,16 @@ import org.mockito.Mockito.`when`
 class PlayerFavoritesControllerTest {
     @get:Rule
     val tempFolder = TemporaryFolder()
+
+    @Before
+    fun setUpCoverMapper() {
+        CoverUrlMapper.installForTest(CoverUrlMapper.createForTest())
+    }
+
+    @After
+    fun tearDownCoverMapper() {
+        CoverUrlMapper.installForTest(null)
+    }
 
     @Test
     fun `optimistic favorite readd projects downloaded copy to remote source`() {

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/database/RoomRecoveryMergeTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/database/RoomRecoveryMergeTest.kt
@@ -1,0 +1,58 @@
+package moe.ouom.neriplayer.data.local.database
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RoomRecoveryMergeTest {
+    @Test
+    fun unchangedLegacySnapshotDoesNotOverwriteRoomState() {
+        val baseline = listOf(Snapshot("one", "legacy"))
+
+        val merged = mergeRoomRecoverySnapshot(
+            roomSnapshot = listOf(Snapshot("one", "room")),
+            recoveryBaseline = baseline,
+            currentSnapshot = baseline,
+            keyOf = Snapshot::key,
+            mergeLocalChange = { _, local -> local }
+        )
+
+        assertEquals(listOf(Snapshot("one", "room")), merged)
+    }
+
+    @Test
+    fun localChangesAndRemovalsAreAppliedToRecoveredRoomState() {
+        val baseline = listOf(
+            Snapshot("one", "legacy"),
+            Snapshot("two", "legacy")
+        )
+
+        val merged = mergeRoomRecoverySnapshot(
+            roomSnapshot = listOf(
+                Snapshot("one", "room"),
+                Snapshot("two", "room"),
+                Snapshot("three", "room")
+            ),
+            recoveryBaseline = baseline,
+            currentSnapshot = listOf(
+                Snapshot("one", "edited"),
+                Snapshot("four", "new")
+            ),
+            keyOf = Snapshot::key,
+            mergeLocalChange = { _, local -> local }
+        )
+
+        assertEquals(
+            listOf(
+                Snapshot("one", "edited"),
+                Snapshot("three", "room"),
+                Snapshot("four", "new")
+            ),
+            merged
+        )
+    }
+
+    private data class Snapshot(
+        val key: String,
+        val value: String
+    )
+}

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomMapperTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomMapperTest.kt
@@ -6,7 +6,6 @@ import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.data.model.stableKey
 import moe.ouom.neriplayer.data.sync.model.SyncCausalToken
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -57,6 +56,7 @@ class LocalPlaylistRoomMapperTest {
             playlists = snapshot.playlists,
             tracks = snapshot.tracks,
             members = snapshot.members,
+            memberNeteaseArtists = snapshot.memberNeteaseArtists,
             memberTokens = snapshot.memberTokens
         )
 
@@ -92,8 +92,11 @@ class LocalPlaylistRoomMapperTest {
         assertEquals(listOf("first", "local file"), snapshot.tracks.map { it.name }.sorted())
         assertTrue(snapshot.memberTokens.none { it.deviceId.isBlank() || it.counter <= 0L })
         assertTrue(snapshot.migrationMetadata.any { it.key == "local_playlist_source_digest" })
-        assertFalse(snapshot.tracks.any { it.durablePayloadJson.contains("temporary-stream") })
-        assertFalse(snapshot.members.any { it.memberPayloadJson.contains("temporary-stream") })
+        assertEquals(
+            listOf("first", "local file", "local file"),
+            snapshot.members.map { it.name }.sorted()
+        )
+        assertEquals(1, snapshot.memberNeteaseArtists.size)
         assertEquals("/storage/emulated/0/Music/local.flac", restored[0].songs.single().localFilePath)
     }
 
@@ -111,6 +114,24 @@ class LocalPlaylistRoomMapperTest {
         assertTrue(result.equivalent)
         assertEquals(1, result.playlistCount)
         assertEquals(1, result.memberCount)
+        assertNull(result.firstMismatch)
+    }
+
+    @Test
+    fun `validation accepts legacy null netease artist list`() {
+        val playlist = LocalPlaylist(
+            id = 31L,
+            name = "legacy artists",
+            songs = mutableListOf(
+                remoteSong(id = 311L, name = "legacy song").copy(
+                    neteaseArtists = null
+                )
+            )
+        )
+
+        val result = mapper.validateRoundTrip(listOf(playlist))
+
+        assertTrue(result.equivalent)
         assertNull(result.firstMismatch)
     }
 
@@ -133,6 +154,12 @@ class LocalPlaylistRoomMapperTest {
             channelId = "netease",
             audioId = id.toString(),
             playlistContextId = "playlist-context-$id",
+            neteaseArtists = listOf(
+                moe.ouom.neriplayer.data.model.NeteaseArtistSummary(
+                    id = id + 100L,
+                    name = "artist-$id"
+                )
+            ),
             streamUrl = streamUrl,
             addedAt = addedAt,
             syncMembershipTokens = tokens

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomMapperTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/database/store/LocalPlaylistRoomMapperTest.kt
@@ -1,0 +1,168 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import moe.ouom.neriplayer.data.local.playlist.model.DISPLAY_ORDER_SONG_ORDER_VERSION
+import moe.ouom.neriplayer.data.local.playlist.model.LocalPlaylist
+import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.model.stableKey
+import moe.ouom.neriplayer.data.sync.model.SyncCausalToken
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalPlaylistRoomMapperTest {
+    private val mapper = LocalPlaylistRoomMapper()
+
+    @Test
+    fun `round trip keeps playlist order membership tokens and local metadata`() {
+        val firstSong = remoteSong(
+            id = 101L,
+            name = "first",
+            addedAt = 7_000L,
+            streamUrl = "https://temporary-stream.example/first",
+            tokens = listOf(
+                SyncCausalToken(deviceId = "device-b", counter = 2L),
+                SyncCausalToken(deviceId = "", counter = 0L),
+                SyncCausalToken(deviceId = "device-a", counter = 1L)
+            )
+        )
+        val secondSong = localSong(
+            name = "local file",
+            addedAt = 6_000L,
+            streamUrl = "https://temporary-stream.example/local",
+            tokens = listOf(SyncCausalToken(deviceId = "device-c", counter = 3L))
+        )
+        val secondSongInFirstPlaylist = secondSong.copy(customName = "playlist-specific name")
+        val playlists = listOf(
+            LocalPlaylist(
+                id = 20L,
+                name = "second playlist",
+                songs = mutableListOf(secondSong),
+                modifiedAt = 2_000L,
+                songOrderVersion = DISPLAY_ORDER_SONG_ORDER_VERSION
+            ),
+            LocalPlaylist(
+                id = 10L,
+                name = "first playlist",
+                songs = mutableListOf(firstSong, secondSongInFirstPlaylist),
+                modifiedAt = 1_000L,
+                customCoverUrl = "https://cover.example/playlist.jpg",
+                songOrderVersion = DISPLAY_ORDER_SONG_ORDER_VERSION
+            )
+        )
+
+        val snapshot = mapper.toSnapshot(playlists, sourceDigest = "digest-1", now = 12_345L)
+        val restored = mapper.toDomain(
+            playlists = snapshot.playlists,
+            tracks = snapshot.tracks,
+            members = snapshot.members,
+            memberTokens = snapshot.memberTokens
+        )
+
+        assertEquals(
+            listOf(
+                playlists[0].copy(
+                    songs = mutableListOf(
+                        secondSong.copy(
+                            streamUrl = null,
+                            syncMembershipTokens = listOf(SyncCausalToken("device-c", 3L))
+                        )
+                    )
+                ),
+                playlists[1].copy(
+                    songs = mutableListOf(
+                        firstSong.copy(
+                            streamUrl = null,
+                            syncMembershipTokens = listOf(
+                                SyncCausalToken("device-a", 1L),
+                                SyncCausalToken("device-b", 2L)
+                            )
+                        ),
+                        secondSongInFirstPlaylist.copy(
+                            streamUrl = null,
+                            syncMembershipTokens = listOf(SyncCausalToken("device-c", 3L))
+                        )
+                    )
+                )
+            ),
+            restored
+        )
+        assertEquals(listOf(20L, 10L), restored.map(LocalPlaylist::id))
+        assertEquals(listOf("first", "local file"), snapshot.tracks.map { it.name }.sorted())
+        assertTrue(snapshot.memberTokens.none { it.deviceId.isBlank() || it.counter <= 0L })
+        assertTrue(snapshot.migrationMetadata.any { it.key == "local_playlist_source_digest" })
+        assertFalse(snapshot.tracks.any { it.durablePayloadJson.contains("temporary-stream") })
+        assertFalse(snapshot.members.any { it.memberPayloadJson.contains("temporary-stream") })
+        assertEquals("/storage/emulated/0/Music/local.flac", restored[0].songs.single().localFilePath)
+    }
+
+    @Test
+    fun `validation accepts mapper equivalent snapshots`() {
+        val playlist = LocalPlaylist(
+            id = 30L,
+            name = "validated",
+            songs = mutableListOf(remoteSong(id = 301L, name = "validated song")),
+            modifiedAt = 3_000L
+        )
+
+        val result = mapper.validateRoundTrip(listOf(playlist))
+
+        assertTrue(result.equivalent)
+        assertEquals(1, result.playlistCount)
+        assertEquals(1, result.memberCount)
+        assertNull(result.firstMismatch)
+    }
+
+    private fun remoteSong(
+        id: Long,
+        name: String,
+        addedAt: Long = 1_000L,
+        streamUrl: String? = null,
+        tokens: List<SyncCausalToken> = emptyList()
+    ): SongItem {
+        return SongItem(
+            id = id,
+            name = name,
+            artist = "artist $id",
+            album = "netease",
+            albumId = id + 10L,
+            durationMs = 180_000L,
+            coverUrl = "https://cover.example/$id.jpg",
+            mediaUri = null,
+            channelId = "netease",
+            audioId = id.toString(),
+            playlistContextId = "playlist-context-$id",
+            streamUrl = streamUrl,
+            addedAt = addedAt,
+            syncMembershipTokens = tokens
+        )
+    }
+
+    private fun localSong(
+        name: String,
+        addedAt: Long,
+        streamUrl: String?,
+        tokens: List<SyncCausalToken>
+    ): SongItem {
+        val source = remoteSong(id = 202L, name = "source")
+        return SongItem(
+            id = 0L,
+            name = name,
+            artist = "local artist",
+            album = "__local_files__",
+            albumId = 0L,
+            durationMs = 240_000L,
+            coverUrl = null,
+            mediaUri = "content://media/external/audio/media/202",
+            localFileName = "local.flac",
+            localFilePath = "/storage/emulated/0/Music/local.flac",
+            channelId = "local",
+            audioId = "local-202",
+            sourceStableKey = source.stableKey(),
+            streamUrl = streamUrl,
+            addedAt = addedAt,
+            syncMembershipTokens = tokens
+        )
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomMapperTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/database/store/PlayHistoryRoomMapperTest.kt
@@ -1,0 +1,53 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import moe.ouom.neriplayer.data.history.PlayedEntry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlayHistoryRoomMapperTest {
+    private val mapper = PlayHistoryRoomMapper()
+
+    @Test
+    fun `round trip keeps identity resume position and metadata`() {
+        val entries = listOf(
+            PlayedEntry(
+                id = 42L,
+                name = "local title",
+                artist = "local artist",
+                album = "__local_files__",
+                albumId = 0L,
+                durationMs = 180_000L,
+                resumePositionMs = 12_345L,
+                coverUrl = "file:///cover.jpg",
+                mediaUri = "content://media/42",
+                matchedLyric = "lyric",
+                customName = "custom",
+                localFileName = "song.flac",
+                localFilePath = "/music/song.flac",
+                channelId = "local",
+                audioId = "42",
+                sourceStableKey = "42|netease|",
+                playedAt = 200L
+            ),
+            PlayedEntry(
+                id = 7L,
+                name = "remote",
+                artist = "artist",
+                album = "netease",
+                durationMs = 210_000L,
+                coverUrl = null,
+                playedAt = 100L
+            )
+        )
+
+        val restored = mapper.toDomain(mapper.toEntities(entries))
+
+        assertEquals(entries, restored)
+        assertTrue(mapper.validateRoundTrip(entries))
+        assertEquals(
+            listOf("42|__local_files__|/music/song.flac", "7|netease|"),
+            mapper.toEntities(entries).map { it.identityKey }
+        )
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepositoryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepositoryTest.kt
@@ -17,14 +17,17 @@ import moe.ouom.neriplayer.data.local.playlist.system.LocalFilesPlaylist
 import moe.ouom.neriplayer.data.model.identity
 import moe.ouom.neriplayer.data.model.stableKey
 import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.sync.CoverUrlMapper
 import moe.ouom.neriplayer.data.sync.github.SyncPlaylistDeletionPolicy
 import moe.ouom.neriplayer.data.sync.model.SyncCausalToken
 import moe.ouom.neriplayer.data.sync.model.SyncSong
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -40,6 +43,16 @@ class LocalPlaylistRepositoryTest {
 
     @get:Rule
     val tempFolder = TemporaryFolder()
+
+    @Before
+    fun setUpCoverMapper() {
+        CoverUrlMapper.installForTest(CoverUrlMapper.createForTest())
+    }
+
+    @After
+    fun tearDownCoverMapper() {
+        CoverUrlMapper.installForTest(null)
+    }
 
     @Test
     fun `async initial load does not publish or overwrite before persisted state is ready`() = runTest {

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepositoryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepositoryTest.kt
@@ -395,6 +395,24 @@ class LocalPlaylistRepositoryTest {
     }
 
     @Test
+    fun `room promotion suppresses legacy playlist normalization rewrite`() {
+        assertFalse(
+            shouldRewriteLegacyPlaylistsAfterInitialLoad(
+                migrationRequired = true,
+                allowMigrationWrite = true,
+                roomPromotedDuringLoad = true
+            )
+        )
+        assertTrue(
+            shouldRewriteLegacyPlaylistsAfterInitialLoad(
+                migrationRequired = true,
+                allowMigrationWrite = true,
+                roomPromotedDuringLoad = false
+            )
+        )
+    }
+
+    @Test
     fun `adding songs to regular playlist places newest songs first`() = runTest {
         val playlistId = 45L
         val repository = LocalPlaylistRepository.createForTest(

--- a/app/src/test/java/moe/ouom/neriplayer/data/platform/bili/BiliVideoSkipRoomRecoveryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/platform/bili/BiliVideoSkipRoomRecoveryTest.kt
@@ -1,0 +1,36 @@
+package moe.ouom.neriplayer.data.platform.bili
+
+import moe.ouom.neriplayer.data.local.database.store.BiliVideoSkipRoomSnapshot
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BiliVideoSkipRoomRecoveryTest {
+    @Test
+    fun unchangedLegacyRulesDoNotRemoveRoomOnlyEntries() {
+        val target = BiliVideoSkipTarget("BVlegacy", 1L)
+        val roomOnly = BiliVideoSkipTarget("BVroom", 2L)
+        val baseline = BiliVideoSkipRoomSnapshot(
+            rules = listOf(BiliVideoSkipRule(target, modifiedAt = 1L)),
+            drafts = listOf(BiliVideoSkipDraft(target, startText = "1", modifiedAt = 1L))
+        )
+        val room = BiliVideoSkipRoomSnapshot(
+            rules = listOf(
+                BiliVideoSkipRule(target, modifiedAt = 2L),
+                BiliVideoSkipRule(roomOnly, modifiedAt = 2L)
+            ),
+            drafts = listOf(
+                BiliVideoSkipDraft(target, startText = "2", modifiedAt = 2L),
+                BiliVideoSkipDraft(roomOnly, endText = "3", modifiedAt = 2L)
+            )
+        )
+
+        assertEquals(
+            room,
+            mergeBiliVideoSkipRoomRecovery(
+                roomSnapshot = room,
+                recoveryBaseline = baseline,
+                currentSnapshot = baseline
+            )
+        )
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRoomRecoveryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/playlist/favorite/FavoritePlaylistRoomRecoveryTest.kt
@@ -1,0 +1,64 @@
+package moe.ouom.neriplayer.data.playlist.favorite
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FavoritePlaylistRoomRecoveryTest {
+    @Test
+    fun unchangedLegacySnapshotDoesNotRemoveRoomOnlyFavorite() {
+        val baseline = listOf(favorite(id = 1L, name = "legacy"))
+        val room = listOf(
+            favorite(id = 1L, name = "room"),
+            favorite(id = 2L, name = "room-only")
+        )
+
+        val recovered = mergeFavoritePlaylistRoomRecovery(
+            roomSnapshot = room,
+            recoveryBaseline = baseline,
+            currentSnapshot = baseline
+        )
+
+        assertEquals(room, recovered)
+    }
+
+    @Test
+    fun localEditAndRemovalAreAppliedWithoutDroppingRoomOnlyFavorite() {
+        val baseline = listOf(
+            favorite(id = 1L, name = "legacy"),
+            favorite(id = 2L, name = "removed")
+        )
+        val room = listOf(
+            favorite(id = 1L, name = "room"),
+            favorite(id = 2L, name = "room-removed"),
+            favorite(id = 3L, name = "room-only")
+        )
+
+        val recovered = mergeFavoritePlaylistRoomRecovery(
+            roomSnapshot = room,
+            recoveryBaseline = baseline,
+            currentSnapshot = listOf(favorite(id = 1L, name = "edited"))
+        )
+
+        assertEquals(
+            listOf(
+                favorite(id = 1L, name = "edited"),
+                favorite(id = 3L, name = "room-only")
+            ),
+            recovered
+        )
+    }
+
+    private fun favorite(id: Long, name: String): FavoritePlaylist {
+        return FavoritePlaylist(
+            id = id,
+            name = name,
+            coverUrl = null,
+            trackCount = 0,
+            source = "test",
+            songs = emptyList(),
+            addedTime = id,
+            sortOrder = id,
+            modifiedAt = id
+        )
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepositoryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/playlist/usage/LocalPlaylistPlaybackStatsRepositoryTest.kt
@@ -29,4 +29,36 @@ class LocalPlaylistPlaybackStatsRepositoryTest {
         assertTrue(normalized.single().counterShards.isEmpty())
         assertTrue(normalized.single().dailyPlayBuckets.isEmpty())
     }
+
+    @Test
+    fun `room recovery keeps Room-only stats and merges local playback delta once`() {
+        val baseline = recordLocalPlaylistPlay(
+            current = emptyList(),
+            playlistId = 1L,
+            playedAt = 100L,
+            deviceId = "local"
+        )
+        val current = recordLocalPlaylistPlay(
+            current = baseline,
+            playlistId = 1L,
+            playedAt = 200L,
+            deviceId = "local"
+        )
+        val roomSnapshot = baseline + recordLocalPlaylistPlay(
+            current = emptyList(),
+            playlistId = 2L,
+            playedAt = 150L,
+            deviceId = "remote"
+        )
+
+        val recovered = mergeLocalPlaylistPlaybackRoomRecovery(
+            roomSnapshot = roomSnapshot,
+            recoveryBaseline = baseline,
+            currentSnapshot = current
+        )
+
+        assertEquals(2, recovered.size)
+        assertEquals(2L, recovered.first { it.playlistId == 1L }.totalPlayCount)
+        assertEquals(1L, recovered.first { it.playlistId == 2L }.totalPlayCount)
+    }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/data/sync/model/SyncFavoritePlaylistCoverMappingTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/sync/model/SyncFavoritePlaylistCoverMappingTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.data.playlist.favorite.FavoritePlaylist
 import moe.ouom.neriplayer.data.sync.CoverUrlMapper
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -16,6 +17,11 @@ class SyncFavoritePlaylistCoverMappingTest {
     @get:Rule
     val tempFolder = TemporaryFolder()
 
+    @After
+    fun tearDown() {
+        CoverUrlMapper.installForTest(null)
+    }
+
     @Test
     fun `favorite playlist sync maps local playlist cover to network url`() {
         val context = mock(Context::class.java)
@@ -23,7 +29,9 @@ class SyncFavoritePlaylistCoverMappingTest {
         `when`(context.applicationContext).thenReturn(context)
         val localCover = File(tempFolder.root, "cover.jpg").toURI().toString()
         val networkCover = "https://example.com/covers/favorite.jpg"
-        CoverUrlMapper.getInstance(context).saveCoverMapping(localCover, networkCover)
+        val mapper = CoverUrlMapper.createForTest()
+        CoverUrlMapper.installForTest(mapper)
+        mapper.saveCoverMapping(localCover, networkCover)
         val playlist = FavoritePlaylist(
             id = 7L,
             name = "favorite",

--- a/app/src/test/java/moe/ouom/neriplayer/data/traffic/TrafficStatsRecoveryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/traffic/TrafficStatsRecoveryTest.kt
@@ -1,0 +1,58 @@
+package moe.ouom.neriplayer.data.traffic
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TrafficStatsRecoveryTest {
+    @Test
+    fun localDeltaIsAddedWithoutReplacingNewerRoomTotals() {
+        val baseline = listOf(
+            TrafficStatsBucket(
+                dayStartAt = 100L,
+                wifiBytes = 100L,
+                playbackNetworkBytes = 100L,
+                requestCount = 1
+            )
+        )
+        val room = listOf(
+            TrafficStatsBucket(
+                dayStartAt = 100L,
+                wifiBytes = 140L,
+                playbackNetworkBytes = 140L,
+                requestCount = 2
+            ),
+            TrafficStatsBucket(dayStartAt = 200L, mobileBytes = 50L)
+        )
+        val current = listOf(
+            TrafficStatsBucket(
+                dayStartAt = 100L,
+                wifiBytes = 130L,
+                playbackNetworkBytes = 130L,
+                requestCount = 2
+            )
+        )
+
+        val recovered = mergeTrafficStatsRoomRecovery(
+            roomSnapshot = room,
+            recoveryBaseline = baseline,
+            currentSnapshot = current
+        )
+
+        assertEquals(2, recovered.size)
+        assertEquals(170L, recovered.first { it.dayStartAt == 100L }.wifiBytes)
+        assertEquals(170L, recovered.first { it.dayStartAt == 100L }.playbackNetworkBytes)
+        assertEquals(3, recovered.first { it.dayStartAt == 100L }.requestCount)
+        assertEquals(50L, recovered.first { it.dayStartAt == 200L }.mobileBytes)
+    }
+
+    @Test
+    fun explicitClearRemovesRecoveredRoomBuckets() {
+        val recovered = mergeTrafficStatsRoomRecovery(
+            roomSnapshot = listOf(TrafficStatsBucket(dayStartAt = 100L, wifiBytes = 10L)),
+            recoveryBaseline = listOf(TrafficStatsBucket(dayStartAt = 100L, wifiBytes = 5L)),
+            currentSnapshot = emptyList()
+        )
+
+        assertEquals(emptyList<TrafficStatsBucket>(), recovered)
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/ui/screen/host/HomeHostScreenTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/screen/host/HomeHostScreenTest.kt
@@ -1,0 +1,68 @@
+package moe.ouom.neriplayer.ui.screen.host
+
+import moe.ouom.neriplayer.data.playlist.usage.UsageEntry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeHostScreenTest {
+
+    @Test
+    fun usageSnapshotStaysStableWhileDetailIsOpen() {
+        val current = listOf(usageEntry(id = 1L))
+        val incoming = listOf(usageEntry(id = 2L), usageEntry(id = 1L))
+
+        assertEquals(
+            current,
+            resolveHomeUsageEntriesForDisplay(
+                currentEntries = current,
+                incomingEntries = incoming,
+                detailOpen = true,
+                snapshotFrozen = false
+            )
+        )
+    }
+
+    @Test
+    fun usageSnapshotStaysStableWhileOpeningDetail() {
+        val current = listOf(usageEntry(id = 1L))
+        val incoming = listOf(usageEntry(id = 2L), usageEntry(id = 1L))
+
+        assertEquals(
+            current,
+            resolveHomeUsageEntriesForDisplay(
+                currentEntries = current,
+                incomingEntries = incoming,
+                detailOpen = false,
+                snapshotFrozen = true
+            )
+        )
+    }
+
+    @Test
+    fun usageSnapshotAppliesLatestEntriesAfterDetailCloses() {
+        val current = listOf(usageEntry(id = 1L))
+        val incoming = listOf(usageEntry(id = 2L), usageEntry(id = 1L))
+
+        assertEquals(
+            incoming,
+            resolveHomeUsageEntriesForDisplay(
+                currentEntries = current,
+                incomingEntries = incoming,
+                detailOpen = false,
+                snapshotFrozen = false
+            )
+        )
+    }
+
+    private fun usageEntry(id: Long): UsageEntry {
+        return UsageEntry(
+            id = id,
+            name = "playlist-$id",
+            picUrl = null,
+            trackCount = 1,
+            source = "netease",
+            lastOpened = id,
+            openCount = 1
+        )
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/util/security/RecoveringEncryptedSharedPreferencesTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/util/security/RecoveringEncryptedSharedPreferencesTest.kt
@@ -1,0 +1,105 @@
+package moe.ouom.neriplayer.util.security
+
+import android.content.SharedPreferences
+import java.security.GeneralSecurityException
+import javax.crypto.AEADBadTagException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RecoveringEncryptedSharedPreferencesTest {
+
+    @Test
+    fun cryptoFailureWhileOpening_resetsOnlyTheAffectedStore() {
+        var openCount = 0
+        var resetCount = 0
+        val replacement = MemoryOnlySharedPreferences()
+        val preferences = RecoveringEncryptedSharedPreferences(
+            storageName = "credential_store",
+            logTag = "RecoveringPreferencesTest",
+            opener = {
+                if (openCount++ == 0) {
+                    throw AEADBadTagException("backup key does not match")
+                }
+                replacement
+            },
+            resetter = { resetCount++ }
+        )
+
+        assertTrue(preferences.isDurable)
+        assertEquals(2, openCount)
+        assertEquals(1, resetCount)
+        assertTrue(preferences.edit().putString("token", "new-token").commit())
+        assertEquals("new-token", replacement.getString("token", null))
+    }
+
+    @Test
+    fun cryptoFailureWhileReading_reopensAnEmptyDurableStore() {
+        var openCount = 0
+        var resetCount = 0
+        val replacement = MemoryOnlySharedPreferences()
+        val preferences = RecoveringEncryptedSharedPreferences(
+            storageName = "credential_store",
+            logTag = "RecoveringPreferencesTest",
+            opener = {
+                if (openCount++ == 0) {
+                    FailingReadPreferences()
+                } else {
+                    replacement
+                }
+            },
+            resetter = { resetCount++ }
+        )
+
+        assertNull(preferences.getString("token", null))
+        assertTrue(preferences.isDurable)
+        assertEquals(2, openCount)
+        assertEquals(1, resetCount)
+    }
+
+    @Test
+    fun transientOpenFailure_keepsPersistentDataUntouchedAndUsesMemoryOnlyStore() {
+        var resetCount = 0
+        val preferences = RecoveringEncryptedSharedPreferences(
+            storageName = "credential_store",
+            logTag = "RecoveringPreferencesTest",
+            opener = { throw IllegalStateException("keystore temporarily unavailable") },
+            resetter = { resetCount++ }
+        )
+
+        assertFalse(preferences.isDurable)
+        assertEquals(0, resetCount)
+        assertTrue(preferences.edit().putString("token", "session-only").commit())
+        assertEquals("session-only", preferences.getString("token", null))
+    }
+
+    @Test
+    fun nonDecryptionSecurityFailure_doesNotDeleteExistingCredentials() {
+        var resetCount = 0
+        val preferences = RecoveringEncryptedSharedPreferences(
+            storageName = "credential_store",
+            logTag = "RecoveringPreferencesTest",
+            opener = { throw GeneralSecurityException("hardware service unavailable") },
+            resetter = { resetCount++ }
+        )
+
+        assertFalse(preferences.isDurable)
+        assertEquals(0, resetCount)
+    }
+
+    private class FailingReadPreferences(
+        private val delegate: SharedPreferences = MemoryOnlySharedPreferences()
+    ) : SharedPreferences by delegate {
+        private var shouldFail = true
+
+        override fun getString(key: String, defValue: String?): String? {
+            if (shouldFail) {
+                shouldFail = false
+                throw AEADBadTagException("backup key does not match")
+            }
+            return delegate.getString(key, defValue)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ okhttp = "5.4.0"
 newpipeExtractor = "v0.26.4"
 paletteKtx = "1.0.0"
 reorderable = "0.9.6"
+room = "2.8.4"
 foundationLayout = "1.11.4"
 securityCrypto = "1.1.0"
 superlyricapi = "3.4"
@@ -63,6 +64,10 @@ androidx-media3-datasource = { module = "androidx.media3:media3-datasource", ver
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Exoplayer" }
 androidx-media3-exoplayer-hls = { module = "androidx.media3:media3-exoplayer-hls", version.ref = "media3ExoplayerHls" }
 androidx-palette-ktx = { module = "androidx.palette:palette-ktx", version.ref = "paletteKtx" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
 superlyricapi = { module = "com.github.HChenX:SuperLyricApi", version.ref = "superlyricapi" }
 taglib = { module = "io.github.kyant0:taglib", version.ref = "taglib" }


### PR DESCRIPTION
## 描述 / Description

本 PR 完成用户数据从高频 JSON 存储到 Room 数据库的迁移，
提升数据一致性、持久化可靠性和高频读写性能。

迁移范围包括本地歌单、历史记录、歌单使用记录、播放统计、
收藏歌单、流量统计、播放状态、下载恢复状态、已下载目录、
Bilibili 跳过规则、平台歌单缓存、ManagedDownloadSnapshot
以及封面 URL 映射。

Room 在迁移成功后成为唯一权威存储，并增加恢复保护、旧数据清理、
增量写入和防止旧 JSON 覆盖新数据的处理。

This PR migrates user data from high-frequency JSON storage to Room,
improving consistency, persistence reliability and read/write performance.

## 类型 / Type

- [ ] Bug 修复 / Bug Fix
- [ ] 新功能 / New Feature
- [ ] 文档更新 / Documentation Update
- [x] 其他（存储架构迁移与稳定性优化）/ Other:
      Storage architecture migration and reliability improvements

## 修复或解决的问题 / Issues Fixed or Closed by This PR

- 减少高频场景下 JSON 全量读写带来的性能开销
- 防止旧 JSON 数据覆盖已经迁移到 Room 的数据
- 修复 Room 恢复过程中状态丢失或恢复不完整的问题
- 增加迁移完成后的旧 JSON 审计清理
- 保持 GitHub 和 WebDAV 现有同步模型与入口
- 修复继续播放卡片点击后首页列表立即跳动的问题

## 清单 / Checklist

- [x] 我已阅读并遵循贡献指南 / I have read and followed the contribution guidelines
- [x] 我已在本地测试这些更改 / I have tested these changes locally
- [x] 我已更新相关文档或注释（如适用） / I have updated relevant documentation or comments (if applicable)
- [ ] 我确认本次更改没有破坏任何原有逻辑 / I confirm this change does not break existing behavior
- [x] 我确认本次更改保持向下兼容（如适用） / I confirm this change remains backward compatible (if applicable)
- [x] 我已运行必要的构建、测试或静态检查 / I have run the required build, tests, or static checks
- [x] 我确认没有提交密钥、Token 或其他敏感信息 / I confirm no secrets, tokens or other sensitive information were committed
- [ ] 涉及 UI 变更时，我已补充截图或录屏（如适用） / I have added screenshots or recordings for UI changes (if applicable)

## 其他信息 / Additional Information

已验证：

- `HomeHostScreenTest`：3 项通过
- `HomeScreenMappingTest`：9 项通过
- `./gradlew :app:assembleDebug`：构建成功
- `./gradlew :app:lintDebug`：执行成功

本次升级保证 Room 数据可继续被新版本读取。
降级版本读取新 Room 数据不作为兼容目标。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 用户可见行为

- 用户数据改用 Room 持久化。覆盖歌单、播放历史、播放统计、播放队列、收藏歌单、下载数据、平台缓存、跳过规则、流量统计和封面映射。
- 首次访问时导入旧 JSON。导入成功后，Room 成为主存储。
- 迁移未完成或失败时保留旧 JSON，并执行恢复重试。迁移完成后，系统按审计状态清理旧 JSON。
- Room 写入失败时保留内存数据。恢复时合并较新的 Room 数据与本地新增、修改和删除。
- 播放来源路由支持持久化。来源路由为空或超过 16 KiB 时清除。
- 加密凭据存储失败时，系统重置受影响存储或切换到内存存储，避免应用崩溃。
- GitHub 或 WebDAV 未配置时，同步立即返回配置错误。
- 打开首页详情页时，使用记录列表保持稳定。关闭详情页后显示最新记录。
- Room 支持从版本 1 连续迁移至版本 15。不保证降级版本读取 Room 数据。

## 测试

- 新增数据库迁移、数据映射、导入、恢复、增量写入和旧 JSON 清理测试。
- 新增下载、播放队列、播放统计、收藏歌单、平台缓存、跳过规则、流量统计和封面映射测试。
- 新增加密凭据恢复测试。
- 新增首页详情页使用记录快照测试。
- 已验证 `HomeHostScreenTest`、`HomeScreenMappingTest`、debug assembly 和 debug lint。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->