### PR TITLE
feat: stop playback and service on task removal and enhance audio route loss handling

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -2499,8 +2499,10 @@ object PlayerManager {
 
     internal fun stopProgressUpdates() = this.stopProgressUpdatesImpl()
 
-    internal fun stopPlaybackImmediately(reason: String) =
-        this.stopPlaybackImmediatelyImpl(reason)
+    internal fun stopPlaybackImmediately(
+        reason: String,
+        forcePersist: Boolean = true
+    ) = this.stopPlaybackImmediatelyImpl(reason, forcePersist)
 
     internal fun stopPlaybackPreservingQueue(clearMediaUrl: Boolean = false) =
         this.stopPlaybackPreservingQueueImpl(clearMediaUrl)

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -230,6 +230,7 @@ import moe.ouom.neriplayer.ui.component.lyrics.LyricEntry
 import moe.ouom.neriplayer.ui.viewmodel.playlist.BiliVideoItem
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.core.player.playback.stopPlaybackImmediatelyImpl
 import moe.ouom.neriplayer.util.platform.LanguageManager
 import java.io.File
 import java.io.RandomAccessFile
@@ -2497,6 +2498,9 @@ object PlayerManager {
     ) = this.applyListenTogetherPlaybackModeImpl(repeatMode, shuffleEnabled)
 
     internal fun stopProgressUpdates() = this.stopProgressUpdatesImpl()
+
+    internal fun stopPlaybackImmediately(reason: String) =
+        this.stopPlaybackImmediatelyImpl(reason)
 
     internal fun stopPlaybackPreservingQueue(clearMediaUrl: Boolean = false) =
         this.stopPlaybackPreservingQueueImpl(clearMediaUrl)

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
@@ -1291,8 +1291,10 @@ internal fun PlayerManager.handleAudioBecomingNoisyImpl(): Boolean {
         }
         NPLogger.d(
             "NERI-PlayerManager",
-            "handleAudioBecomingNoisy(): schedule delayed pause for device=${currentDevice.type}:${currentDevice.name}"
+            "handleAudioBecomingNoisy(): mute while confirming disconnect for " +
+                "device=${currentDevice.type}:${currentDevice.name}"
         )
+        suppressPlaybackForAudioRouteLoss(reason = "bluetooth_disconnect_pending")
         schedulePauseForBluetoothDisconnect(
             previousDevice = currentDevice,
             reason = "becoming_noisy"

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -8,6 +8,7 @@ import androidx.media3.common.Player
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -461,6 +462,26 @@ internal fun PlayerManager.scheduleStatePersist(
             shouldResumePlayback = shouldResumePlayback
         )
     }
+}
+
+internal suspend fun PlayerManager.persistStateNow(
+    positionMs: Long = _playbackPositionMs.value.coerceAtLeast(0L),
+    shouldResumePlayback: Boolean = currentPlaylist.isNotEmpty() && shouldResumePlaybackSnapshot(),
+    reason: String
+): Boolean {
+    if (!initialized) return false
+    val pendingJob = scheduledStatePersistJob
+    scheduledStatePersistJob = null
+    pendingJob?.cancelAndJoin()
+    NPLogger.d(
+        "NERI-PlayerManager",
+        "persistStateNow: reason=$reason positionMs=$positionMs shouldResume=$shouldResumePlayback"
+    )
+    persistState(
+        positionMs = positionMs,
+        shouldResumePlayback = shouldResumePlayback
+    )
+    return true
 }
 
 private suspend fun PlayerManager.updateCurrentFavorite(

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/playback/PlayerManagerPlaybackExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/playback/PlayerManagerPlaybackExtensions.kt
@@ -30,6 +30,7 @@ import moe.ouom.neriplayer.core.player.model.SongUrlResult
 import moe.ouom.neriplayer.core.player.model.resolvePlayerQueueRestoreOrder
 import moe.ouom.neriplayer.core.player.model.resolvePlayerRepeatAllShuffleOrder
 import moe.ouom.neriplayer.core.player.model.resolvePlayerSequentialShuffleOrder
+import moe.ouom.neriplayer.core.player.persistence.persistStateNow
 import moe.ouom.neriplayer.core.player.persistence.scheduleStatePersist
 import moe.ouom.neriplayer.core.player.policy.command.PlaybackCommandSource
 import moe.ouom.neriplayer.core.player.policy.command.PlaybackStartPlan
@@ -195,6 +196,46 @@ internal fun PlayerManager.pauseForAudioRouteLoss(reason: String) {
         debugReason = "audio_route_loss:$reason",
         flushPlayerOutput = true,
     )
+}
+
+private fun PlayerManager.persistPausedPlaybackState(
+    forcePersist: Boolean,
+    positionMs: Long,
+    shouldResumePlayback: Boolean,
+    reason: String
+) {
+    if (!forcePersist) {
+        scheduleStatePersist(
+            positionMs = positionMs,
+            shouldResumePlayback = shouldResumePlayback
+        )
+        return
+    }
+    ioScope.launch {
+        try {
+            runCatching { drainPlaybackStatsPersistJobBlocking(reason) }
+                .onFailure { error ->
+                    NPLogger.w(
+                        "NERI-PlayerManager",
+                        "pause persistence could not drain playback stats: reason=$reason",
+                        error
+                    )
+                }
+            persistStateNow(
+                positionMs = positionMs,
+                shouldResumePlayback = shouldResumePlayback,
+                reason = reason
+            )
+        } catch (error: kotlinx.coroutines.CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            NPLogger.w(
+                "NERI-PlayerManager",
+                "pause persistence failed: reason=$reason",
+                error
+            )
+        }
+    }
 }
 
 internal fun PlayerManager.preparePlayerForManagedStart(plan: PlaybackStartPlan) {
@@ -1272,9 +1313,11 @@ internal fun PlayerManager.pauseImpl(
             LyriconManager.setPlaybackState(false)
         }
         clearAudioRouteMuteSuppression(reason = debugReason)
-        scheduleStatePersist(
+        persistPausedPlaybackState(
+            forcePersist = forcePersist,
             positionMs = action.persistPositionMs,
-            shouldResumePlayback = action.persistShouldResumePlayback
+            shouldResumePlayback = action.persistShouldResumePlayback,
+            reason = debugReason
         )
         emitPlaybackCommand(
             type = "PAUSE",
@@ -1425,34 +1468,12 @@ private fun PlayerManager.pauseInternal(
             _playbackDurationMs.value
         )
     )
-    if (forcePersist) {
-        ioScope.launch {
-            try {
-                runCatching { drainPlaybackStatsPersistJobBlocking(debugReason) }
-                    .onFailure { error ->
-                        NPLogger.w(
-                            "NERI-PlayerManager",
-                            "pause persistence could not drain playback stats: reason=$debugReason",
-                            error
-                        )
-                    }
-                persistState(positionMs = currentPosition, shouldResumePlayback = false)
-            } catch (error: kotlinx.coroutines.CancellationException) {
-                throw error
-            } catch (error: Exception) {
-                NPLogger.w(
-                    "NERI-PlayerManager",
-                    "pause persistence failed: reason=$debugReason",
-                    error
-                )
-            }
-        }
-    } else {
-        scheduleStatePersist(
-            positionMs = currentPosition,
-            shouldResumePlayback = false
-        )
-    }
+    persistPausedPlaybackState(
+        forcePersist = forcePersist,
+        positionMs = currentPosition,
+        shouldResumePlayback = false,
+        reason = debugReason
+    )
 }
 
 internal fun PlayerManager.togglePlayPauseImpl(allowFade: Boolean = true) {
@@ -2073,9 +2094,12 @@ internal fun PlayerManager.stopPlaybackPreservingQueueImpl(clearMediaUrl: Boolea
     scheduleStatePersist()
 }
 
-internal fun PlayerManager.stopPlaybackImmediatelyImpl(reason: String) {
+internal fun PlayerManager.stopPlaybackImmediatelyImpl(
+    reason: String,
+    forcePersist: Boolean = true
+) {
     pauseImpl(
-        forcePersist = true,
+        forcePersist = forcePersist,
         commandSource = PlaybackCommandSource.LOCAL_SAFETY,
         allowFadeOut = false,
         debugReason = reason,

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/playback/PlayerManagerPlaybackExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/playback/PlayerManagerPlaybackExtensions.kt
@@ -192,7 +192,8 @@ internal fun PlayerManager.pauseForAudioRouteLoss(reason: String) {
         },
         allowFadeOut = false,
         preserveMutedVolume = true,
-        debugReason = "audio_route_loss:$reason"
+        debugReason = "audio_route_loss:$reason",
+        flushPlayerOutput = true,
     )
 }
 
@@ -1235,7 +1236,8 @@ internal fun PlayerManager.pauseImpl(
     commandSource: PlaybackCommandSource = PlaybackCommandSource.LOCAL,
     allowFadeOut: Boolean = true,
     preserveMutedVolume: Boolean = false,
-    debugReason: String = "pause_internal"
+    debugReason: String = "pause_internal",
+    flushPlayerOutput: Boolean = false,
 ) {
     ensureInitialized()
     if (!initialized) return
@@ -1259,6 +1261,13 @@ internal fun PlayerManager.pauseImpl(
         pendingMediaLoadPositionMs = action.persistPositionMs
         _playWhenReadyFlow.value = action.resumePlaybackAfterLoad
         _isPlayingFlow.value = false
+        if (flushPlayerOutput) {
+            runCatching {
+                player.playWhenReady = false
+                player.stop()
+            }
+            _playerPlaybackStateFlow.value = Player.STATE_IDLE
+        }
         if (lyriconEnabled) {
             LyriconManager.setPlaybackState(false)
         }
@@ -1316,7 +1325,8 @@ internal fun PlayerManager.pauseImpl(
                     forcePersist = forcePersist,
                     resetVolumeBeforePause = pauseVolumePlan.resetVolumeBeforePause,
                     restoreVolumeAfterPause = pauseVolumePlan.restoreVolumeAfterPause,
-                    debugReason = debugReason
+                    debugReason = debugReason,
+                    flushPlayerOutput = flushPlayerOutput,
                 )
             } finally {
                 if (pendingPauseJob === scheduledPauseJob) {
@@ -1330,7 +1340,8 @@ internal fun PlayerManager.pauseImpl(
             forcePersist = forcePersist,
             resetVolumeBeforePause = pauseVolumePlan.resetVolumeBeforePause,
             restoreVolumeAfterPause = pauseVolumePlan.restoreVolumeAfterPause,
-            debugReason = debugReason
+            debugReason = debugReason,
+            flushPlayerOutput = flushPlayerOutput,
         )
     }
     emitPlaybackCommand(
@@ -1356,7 +1367,8 @@ private fun PlayerManager.pauseInternal(
     forcePersist: Boolean,
     resetVolumeBeforePause: Boolean,
     restoreVolumeAfterPause: Boolean,
-    debugReason: String
+    debugReason: String,
+    flushPlayerOutput: Boolean,
 ) {
     pendingPauseJob = null
     updateResumePlaybackRequested(false)
@@ -1377,7 +1389,13 @@ private fun PlayerManager.pauseInternal(
         "pauseInternal: reason=$debugReason, song=${currentSong?.name}, positionMs=$currentPosition, state=${playbackStateName(player.playbackState)}, playWhenReady=${player.playWhenReady}, forcePersist=$forcePersist, resetVolumeBeforePause=$resetVolumeBeforePause, restoreVolumeAfterPause=$restoreVolumeAfterPause, stack=[$stackHint]"
     )
     player.playWhenReady = false
-    player.pause()
+    if (flushPlayerOutput) {
+        player.stop()
+        _playerPlaybackStateFlow.value = Player.STATE_IDLE
+        stopProgressUpdates()
+    } else {
+        player.pause()
+    }
     if (lyriconEnabled) {
         LyriconManager.setPlaybackState(false)
     }
@@ -2053,4 +2071,14 @@ internal fun PlayerManager.stopPlaybackPreservingQueueImpl(clearMediaUrl: Boolea
         "stopPlaybackPreservingQueue(): completed, queueSize=${currentPlaylist.size}, currentIndex=$currentIndex, retainedSong=${_currentSongFlow.value?.name}, mediaUrlPresent=${!_currentMediaUrl.value.isNullOrBlank()}"
     )
     scheduleStatePersist()
+}
+
+internal fun PlayerManager.stopPlaybackImmediatelyImpl(reason: String) {
+    pauseImpl(
+        forcePersist = true,
+        commandSource = PlaybackCommandSource.LOCAL_SAFETY,
+        allowFadeOut = false,
+        debugReason = reason,
+        flushPlayerOutput = true,
+    )
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/policy/offload/PlaybackAudioOffloadPolicy.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/policy/offload/PlaybackAudioOffloadPolicy.kt
@@ -18,8 +18,9 @@ internal fun requiresPcmAudioProcessing(
     audioSource: PlaybackAudioSource?,
     listenTogetherPlaybackRate: Float,
 ): Boolean {
-    // 网易云直链在部分设备的系统卸载输出会反复重配，保持 PCM 管线避免视觉设置影响播放
+    // 网易云直链和 B 站换源都容易触发系统 offload 残留缓冲，主动走 PCM 管线
     return audioSource == PlaybackAudioSource.NETEASE ||
+        audioSource == PlaybackAudioSource.BILIBILI ||
         usbExclusivePlaybackEnabled ||
         abs(playbackSpeed - 1f) > PLAYBACK_PARAMETER_EPSILON ||
         abs(playbackPitch - 1f) > PLAYBACK_PARAMETER_EPSILON ||

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
@@ -230,6 +230,13 @@ internal fun shouldStopServiceForExternalPauseCommand(
     return stopServiceRequested && source != MEDIA_SESSION_STOP_SOURCE
 }
 
+internal fun shouldStopPlaybackOnTaskRemoved(
+    hasPlaybackSurfaceContent: Boolean,
+    transportActive: Boolean,
+): Boolean {
+    return hasPlaybackSurfaceContent && transportActive
+}
+
 internal fun mediaSessionPlaybackActions(): Long {
     return PlaybackState.ACTION_PLAY or
         PlaybackState.ACTION_PAUSE or
@@ -2574,25 +2581,60 @@ class AudioPlayerService : Service() {
 
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
+        val hasPlaybackSurfaceContent = hasPlaybackSurfaceContent()
+        val transportActive = runCatching {
+            PlayerManager.isTransportActiveWithoutInitialization()
+        }.getOrDefault(false)
         NPLogger.w(
             "NERI-APS",
-            "onTaskRemoved hasItems=${PlayerManager.hasItems()} isPlaying=${PlayerManager.isPlayingFlow.value}"
+            "onTaskRemoved hasSurface=$hasPlaybackSurfaceContent " +
+                "transportActive=$transportActive hasItems=${PlayerManager.hasItems()} " +
+                "isPlaying=${PlayerManager.isPlayingFlow.value}"
         )
-        // 划掉任务不代表用户停止播放, 正在播的会话要保留进程重建恢复意图
-        if (PlayerManager.hasItems()) {
+        if (
+            shouldStopPlaybackOnTaskRemoved(
+                hasPlaybackSurfaceContent = hasPlaybackSurfaceContent,
+                transportActive = transportActive,
+            )
+        ) {
+            allowServiceRestart = false
             flushPlaybackStatsSafely("task_removed", "task removed")
+            runCatching {
+                PlayerManager.stopPlaybackImmediately("task_removed")
+            }.onFailure {
+                NPLogger.w("NERI-APS", "playback stop failed during task removed", it)
+            }
             runCatching {
                 PlayerManager.scheduleStatePersist(
                     positionMs = PlayerManager.playbackPositionFlow.value,
-                    shouldResumePlayback = PlayerManager.playWhenReadyFlow.value ||
-                        PlayerManager.isPlayingFlow.value,
+                    shouldResumePlayback = false,
                     debounceMs = 0L
                 )
             }.onFailure {
                 NPLogger.w("NERI-APS", "state persist failed during task removed", it)
             }
+            stopForegroundIfStarted("task_removed")
+            stopSelf()
+            return
+        }
+        if (PlayerManager.hasItems()) {
+            runCatching {
+                PlayerManager.scheduleStatePersist(
+                    positionMs = PlayerManager.playbackPositionFlow.value,
+                    shouldResumePlayback = false,
+                    debounceMs = 0L
+                )
+            }.onFailure {
+                NPLogger.w("NERI-APS", "state persist failed during inactive task removed", it)
+            }
             runCatching { updateNotification() }
-                .onFailure { NPLogger.w("NERI-APS", "notification update failed during task removed", it) }
+                .onFailure {
+                    NPLogger.w(
+                        "NERI-APS",
+                        "notification update failed during inactive task removed",
+                        it
+                    )
+                }
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
@@ -240,6 +240,13 @@ internal fun shouldStopPlaybackOnTaskRemoved(
     return hasPlaybackSurfaceContent && transportActive
 }
 
+internal fun resolveTaskRemovedTransportActive(
+    playerTransportActive: Boolean,
+    listenTogetherRemotePlaying: Boolean,
+): Boolean {
+    return playerTransportActive || listenTogetherRemotePlaying
+}
+
 internal data class TaskRemovedPlaybackAction(
     val stopPlaybackImmediately: Boolean,
     val persistPlaybackState: Boolean,
@@ -259,9 +266,14 @@ internal data class TaskRemovedPlaybackCallbacks(
 
 internal fun resolveTaskRemovedPlaybackAction(
     hasPlaybackSurfaceContent: Boolean,
-    transportActive: Boolean,
+    playerTransportActive: Boolean,
+    listenTogetherRemotePlaying: Boolean,
     hasItems: Boolean,
 ): TaskRemovedPlaybackAction {
+    val transportActive = resolveTaskRemovedTransportActive(
+        playerTransportActive = playerTransportActive,
+        listenTogetherRemotePlaying = listenTogetherRemotePlaying,
+    )
     val stopPlaybackImmediately = shouldStopPlaybackOnTaskRemoved(
         hasPlaybackSurfaceContent = hasPlaybackSurfaceContent,
         transportActive = transportActive,
@@ -282,21 +294,28 @@ internal suspend fun executeTaskRemovedPlaybackAction(
         runCatching { callbacks.stopPlaybackImmediately() }
             .onFailure(callbacks.onPlaybackStopFailure)
     }
-    if (action.persistPlaybackState) {
+    val playbackStatePersisted = if (action.persistPlaybackState) {
         val reason = if (action.stopPlaybackImmediately) {
             "task_removed"
         } else {
             "inactive_task_removed"
         }
         callbacks.persistPlaybackState(reason)
+    } else {
+        true
     }
     if (action.updateNotificationAfterPersist) {
         runCatching { callbacks.updateNotification() }
             .onFailure(callbacks.onNotificationUpdateFailure)
     }
     if (action.stopServiceAfterPersist) {
-        callbacks.stopForegroundIfStarted("task_removed")
-        callbacks.stopSelf()
+        if (playbackStatePersisted) {
+            callbacks.stopForegroundIfStarted("task_removed")
+            callbacks.stopSelf()
+        } else {
+            runCatching { callbacks.updateNotification() }
+                .onFailure(callbacks.onNotificationUpdateFailure)
+        }
     }
 }
 
@@ -2646,18 +2665,25 @@ class AudioPlayerService : Service() {
         super.onTaskRemoved(rootIntent)
         val hasPlaybackSurfaceContent = hasPlaybackSurfaceContent()
         val hasItems = PlayerManager.hasItems()
-        val transportActive = runCatching {
+        val playerTransportActive = runCatching {
             PlayerManager.isTransportActiveWithoutInitialization()
         }.getOrDefault(false)
+        val listenTogetherRemotePlaying = isListenTogetherRemotePlaying()
+        val transportActive = resolveTaskRemovedTransportActive(
+            playerTransportActive = playerTransportActive,
+            listenTogetherRemotePlaying = listenTogetherRemotePlaying,
+        )
         val taskRemovedAction = resolveTaskRemovedPlaybackAction(
             hasPlaybackSurfaceContent = hasPlaybackSurfaceContent,
-            transportActive = transportActive,
+            playerTransportActive = playerTransportActive,
+            listenTogetherRemotePlaying = listenTogetherRemotePlaying,
             hasItems = hasItems,
         )
         NPLogger.w(
             "NERI-APS",
             "onTaskRemoved hasSurface=$hasPlaybackSurfaceContent " +
-                "transportActive=$transportActive hasItems=$hasItems " +
+                "transportActive=$transportActive playerTransport=$playerTransportActive " +
+                "listenTogetherRemotePlaying=$listenTogetherRemotePlaying hasItems=$hasItems " +
                 "isPlaying=${PlayerManager.isPlayingFlow.value}"
         )
         if (taskRemovedAction.stopPlaybackImmediately) {

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/service/AudioPlayerService.kt
@@ -78,6 +78,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import moe.ouom.neriplayer.R
 import moe.ouom.neriplayer.activity.MainActivity
 import moe.ouom.neriplayer.activity.shouldProcessUsbDeviceAttachedAction
@@ -92,6 +93,7 @@ import moe.ouom.neriplayer.core.player.lifecycle.scheduleUsbExclusivePlaybackRes
 import moe.ouom.neriplayer.core.player.lifecycle.stopPlaybackAfterUsbExclusiveNativeFailure
 import moe.ouom.neriplayer.core.player.metadata.resolveExternalBluetoothMetadataText
 import moe.ouom.neriplayer.core.player.metadata.shouldUseExternalBluetoothLyrics
+import moe.ouom.neriplayer.core.player.persistence.persistStateNow
 import moe.ouom.neriplayer.core.player.persistence.preloadRestoredStateSnapshot
 import moe.ouom.neriplayer.core.player.persistence.scheduleStatePersist
 import moe.ouom.neriplayer.core.player.policy.usb.shouldRunUsbExclusiveBackgroundAudioAnchor
@@ -213,6 +215,7 @@ private const val USB_EXCLUSIVE_BACKGROUND_KEEPALIVE_INTERVAL_MS = 1_000L
 private const val USB_EXCLUSIVE_KEEPALIVE_STALL_WARN_MS = 25_000L
 private const val USB_EXCLUSIVE_KEEPALIVE_STALL_RECOVERY_TICKS = 1
 private const val USB_EXCLUSIVE_KEEPALIVE_LOG_INTERVAL_TICKS = 3L
+private const val TASK_REMOVED_STATE_PERSIST_TIMEOUT_MS = 3_000L
 
 internal fun isLocalPlaybackCommandSyncSource(
     source: String,
@@ -235,6 +238,66 @@ internal fun shouldStopPlaybackOnTaskRemoved(
     transportActive: Boolean,
 ): Boolean {
     return hasPlaybackSurfaceContent && transportActive
+}
+
+internal data class TaskRemovedPlaybackAction(
+    val stopPlaybackImmediately: Boolean,
+    val persistPlaybackState: Boolean,
+    val stopServiceAfterPersist: Boolean,
+    val updateNotificationAfterPersist: Boolean,
+)
+
+internal data class TaskRemovedPlaybackCallbacks(
+    val stopPlaybackImmediately: () -> Unit,
+    val persistPlaybackState: suspend (String) -> Boolean,
+    val stopForegroundIfStarted: (String) -> Unit,
+    val stopSelf: () -> Unit,
+    val updateNotification: () -> Unit,
+    val onPlaybackStopFailure: (Throwable) -> Unit,
+    val onNotificationUpdateFailure: (Throwable) -> Unit,
+)
+
+internal fun resolveTaskRemovedPlaybackAction(
+    hasPlaybackSurfaceContent: Boolean,
+    transportActive: Boolean,
+    hasItems: Boolean,
+): TaskRemovedPlaybackAction {
+    val stopPlaybackImmediately = shouldStopPlaybackOnTaskRemoved(
+        hasPlaybackSurfaceContent = hasPlaybackSurfaceContent,
+        transportActive = transportActive,
+    )
+    return TaskRemovedPlaybackAction(
+        stopPlaybackImmediately = stopPlaybackImmediately,
+        persistPlaybackState = stopPlaybackImmediately || hasItems,
+        stopServiceAfterPersist = stopPlaybackImmediately,
+        updateNotificationAfterPersist = hasItems && !stopPlaybackImmediately,
+    )
+}
+
+internal suspend fun executeTaskRemovedPlaybackAction(
+    action: TaskRemovedPlaybackAction,
+    callbacks: TaskRemovedPlaybackCallbacks,
+) {
+    if (action.stopPlaybackImmediately) {
+        runCatching { callbacks.stopPlaybackImmediately() }
+            .onFailure(callbacks.onPlaybackStopFailure)
+    }
+    if (action.persistPlaybackState) {
+        val reason = if (action.stopPlaybackImmediately) {
+            "task_removed"
+        } else {
+            "inactive_task_removed"
+        }
+        callbacks.persistPlaybackState(reason)
+    }
+    if (action.updateNotificationAfterPersist) {
+        runCatching { callbacks.updateNotification() }
+            .onFailure(callbacks.onNotificationUpdateFailure)
+    }
+    if (action.stopServiceAfterPersist) {
+        callbacks.stopForegroundIfStarted("task_removed")
+        callbacks.stopSelf()
+    }
 }
 
 internal fun mediaSessionPlaybackActions(): Long {
@@ -2582,60 +2645,87 @@ class AudioPlayerService : Service() {
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
         val hasPlaybackSurfaceContent = hasPlaybackSurfaceContent()
+        val hasItems = PlayerManager.hasItems()
         val transportActive = runCatching {
             PlayerManager.isTransportActiveWithoutInitialization()
         }.getOrDefault(false)
+        val taskRemovedAction = resolveTaskRemovedPlaybackAction(
+            hasPlaybackSurfaceContent = hasPlaybackSurfaceContent,
+            transportActive = transportActive,
+            hasItems = hasItems,
+        )
         NPLogger.w(
             "NERI-APS",
             "onTaskRemoved hasSurface=$hasPlaybackSurfaceContent " +
-                "transportActive=$transportActive hasItems=${PlayerManager.hasItems()} " +
+                "transportActive=$transportActive hasItems=$hasItems " +
                 "isPlaying=${PlayerManager.isPlayingFlow.value}"
         )
-        if (
-            shouldStopPlaybackOnTaskRemoved(
-                hasPlaybackSurfaceContent = hasPlaybackSurfaceContent,
-                transportActive = transportActive,
-            )
-        ) {
+        if (taskRemovedAction.stopPlaybackImmediately) {
             allowServiceRestart = false
             flushPlaybackStatsSafely("task_removed", "task removed")
-            runCatching {
-                PlayerManager.stopPlaybackImmediately("task_removed")
-            }.onFailure {
-                NPLogger.w("NERI-APS", "playback stop failed during task removed", it)
-            }
-            runCatching {
-                PlayerManager.scheduleStatePersist(
-                    positionMs = PlayerManager.playbackPositionFlow.value,
-                    shouldResumePlayback = false,
-                    debounceMs = 0L
+            serviceScope.launch {
+                executeTaskRemovedPlaybackAction(
+                    action = taskRemovedAction,
+                    callbacks = taskRemovedPlaybackCallbacks()
                 )
-            }.onFailure {
-                NPLogger.w("NERI-APS", "state persist failed during task removed", it)
             }
-            stopForegroundIfStarted("task_removed")
-            stopSelf()
             return
         }
-        if (PlayerManager.hasItems()) {
-            runCatching {
-                PlayerManager.scheduleStatePersist(
+        if (taskRemovedAction.persistPlaybackState) {
+            serviceScope.launch {
+                executeTaskRemovedPlaybackAction(
+                    action = taskRemovedAction,
+                    callbacks = taskRemovedPlaybackCallbacks()
+                )
+            }
+        }
+    }
+
+    private fun taskRemovedPlaybackCallbacks(): TaskRemovedPlaybackCallbacks {
+        return TaskRemovedPlaybackCallbacks(
+            stopPlaybackImmediately = {
+                PlayerManager.stopPlaybackImmediately(
+                    reason = "task_removed",
+                    forcePersist = false
+                )
+            },
+            persistPlaybackState = { reason ->
+                persistTaskRemovedPlaybackState(reason)
+            },
+            stopForegroundIfStarted = { reason ->
+                stopForegroundIfStarted(reason)
+            },
+            stopSelf = {
+                stopSelf()
+            },
+            updateNotification = {
+                updateNotification()
+            },
+            onPlaybackStopFailure = { error ->
+                NPLogger.w("NERI-APS", "playback stop failed during task removed", error)
+            },
+            onNotificationUpdateFailure = { error ->
+                NPLogger.w(
+                    "NERI-APS",
+                    "notification update failed during inactive task removed",
+                    error
+                )
+            },
+        )
+    }
+
+    private suspend fun persistTaskRemovedPlaybackState(reason: String): Boolean {
+        return runCatching {
+            withTimeout(TASK_REMOVED_STATE_PERSIST_TIMEOUT_MS) {
+                PlayerManager.persistStateNow(
                     positionMs = PlayerManager.playbackPositionFlow.value,
                     shouldResumePlayback = false,
-                    debounceMs = 0L
+                    reason = reason
                 )
-            }.onFailure {
-                NPLogger.w("NERI-APS", "state persist failed during inactive task removed", it)
             }
-            runCatching { updateNotification() }
-                .onFailure {
-                    NPLogger.w(
-                        "NERI-APS",
-                        "notification update failed during inactive task removed",
-                        it
-                    )
-                }
-        }
+        }.onFailure { error ->
+            NPLogger.w("NERI-APS", "state persist failed during $reason", error)
+        }.getOrDefault(false)
     }
 
     private fun flushPlaybackStatsSafely(reason: String, context: String) {

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/policy/offload/PlaybackAudioOffloadPolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/policy/offload/PlaybackAudioOffloadPolicyTest.kt
@@ -38,7 +38,11 @@ class PlaybackAudioOffloadPolicyTest {
                 audioSource = PlaybackAudioSource.NETEASE
             )
         )
-        assertFalse(
+    }
+
+    @Test
+    fun `bili fallback streams require pcm so task removal cannot leave queued offload audio`() {
+        assertTrue(
             resolveRequiresPcmAudioProcessing(
                 audioSource = PlaybackAudioSource.BILIBILI
             )

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/service/AudioPlayerServicePolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/service/AudioPlayerServicePolicyTest.kt
@@ -14,6 +14,7 @@ import moe.ouom.neriplayer.core.player.audio.focus.shouldSuppressUsbExclusiveFor
 import moe.ouom.neriplayer.listentogether.protocol.ListenTogetherPlaybackState
 import moe.ouom.neriplayer.listentogether.protocol.ListenTogetherRoomState
 import moe.ouom.neriplayer.listentogether.protocol.ListenTogetherTrack
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -22,32 +23,203 @@ import org.junit.Test
 class AudioPlayerServicePolicyTest {
 
     @Test
-    fun `active transport is stopped when task is removed`() {
+    fun `active transport is persisted before service stops when task is removed`() {
+        val action = resolveTaskRemovedPlaybackAction(
+            hasPlaybackSurfaceContent = true,
+            transportActive = true,
+            hasItems = true,
+        )
+
+        assertTrue(action.stopPlaybackImmediately)
+        assertTrue(action.persistPlaybackState)
+        assertTrue(action.stopServiceAfterPersist)
+        assertFalse(action.updateNotificationAfterPersist)
+    }
+
+    @Test
+    fun `listen together transport is persisted before service stops when task is removed`() {
+        val action = resolveTaskRemovedPlaybackAction(
+            hasPlaybackSurfaceContent = true,
+            transportActive = true,
+            hasItems = false,
+        )
+
+        assertTrue(action.stopPlaybackImmediately)
+        assertTrue(action.persistPlaybackState)
+        assertTrue(action.stopServiceAfterPersist)
+        assertFalse(action.updateNotificationAfterPersist)
+    }
+
+    @Test
+    fun `paused queue is persisted but service is retained when task is removed`() {
+        val action = resolveTaskRemovedPlaybackAction(
+            hasPlaybackSurfaceContent = true,
+            transportActive = false,
+            hasItems = true,
+        )
+
+        assertFalse(action.stopPlaybackImmediately)
+        assertTrue(action.persistPlaybackState)
+        assertFalse(action.stopServiceAfterPersist)
+        assertTrue(action.updateNotificationAfterPersist)
+    }
+
+    @Test
+    fun `empty playback surface is ignored for task removal`() {
+        val action = resolveTaskRemovedPlaybackAction(
+            hasPlaybackSurfaceContent = false,
+            transportActive = true,
+            hasItems = false,
+        )
+
+        assertFalse(action.stopPlaybackImmediately)
+        assertFalse(action.persistPlaybackState)
+        assertFalse(action.stopServiceAfterPersist)
+        assertFalse(action.updateNotificationAfterPersist)
+    }
+
+    @Test
+    fun `active task removal waits for persistence before stopping service`() = runTest {
+        val calls = mutableListOf<String>()
+
+        executeTaskRemovedPlaybackAction(
+            action = resolveTaskRemovedPlaybackAction(
+                hasPlaybackSurfaceContent = true,
+                transportActive = true,
+                hasItems = true,
+            ),
+            callbacks = taskRemovedCallbacks(calls)
+        )
+
+        assertEquals(
+            listOf(
+                "stop_playback",
+                "persist:task_removed",
+                "stop_foreground:task_removed",
+                "stop_self",
+            ),
+            calls
+        )
+    }
+
+    @Test
+    fun `task removal still persists and stops service after stop playback failure`() = runTest {
+        val calls = mutableListOf<String>()
+
+        executeTaskRemovedPlaybackAction(
+            action = resolveTaskRemovedPlaybackAction(
+                hasPlaybackSurfaceContent = true,
+                transportActive = true,
+                hasItems = true,
+            ),
+            callbacks = taskRemovedCallbacks(
+                calls = calls,
+                stopPlaybackImmediately = {
+                    calls += "stop_playback"
+                    error("stop failed")
+                }
+            )
+        )
+
+        assertEquals(
+            listOf(
+                "stop_playback",
+                "stop_error:IllegalStateException",
+                "persist:task_removed",
+                "stop_foreground:task_removed",
+                "stop_self",
+            ),
+            calls
+        )
+    }
+
+    @Test
+    fun `inactive task removal persists before notification and keeps service`() = runTest {
+        val calls = mutableListOf<String>()
+
+        executeTaskRemovedPlaybackAction(
+            action = resolveTaskRemovedPlaybackAction(
+                hasPlaybackSurfaceContent = true,
+                transportActive = false,
+                hasItems = true,
+            ),
+            callbacks = taskRemovedCallbacks(calls)
+        )
+
+        assertEquals(
+            listOf(
+                "persist:inactive_task_removed",
+                "update_notification",
+            ),
+            calls
+        )
+    }
+
+    @Test
+    fun `empty task removal performs no playback side effects`() = runTest {
+        val calls = mutableListOf<String>()
+
+        executeTaskRemovedPlaybackAction(
+            action = resolveTaskRemovedPlaybackAction(
+                hasPlaybackSurfaceContent = false,
+                transportActive = true,
+                hasItems = false,
+            ),
+            callbacks = taskRemovedCallbacks(calls)
+        )
+
+        assertTrue(calls.isEmpty())
+    }
+
+    @Test
+    fun `task removal stop predicate requires content and active transport`() {
         assertTrue(
             shouldStopPlaybackOnTaskRemoved(
                 hasPlaybackSurfaceContent = true,
                 transportActive = true,
             )
         )
-    }
-
-    @Test
-    fun `paused queue is retained when task is removed`() {
         assertFalse(
             shouldStopPlaybackOnTaskRemoved(
                 hasPlaybackSurfaceContent = true,
                 transportActive = false,
             )
         )
-    }
-
-    @Test
-    fun `empty playback surface is never stopped for task removal`() {
         assertFalse(
             shouldStopPlaybackOnTaskRemoved(
                 hasPlaybackSurfaceContent = false,
                 transportActive = true,
             )
+        )
+    }
+
+    private fun taskRemovedCallbacks(
+        calls: MutableList<String>,
+        stopPlaybackImmediately: () -> Unit = {
+            calls += "stop_playback"
+        },
+    ): TaskRemovedPlaybackCallbacks {
+        return TaskRemovedPlaybackCallbacks(
+            stopPlaybackImmediately = stopPlaybackImmediately,
+            persistPlaybackState = { reason ->
+                calls += "persist:$reason"
+                true
+            },
+            stopForegroundIfStarted = { reason ->
+                calls += "stop_foreground:$reason"
+            },
+            stopSelf = {
+                calls += "stop_self"
+            },
+            updateNotification = {
+                calls += "update_notification"
+            },
+            onPlaybackStopFailure = { error ->
+                calls += "stop_error:${error::class.simpleName}"
+            },
+            onNotificationUpdateFailure = { error ->
+                calls += "notification_error:${error::class.simpleName}"
+            },
         )
     }
 

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/service/AudioPlayerServicePolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/service/AudioPlayerServicePolicyTest.kt
@@ -26,7 +26,8 @@ class AudioPlayerServicePolicyTest {
     fun `active transport is persisted before service stops when task is removed`() {
         val action = resolveTaskRemovedPlaybackAction(
             hasPlaybackSurfaceContent = true,
-            transportActive = true,
+            playerTransportActive = true,
+            listenTogetherRemotePlaying = false,
             hasItems = true,
         )
 
@@ -40,7 +41,8 @@ class AudioPlayerServicePolicyTest {
     fun `listen together transport is persisted before service stops when task is removed`() {
         val action = resolveTaskRemovedPlaybackAction(
             hasPlaybackSurfaceContent = true,
-            transportActive = true,
+            playerTransportActive = false,
+            listenTogetherRemotePlaying = true,
             hasItems = false,
         )
 
@@ -54,7 +56,8 @@ class AudioPlayerServicePolicyTest {
     fun `paused queue is persisted but service is retained when task is removed`() {
         val action = resolveTaskRemovedPlaybackAction(
             hasPlaybackSurfaceContent = true,
-            transportActive = false,
+            playerTransportActive = false,
+            listenTogetherRemotePlaying = false,
             hasItems = true,
         )
 
@@ -68,7 +71,8 @@ class AudioPlayerServicePolicyTest {
     fun `empty playback surface is ignored for task removal`() {
         val action = resolveTaskRemovedPlaybackAction(
             hasPlaybackSurfaceContent = false,
-            transportActive = true,
+            playerTransportActive = true,
+            listenTogetherRemotePlaying = true,
             hasItems = false,
         )
 
@@ -85,7 +89,8 @@ class AudioPlayerServicePolicyTest {
         executeTaskRemovedPlaybackAction(
             action = resolveTaskRemovedPlaybackAction(
                 hasPlaybackSurfaceContent = true,
-                transportActive = true,
+                playerTransportActive = true,
+                listenTogetherRemotePlaying = false,
                 hasItems = true,
             ),
             callbacks = taskRemovedCallbacks(calls)
@@ -109,7 +114,8 @@ class AudioPlayerServicePolicyTest {
         executeTaskRemovedPlaybackAction(
             action = resolveTaskRemovedPlaybackAction(
                 hasPlaybackSurfaceContent = true,
-                transportActive = true,
+                playerTransportActive = true,
+                listenTogetherRemotePlaying = false,
                 hasItems = true,
             ),
             callbacks = taskRemovedCallbacks(
@@ -140,7 +146,8 @@ class AudioPlayerServicePolicyTest {
         executeTaskRemovedPlaybackAction(
             action = resolveTaskRemovedPlaybackAction(
                 hasPlaybackSurfaceContent = true,
-                transportActive = false,
+                playerTransportActive = false,
+                listenTogetherRemotePlaying = false,
                 hasItems = true,
             ),
             callbacks = taskRemovedCallbacks(calls)
@@ -162,7 +169,8 @@ class AudioPlayerServicePolicyTest {
         executeTaskRemovedPlaybackAction(
             action = resolveTaskRemovedPlaybackAction(
                 hasPlaybackSurfaceContent = false,
-                transportActive = true,
+                playerTransportActive = true,
+                listenTogetherRemotePlaying = true,
                 hasItems = false,
             ),
             callbacks = taskRemovedCallbacks(calls)
@@ -193,18 +201,67 @@ class AudioPlayerServicePolicyTest {
         )
     }
 
+    @Test
+    fun `remote listen together playback counts as active task removal transport`() {
+        assertTrue(
+            resolveTaskRemovedTransportActive(
+                playerTransportActive = false,
+                listenTogetherRemotePlaying = true,
+            )
+        )
+        assertTrue(
+            resolveTaskRemovedPlaybackAction(
+                hasPlaybackSurfaceContent = true,
+                playerTransportActive = false,
+                listenTogetherRemotePlaying = true,
+                hasItems = false,
+            ).stopPlaybackImmediately
+        )
+    }
+
+    @Test
+    fun `active task removal keeps service when persistence fails`() = runTest {
+        val calls = mutableListOf<String>()
+
+        executeTaskRemovedPlaybackAction(
+            action = resolveTaskRemovedPlaybackAction(
+                hasPlaybackSurfaceContent = true,
+                playerTransportActive = true,
+                listenTogetherRemotePlaying = false,
+                hasItems = true,
+            ),
+            callbacks = taskRemovedCallbacks(
+                calls = calls,
+                persistPlaybackState = { reason ->
+                    calls += "persist:$reason"
+                    false
+                }
+            )
+        )
+
+        assertEquals(
+            listOf(
+                "stop_playback",
+                "persist:task_removed",
+                "update_notification",
+            ),
+            calls
+        )
+    }
+
     private fun taskRemovedCallbacks(
         calls: MutableList<String>,
         stopPlaybackImmediately: () -> Unit = {
             calls += "stop_playback"
         },
+        persistPlaybackState: suspend (String) -> Boolean = { reason ->
+            calls += "persist:$reason"
+            true
+        },
     ): TaskRemovedPlaybackCallbacks {
         return TaskRemovedPlaybackCallbacks(
             stopPlaybackImmediately = stopPlaybackImmediately,
-            persistPlaybackState = { reason ->
-                calls += "persist:$reason"
-                true
-            },
+            persistPlaybackState = persistPlaybackState,
             stopForegroundIfStarted = { reason ->
                 calls += "stop_foreground:$reason"
             },

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/service/AudioPlayerServicePolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/service/AudioPlayerServicePolicyTest.kt
@@ -22,6 +22,36 @@ import org.junit.Test
 class AudioPlayerServicePolicyTest {
 
     @Test
+    fun `active transport is stopped when task is removed`() {
+        assertTrue(
+            shouldStopPlaybackOnTaskRemoved(
+                hasPlaybackSurfaceContent = true,
+                transportActive = true,
+            )
+        )
+    }
+
+    @Test
+    fun `paused queue is retained when task is removed`() {
+        assertFalse(
+            shouldStopPlaybackOnTaskRemoved(
+                hasPlaybackSurfaceContent = true,
+                transportActive = false,
+            )
+        )
+    }
+
+    @Test
+    fun `empty playback surface is never stopped for task removal`() {
+        assertFalse(
+            shouldStopPlaybackOnTaskRemoved(
+                hasPlaybackSurfaceContent = false,
+                transportActive = true,
+            )
+        )
+    }
+
+    @Test
     fun `media session stop is downgraded to pause-only`() {
         assertFalse(
             shouldStopServiceForExternalPauseCommand(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 用户可见行为
- 移除任务时，如果存在播放内容且传输处于活动状态，应用会立即停止播放并停止服务。
- 移除任务时，如果传输未处于活动状态，应用会保留服务并更新通知。
- 移除任务时，如果没有播放内容，应用不会执行播放、持久化或通知操作。
- 蓝牙断开期间，应用会先抑制播放，再执行延迟暂停。
- 音频路由丢失时，应用会刷新播放器输出并停止进度更新。
- 暂停队列会在移除任务后保留。

## 兼容性影响
- 内部 `pauseImpl` 和 `pauseInternal` 增加音频输出刷新参数。
- 新增立即持久化状态流程，并设置 3 秒超时。
- 未修改导出的公共实体。

## 测试
- 新增任务移除策略和执行流程测试。
- 覆盖活动传输、Listen Together、暂停队列、空播放内容、持久化顺序、播放停止失败及通知更新场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->