### PR TITLE
feat: enable playback fade-in and crossfade by default

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -406,8 +406,8 @@ object PlayerManager {
     internal var mobileDataNeteaseAudioQuality: String = "standard"
     internal var mobileDataYouTubeAudioQuality: String = "low"
     internal var mobileDataBiliAudioQuality: String = "low"
-    internal var playbackFadeInEnabled = false
-    internal var playbackCrossfadeNextEnabled = false
+    internal var playbackFadeInEnabled = true
+    internal var playbackCrossfadeNextEnabled = true
     internal var playbackFadeInDurationMs = DEFAULT_FADE_DURATION_MS
     internal var playbackFadeOutDurationMs = DEFAULT_FADE_DURATION_MS
     internal var playbackCrossfadeInDurationMs = DEFAULT_FADE_DURATION_MS

--- a/app/src/main/java/moe/ouom/neriplayer/data/settings/AutoSettingsSchema.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/settings/AutoSettingsSchema.kt
@@ -1476,7 +1476,7 @@ object AutoSettingsSchema {
         @AutoSetting(
             key = "playback_fade_in",
             type = SettingValueType.Boolean,
-            defaultBoolean = false,
+            defaultBoolean = true,
             order = 10,
             ui = SettingUiType.Custom,
             access = SettingAccessMode.KeyOnly
@@ -1489,7 +1489,7 @@ object AutoSettingsSchema {
         @AutoSetting(
             key = "playback_crossfade_next",
             type = SettingValueType.Boolean,
-            defaultBoolean = false,
+            defaultBoolean = true,
             order = 20,
             ui = SettingUiType.Custom,
             access = SettingAccessMode.KeyOnly

--- a/app/src/main/java/moe/ouom/neriplayer/data/settings/PlaybackPreferenceSnapshot.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/settings/PlaybackPreferenceSnapshot.kt
@@ -115,8 +115,8 @@ data class PlaybackPreferenceSnapshot(
     val keepPlaybackModeState: Boolean = true,
     val neteaseAutoSourceSwitch: Boolean = false,
     val neteaseLocalSourceFallback: Boolean = false,
-    val playbackFadeIn: Boolean = false,
-    val playbackCrossfadeNext: Boolean = false,
+    val playbackFadeIn: Boolean = true,
+    val playbackCrossfadeNext: Boolean = true,
     val sleepTimerFinishCurrentOnExpiry: Boolean = false,
     val playbackFadeInDurationMs: Long = 500L,
     val playbackFadeOutDurationMs: Long = 500L,
@@ -432,8 +432,8 @@ internal fun Preferences.toPlaybackPreferenceSnapshot(): PlaybackPreferenceSnaps
         keepPlaybackModeState = this[SettingsKeys.KEEP_PLAYBACK_MODE_STATE] ?: true,
         neteaseAutoSourceSwitch = this[SettingsKeys.NETEASE_AUTO_SOURCE_SWITCH] ?: false,
         neteaseLocalSourceFallback = this[SettingsKeys.NETEASE_LOCAL_SOURCE_FALLBACK] ?: false,
-        playbackFadeIn = this[SettingsKeys.PLAYBACK_FADE_IN] ?: false,
-        playbackCrossfadeNext = this[SettingsKeys.PLAYBACK_CROSSFADE_NEXT] ?: false,
+        playbackFadeIn = this[SettingsKeys.PLAYBACK_FADE_IN] ?: true,
+        playbackCrossfadeNext = this[SettingsKeys.PLAYBACK_CROSSFADE_NEXT] ?: true,
         sleepTimerFinishCurrentOnExpiry =
             this[SettingsKeys.PLAYBACK_SLEEP_TIMER_FINISH_CURRENT_ON_EXPIRY] ?: false,
         playbackFadeInDurationMs = this[SettingsKeys.PLAYBACK_FADE_IN_DURATION_MS] ?: 500L,
@@ -580,8 +580,8 @@ private fun readCachedPlaybackPreferenceSnapshot(context: Context): PlaybackPref
             prefs.getBoolean(PLAYBACK_NETEASE_AUTO_SOURCE_SWITCH_KEY, false),
         neteaseLocalSourceFallback =
             prefs.getBoolean(PLAYBACK_NETEASE_LOCAL_SOURCE_FALLBACK_KEY, false),
-        playbackFadeIn = prefs.getBoolean(PLAYBACK_FADE_IN_KEY, false),
-        playbackCrossfadeNext = prefs.getBoolean(PLAYBACK_CROSSFADE_NEXT_KEY, false),
+        playbackFadeIn = prefs.getBoolean(PLAYBACK_FADE_IN_KEY, true),
+        playbackCrossfadeNext = prefs.getBoolean(PLAYBACK_CROSSFADE_NEXT_KEY, true),
         sleepTimerFinishCurrentOnExpiry = prefs.getBoolean(
             PLAYBACK_SLEEP_TIMER_FINISH_CURRENT_ON_EXPIRY_KEY,
             false

--- a/app/src/main/java/moe/ouom/neriplayer/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/settings/SettingsRepository.kt
@@ -437,10 +437,10 @@ class SettingsRepository(private val context: Context) {
         autoSettingsRepository.homeCardRecommendedFlow
 
     val playbackFadeInFlow: Flow<Boolean> =
-        dataStoreSettingFlow { it[SettingsKeys.PLAYBACK_FADE_IN] ?: false }
+        dataStoreSettingFlow { it[SettingsKeys.PLAYBACK_FADE_IN] ?: true }
 
     val playbackCrossfadeNextFlow: Flow<Boolean> =
-        dataStoreSettingFlow { it[SettingsKeys.PLAYBACK_CROSSFADE_NEXT] ?: false }
+        dataStoreSettingFlow { it[SettingsKeys.PLAYBACK_CROSSFADE_NEXT] ?: true }
 
     val sleepTimerFinishCurrentOnExpiryFlow: Flow<Boolean> =
         dataStoreSettingFlow {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
@@ -1526,8 +1526,12 @@ private fun NeriAppContent(
     val showHomeTrendingCard by repo.homeCardTrendingFlow.collectAsStateWithLifecycle(initialValue = true)
     val showHomeRadarCard by repo.homeCardRadarFlow.collectAsStateWithLifecycle(initialValue = true)
     val showHomeRecommendedCard by repo.homeCardRecommendedFlow.collectAsStateWithLifecycle(initialValue = true)
-    val playbackFadeIn by repo.playbackFadeInFlow.collectAsStateWithLifecycle(initialValue = false)
-    val playbackCrossfadeNext by repo.playbackCrossfadeNextFlow.collectAsStateWithLifecycle(initialValue = false)
+    val playbackFadeIn by repo.playbackFadeInFlow.collectAsStateWithLifecycle(
+        initialValue = startupPlaybackPreferences.playbackFadeIn
+    )
+    val playbackCrossfadeNext by repo.playbackCrossfadeNextFlow.collectAsStateWithLifecycle(
+        initialValue = startupPlaybackPreferences.playbackCrossfadeNext
+    )
     val sleepTimerFinishCurrentOnExpiry by repo.sleepTimerFinishCurrentOnExpiryFlow
         .collectAsStateWithLifecycle(
             initialValue = startupPlaybackPreferences.sleepTimerFinishCurrentOnExpiry

--- a/app/src/test/java/moe/ouom/neriplayer/data/settings/AutoSettingsGeneratedTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/settings/AutoSettingsGeneratedTest.kt
@@ -364,6 +364,28 @@ class AutoSettingsGeneratedTest {
     }
 
     @Test
+    fun playbackFadeInSettingUsesPlaybackMetadata() {
+        val metadata = AutoSettingsMetadata.requireSetting(SettingsKeys.PLAYBACK_FADE_IN)
+
+        assertEquals("playback_fade_in", metadata.keyName)
+        assertEquals(SettingValueType.Boolean, metadata.valueType)
+        assertEquals(SettingUiType.Custom, metadata.ui)
+        assertEquals(SettingAccessMode.KeyOnly, metadata.access)
+        assertEquals(AutoSettingsSections.playback, metadata.section)
+    }
+
+    @Test
+    fun playbackCrossfadeNextSettingUsesPlaybackMetadata() {
+        val metadata = AutoSettingsMetadata.requireSetting(SettingsKeys.PLAYBACK_CROSSFADE_NEXT)
+
+        assertEquals("playback_crossfade_next", metadata.keyName)
+        assertEquals(SettingValueType.Boolean, metadata.valueType)
+        assertEquals(SettingUiType.Custom, metadata.ui)
+        assertEquals(SettingAccessMode.KeyOnly, metadata.access)
+        assertEquals(AutoSettingsSections.playback, metadata.section)
+    }
+
+    @Test
     fun exploreSearchHistorySettingDefaultsToEnabled() {
         val setting = AutoSettingsSchema.general.exploreSearchHistoryEnabled
 

--- a/app/src/test/java/moe/ouom/neriplayer/data/settings/PlaybackPreferenceSnapshotTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/settings/PlaybackPreferenceSnapshotTest.kt
@@ -34,6 +34,25 @@ class PlaybackPreferenceSnapshotTest {
     }
 
     @Test
+    fun `empty preferences enable playback fade by default`() {
+        val snapshot = preferencesOf().toPlaybackPreferenceSnapshot()
+
+        assertTrue(snapshot.playbackFadeIn)
+        assertTrue(snapshot.playbackCrossfadeNext)
+    }
+
+    @Test
+    fun `explicitly disabled playback fades remain disabled`() {
+        val snapshot = preferencesOf(
+            SettingsKeys.PLAYBACK_FADE_IN to false,
+            SettingsKeys.PLAYBACK_CROSSFADE_NEXT to false
+        ).toPlaybackPreferenceSnapshot()
+
+        assertFalse(snapshot.playbackFadeIn)
+        assertFalse(snapshot.playbackCrossfadeNext)
+    }
+
+    @Test
     fun `preferences restore long form playback progress setting`() {
         val snapshot = preferencesOf(
             SettingsKeys.REMEMBER_LONG_FORM_PLAYBACK_PROGRESS to false
@@ -113,7 +132,8 @@ class PlaybackPreferenceSnapshotTest {
         assertFalse(snapshot.neteaseAutoSourceSwitch)
         assertFalse(snapshot.neteaseLocalSourceFallback)
         assertFalse(snapshot.allowMixedPlayback)
-        assertFalse(snapshot.playbackFadeIn)
+        assertTrue(snapshot.playbackFadeIn)
+        assertTrue(snapshot.playbackCrossfadeNext)
         assertFalse(snapshot.sleepTimerFinishCurrentOnExpiry)
         assertFalse(snapshot.playbackVolumeNormalizationEnabled)
         assertFalse(snapshot.playbackHighResolutionOutputEnabled)

--- a/app/src/test/java/moe/ouom/neriplayer/data/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/settings/SettingsRepositoryTest.kt
@@ -11,6 +11,24 @@ import java.io.File
 
 class SettingsRepositoryTest {
     @Test
+    fun playbackFadeSettingsDefaultToEnabledWhenUnset() {
+        val filesDir = File.createTempFile("neriplayer-settings-fade", "").apply {
+            delete()
+            mkdirs()
+            deleteOnExit()
+        }
+        val context = mock(Context::class.java)
+        `when`(context.filesDir).thenReturn(filesDir)
+        `when`(context.applicationContext).thenReturn(context)
+        val repository = SettingsRepository(context)
+
+        runBlocking {
+            assertTrue(repository.playbackFadeInFlow.first())
+            assertTrue(repository.playbackCrossfadeNextFlow.first())
+        }
+    }
+
+    @Test
     fun enablingDynamicIslandLyricsTurnsOnBluetoothLyricsAndTranslation() {
         val filesDir = File.createTempFile("neriplayer-settings", "").apply {
             delete()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

默认启用播放淡入和下一曲交叉淡化。用户仍可在设置中关闭这两项功能。

新增测试，覆盖默认启用、显式禁用和设置元数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->