### PR TITLE
feat: implement backdrop fill logic for AdvancedGlassOverscroll

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscrollRenderTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscrollRenderTest.kt
@@ -1,0 +1,123 @@
+package moe.ouom.neriplayer.ui.effect.glass
+
+import android.os.Build
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
+import moe.ouom.neriplayer.testutil.assumeComposeHostAvailable
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
+class AdvancedGlassOverscrollRenderTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun assumeDeviceUnlocked() {
+        assumeComposeHostAvailable()
+    }
+
+    @Test
+    fun playlistHeroColorFillsTheTopGapDuringDownwardOverscroll() {
+        val overscrollApplied = mutableStateOf(false)
+
+        composeRule.setContent {
+            val effect = remember { AdvancedGlassOverscrollFactory.createOverscrollEffect() }
+            val layoutReady = remember { mutableStateOf(false) }
+            val overscrollOffset = remember { mutableStateOf(0f) }
+            CompositionLocalProvider(
+                LocalAdvancedGlassOverscrollBackdrop provides AdvancedGlassOverscrollBackdrop(
+                    color = Color.Blue,
+                    offsetY = overscrollOffset
+                )
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Red)
+                        .drawAdvancedGlassOverscrollBackdrop(
+                            AdvancedGlassOverscrollBackdrop(
+                                color = Color.Blue,
+                                offsetY = overscrollOffset
+                            )
+                        )
+                        .onGloballyPositioned { layoutReady.value = true }
+                        .testTag(PlaylistOverscrollRootTag)
+                ) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        overscrollEffect = effect
+                    ) {
+                        item {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(48.dp)
+                                    .background(Color.Green)
+                            )
+                        }
+                    }
+                }
+            }
+            LaunchedEffect(effect, layoutReady.value) {
+                if (!layoutReady.value) return@LaunchedEffect
+                withFrameNanos { }
+                effect.applyToScroll(
+                    delta = Offset(0f, 64f),
+                    source = NestedScrollSource.UserInput,
+                    performScroll = { Offset.Zero }
+                )
+                overscrollApplied.value = effect.isInProgress
+            }
+        }
+
+        composeRule.waitUntil(timeoutMillis = 3_000) { overscrollApplied.value }
+        composeRule.waitForIdle()
+        val image = composeRule.onNodeWithTag(PlaylistOverscrollRootTag).captureToImage()
+        val pixels = image.toPixelMap()
+        val topPixel = pixels[image.width / 2, 8]
+        val firstGreenPixel = (0 until image.height).firstOrNull { y ->
+            val pixel = pixels[image.width / 2, y]
+            pixel.green > 0.9f && pixel.red < 0.1f && pixel.blue < 0.1f
+        }
+
+        assertTrue(
+            "playlist overscroll exposed the parent instead of the hero color: $topPixel",
+            topPixel.blue > 0.9f && topPixel.red < 0.1f
+        )
+        assertTrue(
+            "playlist content did not move below the fixed hero fill",
+            firstGreenPixel != null && firstGreenPixel > 8
+        )
+    }
+
+    private companion object {
+        const val PlaylistOverscrollRootTag = "playlist_overscroll_root"
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscroll.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscroll.kt
@@ -4,7 +4,12 @@ import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.OverscrollEffect
 import androidx.compose.foundation.OverscrollFactory
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasureResult
@@ -29,6 +34,14 @@ import kotlin.math.pow
 import kotlin.math.round
 import kotlin.math.sign
 
+internal data class AdvancedGlassOverscrollBackdrop(
+    val color: Color,
+    val offsetY: MutableState<Float>
+)
+
+internal val LocalAdvancedGlassOverscrollBackdrop =
+    staticCompositionLocalOf<AdvancedGlassOverscrollBackdrop?> { null }
+
 internal object AdvancedGlassOverscrollFactory : OverscrollFactory {
     override fun createOverscrollEffect(): OverscrollEffect = AdvancedGlassOverscrollEffect()
 
@@ -43,12 +56,14 @@ private class AdvancedGlassOverscrollEffect : OverscrollEffect {
             if (field != value) {
                 field = value
                 invalidatePlacement?.invoke()
+                syncBackdropOffset?.invoke()
             }
         }
     private var rawDragY = 0f
     private var resistanceScalePx = 0f
     private var animationJob: Job? = null
     private var invalidatePlacement: (() -> Unit)? = null
+    private var syncBackdropOffset: (() -> Unit)? = null
     private var launchAnimation: ((suspend CoroutineScope.() -> Unit) -> Job)? = null
 
     override val isInProgress: Boolean
@@ -126,10 +141,12 @@ private class AdvancedGlassOverscrollEffect : OverscrollEffect {
     fun attach(
         resistanceScalePx: Float,
         invalidatePlacement: () -> Unit,
+        syncBackdropOffset: () -> Unit,
         launchAnimation: (suspend CoroutineScope.() -> Unit) -> Job
     ) {
         this.resistanceScalePx = resistanceScalePx
         this.invalidatePlacement = invalidatePlacement
+        this.syncBackdropOffset = syncBackdropOffset
         this.launchAnimation = launchAnimation
     }
 
@@ -146,6 +163,7 @@ private class AdvancedGlassOverscrollEffect : OverscrollEffect {
         animationJob = null
         resetOffset()
         invalidatePlacement = null
+        syncBackdropOffset = null
         launchAnimation = null
     }
 
@@ -200,6 +218,7 @@ private class AdvancedGlassOverscrollNode(
         effect.attach(
             resistanceScalePx = resistanceScalePx(),
             invalidatePlacement = { invalidatePlacement() },
+            syncBackdropOffset = { syncBackdropOffset() },
             launchAnimation = { block -> coroutineScope.launch(block = block) }
         )
     }
@@ -207,6 +226,15 @@ private class AdvancedGlassOverscrollNode(
     override fun onDetach() {
         effect.detach()
         super.onDetach()
+    }
+
+    private fun syncBackdropOffset() {
+        currentValueOf(LocalAdvancedGlassOverscrollBackdrop)?.offsetY?.value =
+            effect.currentOffsetY()
+    }
+
+    private fun resistanceScalePx(): Float = with(currentValueOf(LocalDensity)) {
+        OVERSCROLL_RESISTANCE_SCALE_DP.dp.toPx()
     }
 
     override fun MeasureScope.measure(
@@ -226,10 +254,40 @@ private class AdvancedGlassOverscrollNode(
             }
         }
     }
+}
 
-    private fun resistanceScalePx(): Float = with(currentValueOf(LocalDensity)) {
-        OVERSCROLL_RESISTANCE_SCALE_DP.dp.toPx()
+internal fun androidx.compose.ui.Modifier.drawAdvancedGlassOverscrollBackdrop(
+    backdrop: AdvancedGlassOverscrollBackdrop
+): androidx.compose.ui.Modifier = drawBehind {
+    val fill = resolveAdvancedGlassOverscrollEdgeFill(
+        offsetY = backdrop.offsetY.value,
+        viewportHeight = size.height
+    )
+    if (fill != null) {
+        drawRect(
+            color = backdrop.color,
+            topLeft = Offset(0f, fill.top),
+            size = Size(size.width, fill.height)
+        )
     }
+}
+
+internal data class AdvancedGlassOverscrollEdgeFill(
+    val top: Float,
+    val height: Float
+)
+
+internal fun resolveAdvancedGlassOverscrollEdgeFill(
+    offsetY: Float,
+    viewportHeight: Float
+): AdvancedGlassOverscrollEdgeFill? {
+    if (offsetY <= 0f || viewportHeight <= 0f) return null
+    val height = round(offsetY).coerceAtMost(viewportHeight)
+    if (height <= 0f) return null
+    return AdvancedGlassOverscrollEdgeFill(
+        top = 0f,
+        height = height
+    )
 }
 
 internal fun dampedAdvancedGlassOverscrollOffset(

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/playlist/LocalPlaylistDetailModernComponents.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/playlist/LocalPlaylistDetailModernComponents.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -78,7 +79,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import moe.ouom.neriplayer.R
 import moe.ouom.neriplayer.ui.effect.glass.AdvancedGlassRole
+import moe.ouom.neriplayer.ui.effect.glass.AdvancedGlassOverscrollBackdrop
 import moe.ouom.neriplayer.ui.effect.glass.AdvancedGlassSurface
+import moe.ouom.neriplayer.ui.effect.glass.LocalAdvancedGlassOverscrollBackdrop
+import moe.ouom.neriplayer.ui.effect.glass.drawAdvancedGlassOverscrollBackdrop
 import moe.ouom.neriplayer.ui.haptic.HapticFilledIconButton
 import moe.ouom.neriplayer.ui.haptic.HapticIconButton
 import moe.ouom.neriplayer.util.format.formatPlayCount
@@ -618,8 +622,24 @@ internal fun PlaylistModernVisualColorsProvider(
             coverUrl = coverUrl,
             offlineMode = offlineMode
         )
-    CompositionLocalProvider(LocalPlaylistHeroVisualColors provides visualColors) {
-        content()
+    val overscrollOffset = remember { mutableStateOf(0f) }
+    val overscrollBackdrop = remember(overscrollOffset, visualColors.background) {
+        AdvancedGlassOverscrollBackdrop(
+            color = visualColors.background,
+            offsetY = overscrollOffset
+        )
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .drawAdvancedGlassOverscrollBackdrop(overscrollBackdrop)
+    ) {
+        CompositionLocalProvider(
+            LocalPlaylistHeroVisualColors provides visualColors,
+            LocalAdvancedGlassOverscrollBackdrop provides overscrollBackdrop
+        ) {
+            content()
+        }
     }
 }
 

--- a/app/src/test/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscrollTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscrollTest.kt
@@ -1,6 +1,7 @@
 package moe.ouom.neriplayer.ui.effect.glass
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -40,5 +41,47 @@ class AdvancedGlassOverscrollTest {
 
             assertEquals(rawDrag, restored, 0.01f)
         }
+    }
+
+    @Test
+    fun positiveOverscrollFillsTheExposedTopEdgeUsingRoundedTranslation() {
+        val fill = resolveAdvancedGlassOverscrollEdgeFill(
+            offsetY = 47.6f,
+            viewportHeight = 320f
+        )
+
+        val resolvedFill = requireNotNull(fill)
+        assertEquals(0f, resolvedFill.top, 0.001f)
+        assertEquals(48f, resolvedFill.height, 0.001f)
+    }
+
+    @Test
+    fun negativeOverscrollDoesNotFillTheTopEdge() {
+        assertNull(
+            resolveAdvancedGlassOverscrollEdgeFill(
+                offsetY = -48f,
+                viewportHeight = 320f
+            )
+        )
+    }
+
+    @Test
+    fun oversizedPositiveOverscrollIsClampedToTheViewport() {
+        val fill = resolveAdvancedGlassOverscrollEdgeFill(
+            offsetY = 500f,
+            viewportHeight = 320f
+        )
+
+        assertEquals(320f, requireNotNull(fill).height, 0.001f)
+    }
+
+    @Test
+    fun zeroOverscrollDoesNotDrawAnEdgeFill() {
+        assertNull(
+            resolveAdvancedGlassOverscrollEdgeFill(
+                offsetY = 0f,
+                viewportHeight = 320f
+            )
+        )
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 用户可见变化

- 播放列表向下过度滚动时，顶部间隙显示英雄背景色。
- 列表内容会随过度滚动正确下移。
- 填充高度会限制在视口范围内。

## 兼容性

- Android P 及更高版本支持该渲染行为。

## 测试

- 新增边缘填充逻辑的单元测试。
- 新增 Android Compose 渲染测试，验证背景颜色和列表位置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->