### PR TITLE
fix(network): avoid offline mode for known direct transports

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/data/traffic/NetworkStatusMonitor.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/traffic/NetworkStatusMonitor.kt
@@ -27,11 +27,9 @@ fun Context.isTrafficRiskNetworkNow(): Boolean {
 }
 
 private fun ConnectivityManager.hasLikelyInternetAccess(): Boolean = runCatching {
-    val network = activeNetwork ?: return@runCatching false
-    val capabilities = getNetworkCapabilities(network) ?: return@runCatching false
+    val capabilities = activeNetwork?.let { network -> getNetworkCapabilities(network) }
     hasLikelyNetworkTransport(
-        activeHasDirectTransport = capabilities.hasDirectNetworkTransport(),
-        activeHasVpnTransport = capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN),
+        activeHasDirectTransport = capabilities?.hasDirectNetworkTransport() == true,
         anyKnownHasDirectTransport = { anyKnownNetworkHasDirectTransport() }
     )
 }.getOrDefault(false)
@@ -58,11 +56,9 @@ private fun NetworkCapabilities.hasDirectNetworkTransport(): Boolean {
 
 internal fun hasLikelyNetworkTransport(
     activeHasDirectTransport: Boolean,
-    activeHasVpnTransport: Boolean,
     anyKnownHasDirectTransport: () -> Boolean
 ): Boolean {
     if (activeHasDirectTransport) return true
-    if (!activeHasVpnTransport) return false
 
     return anyKnownHasDirectTransport()
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/traffic/NetworkStatusMonitor.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/traffic/NetworkStatusMonitor.kt
@@ -19,8 +19,10 @@ fun Context.currentTrafficNetworkType(): TrafficNetworkType {
 }
 
 private fun ConnectivityManager.hasLikelyInternetAccess(): Boolean = runCatching {
-    val capabilities = activeNetwork?.let { network -> getNetworkCapabilities(network) }
+    val network = activeNetwork ?: return@runCatching false
+    val capabilities = getNetworkCapabilities(network)
     hasLikelyNetworkTransport(
+        hasActiveNetwork = true,
         activeHasDirectTransport = capabilities?.hasDirectNetworkTransport() == true,
         anyKnownHasDirectTransport = { anyKnownNetworkHasDirectTransport() }
     )
@@ -47,9 +49,11 @@ private fun NetworkCapabilities.hasDirectNetworkTransport(): Boolean {
 }
 
 internal fun hasLikelyNetworkTransport(
+    hasActiveNetwork: Boolean,
     activeHasDirectTransport: Boolean,
     anyKnownHasDirectTransport: () -> Boolean
 ): Boolean {
+    if (!hasActiveNetwork) return false
     if (activeHasDirectTransport) return true
 
     return anyKnownHasDirectTransport()

--- a/app/src/main/java/moe/ouom/neriplayer/data/traffic/NetworkStatusMonitor.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/traffic/NetworkStatusMonitor.kt
@@ -18,14 +18,6 @@ fun Context.currentTrafficNetworkType(): TrafficNetworkType {
     return connectivityManager.currentTrafficNetworkType()
 }
 
-fun Context.isTrafficRiskNetworkNow(): Boolean {
-    return when (currentTrafficNetworkType()) {
-        TrafficNetworkType.MOBILE,
-        TrafficNetworkType.ROAMING -> true
-        TrafficNetworkType.WIFI -> false
-    }
-}
-
 private fun ConnectivityManager.hasLikelyInternetAccess(): Boolean = runCatching {
     val capabilities = activeNetwork?.let { network -> getNetworkCapabilities(network) }
     hasLikelyNetworkTransport(

--- a/app/src/test/java/moe/ouom/neriplayer/data/traffic/NetworkStatusMonitorPolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/traffic/NetworkStatusMonitorPolicyTest.kt
@@ -46,22 +46,20 @@ class NetworkStatusMonitorPolicyTest {
     }
 
     @Test
-    fun `vpn transport alone does not keep app online`() {
+    fun `virtual transport alone does not keep app online`() {
         assertFalse(
             hasLikelyNetworkTransport(
                 activeHasDirectTransport = false,
-                activeHasVpnTransport = true,
                 anyKnownHasDirectTransport = { false }
             )
         )
     }
 
     @Test
-    fun `vpn default network follows underlying direct transport`() {
+    fun `fallback direct network keeps app online when active network is unusable`() {
         assertTrue(
             hasLikelyNetworkTransport(
                 activeHasDirectTransport = false,
-                activeHasVpnTransport = true,
                 anyKnownHasDirectTransport = { true }
             )
         )
@@ -72,7 +70,6 @@ class NetworkStatusMonitorPolicyTest {
         assertTrue(
             hasLikelyNetworkTransport(
                 activeHasDirectTransport = true,
-                activeHasVpnTransport = false,
                 anyKnownHasDirectTransport = { error("fallback should not be evaluated") }
             )
         )

--- a/app/src/test/java/moe/ouom/neriplayer/data/traffic/NetworkStatusMonitorPolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/traffic/NetworkStatusMonitorPolicyTest.kt
@@ -49,6 +49,7 @@ class NetworkStatusMonitorPolicyTest {
     fun `virtual transport alone does not keep app online`() {
         assertFalse(
             hasLikelyNetworkTransport(
+                hasActiveNetwork = true,
                 activeHasDirectTransport = false,
                 anyKnownHasDirectTransport = { false }
             )
@@ -56,9 +57,21 @@ class NetworkStatusMonitorPolicyTest {
     }
 
     @Test
-    fun `fallback direct network keeps app online when active network is unusable`() {
+    fun `missing active network enters offline mode even with stale direct transport`() {
+        assertFalse(
+            hasLikelyNetworkTransport(
+                hasActiveNetwork = false,
+                activeHasDirectTransport = false,
+                anyKnownHasDirectTransport = { true }
+            )
+        )
+    }
+
+    @Test
+    fun `fallback direct network keeps app online when active network is indirect`() {
         assertTrue(
             hasLikelyNetworkTransport(
+                hasActiveNetwork = true,
                 activeHasDirectTransport = false,
                 anyKnownHasDirectTransport = { true }
             )
@@ -69,6 +82,7 @@ class NetworkStatusMonitorPolicyTest {
     fun `active direct transport does not scan fallback networks`() {
         assertTrue(
             hasLikelyNetworkTransport(
+                hasActiveNetwork = true,
                 activeHasDirectTransport = true,
                 anyKnownHasDirectTransport = { error("fallback should not be evaluated") }
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 修复网络状态判断，避免仅因 VPN 或过期直连网络而错误退出离线模式。
- 当前无活动网络时保持离线；活动网络为间接传输但存在已知直连传输时保持在线。
- 新增并更新策略测试，覆盖 VPN-only、无活动网络及间接网络场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->