### PR TITLE
refactor: extract SettingsPageHost and optimize split-layout transitions for nested settings pages

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/tab/SettingsPageHostTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/tab/SettingsPageHostTest.kt
@@ -1,0 +1,253 @@
+package moe.ouom.neriplayer.ui.screen.tab
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import moe.ouom.neriplayer.testutil.assumeComposeHostAvailable
+import moe.ouom.neriplayer.ui.screen.tab.settings.page.MiuixSettingsPageGroupCard
+import moe.ouom.neriplayer.ui.screen.tab.settings.page.MiuixSettingsResponsiveDetailScaffold
+import moe.ouom.neriplayer.ui.screen.tab.settings.page.SettingsPage
+import moe.ouom.neriplayer.ui.screen.tab.settings.page.backTargetPage
+import moe.ouom.neriplayer.ui.screen.tab.settings.page.settingsPageRowTestTag
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SettingsPageHostTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun assumeDeviceUnlocked() {
+        assumeComposeHostAvailable()
+    }
+
+    @Test
+    fun splitLayoutKeepsOneNavigationPaneWhileSwitchingPages() {
+        lateinit var activePage: MutableState<SettingsPage>
+        composeRule.mainClock.autoAdvance = false
+        try {
+            composeRule.setContent {
+                activePage = remember { mutableStateOf(SettingsPage.General) }
+                MaterialTheme {
+                    SettingsPageHost(
+                        activePage = activePage.value,
+                        splitLayout = true,
+                        isolateAdvancedGlassTransitions = false
+                    ) { page ->
+                        Row(modifier = Modifier.fillMaxSize()) {
+                            Box(
+                                modifier = Modifier
+                                    .weight(0.42f)
+                                    .fillMaxSize()
+                                    .testTag(NAVIGATION_PANE_TAG)
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .weight(0.58f)
+                                    .fillMaxSize()
+                                    .testTag("settings-detail-${page?.name}")
+                            )
+                        }
+                    }
+                }
+            }
+
+            composeRule.waitForIdle()
+            composeRule.onAllNodesWithTag(NAVIGATION_PANE_TAG).assertCountEquals(1)
+            composeRule.onNodeWithTag("settings-detail-General").assertExists()
+
+            composeRule.runOnIdle { activePage.value = SettingsPage.Accounts }
+            advanceRecompositionFrame()
+            composeRule.onAllNodesWithTag(NAVIGATION_PANE_TAG).assertCountEquals(1)
+            composeRule.onNodeWithTag("settings-detail-Accounts").assertExists()
+
+            composeRule.runOnIdle { activePage.value = SettingsPage.Theme }
+            advanceRecompositionFrame()
+            composeRule.onAllNodesWithTag(NAVIGATION_PANE_TAG).assertCountEquals(1)
+            composeRule.onNodeWithTag("settings-detail-Theme").assertExists()
+        } finally {
+            composeRule.mainClock.autoAdvance = true
+        }
+    }
+
+    @Test
+    fun splitDetailSwitchesWithoutKeepingOutgoingPage() {
+        lateinit var activePage: MutableState<SettingsPage>
+        composeRule.mainClock.autoAdvance = false
+        try {
+            composeRule.setContent {
+                activePage = remember { mutableStateOf(SettingsPage.General) }
+                MaterialTheme {
+                    MiuixSettingsResponsiveDetailScaffold(
+                        title = "Settings",
+                        onBack = {},
+                        listState = rememberLazyListState(),
+                        topAppBarState = rememberTopAppBarState(),
+                        splitLayout = true,
+                        selectedPage = activePage.value,
+                        homeListState = rememberLazyListState(),
+                        homeTopAppBarState = rememberTopAppBarState(),
+                        homeTitle = {},
+                        homeContent = {
+                            item {
+                                Box(modifier = Modifier.testTag(NAVIGATION_PANE_TAG))
+                            }
+                        },
+                        detailContent = { page ->
+                            item {
+                                Box(
+                                    modifier = Modifier.testTag(
+                                        "settings-detail-${page.name}"
+                                    )
+                                )
+                            }
+                        },
+                        content = {}
+                    )
+                }
+            }
+
+            composeRule.waitForIdle()
+            composeRule.onAllNodesWithTag(NAVIGATION_PANE_TAG).assertCountEquals(1)
+            composeRule.onNodeWithTag("settings-detail-General").assertExists()
+
+            composeRule.runOnIdle { activePage.value = SettingsPage.Accounts }
+            advanceRecompositionFrame()
+            composeRule.onAllNodesWithTag(NAVIGATION_PANE_TAG).assertCountEquals(1)
+            composeRule.onNodeWithTag("settings-detail-Accounts").assertExists()
+            composeRule.onAllNodesWithTag("settings-detail-General").assertCountEquals(0)
+        } finally {
+            composeRule.mainClock.autoAdvance = true
+        }
+    }
+
+    @Test
+    fun splitNavigationSelectionMovesWithPrimaryPageSwitch() {
+        lateinit var activePage: MutableState<SettingsPage>
+        composeRule.mainClock.autoAdvance = false
+        try {
+            composeRule.setContent {
+                activePage = remember { mutableStateOf(SettingsPage.General) }
+                MaterialTheme {
+                    MiuixSettingsPageGroupCard(
+                        pages = listOf(
+                            SettingsPage.General,
+                            SettingsPage.Accounts,
+                            SettingsPage.Playback
+                        ),
+                        onPageClick = { page -> activePage.value = page },
+                        selectedPage = activePage.value.backTargetPage() ?: activePage.value
+                    )
+                }
+            }
+
+            composeRule.waitForIdle()
+            composeRule.onNodeWithTag(settingsPageRowTestTag(SettingsPage.General))
+                .assertIsSelected()
+            composeRule.onNodeWithTag(settingsPageRowTestTag(SettingsPage.Accounts))
+                .assertIsNotSelected()
+
+            composeRule.runOnIdle { activePage.value = SettingsPage.Accounts }
+            advanceRecompositionFrame()
+            composeRule.onNodeWithTag(settingsPageRowTestTag(SettingsPage.General))
+                .assertIsNotSelected()
+            composeRule.onNodeWithTag(settingsPageRowTestTag(SettingsPage.Accounts))
+                .assertIsSelected()
+
+            repeat(3) {
+                composeRule.mainClock.advanceTimeByFrame()
+                composeRule.waitForIdle()
+                composeRule.onNodeWithTag(settingsPageRowTestTag(SettingsPage.General))
+                    .assertIsNotSelected()
+                composeRule.onNodeWithTag(settingsPageRowTestTag(SettingsPage.Accounts))
+                    .assertIsSelected()
+            }
+
+            composeRule.runOnIdle { activePage.value = SettingsPage.UsbExclusive }
+            advanceRecompositionFrame()
+            composeRule.onNodeWithTag(settingsPageRowTestTag(SettingsPage.Accounts))
+                .assertIsNotSelected()
+            composeRule.onNodeWithTag(settingsPageRowTestTag(SettingsPage.Playback))
+                .assertIsSelected()
+        } finally {
+            composeRule.mainClock.autoAdvance = true
+        }
+    }
+
+    @Test
+    fun splitDetailKeepsAnimationForNestedPage() {
+        lateinit var activePage: MutableState<SettingsPage>
+        composeRule.mainClock.autoAdvance = false
+        try {
+            composeRule.setContent {
+                activePage = remember { mutableStateOf(SettingsPage.Playback) }
+                MaterialTheme {
+                    MiuixSettingsResponsiveDetailScaffold(
+                        title = "Settings",
+                        onBack = {},
+                        listState = rememberLazyListState(),
+                        topAppBarState = rememberTopAppBarState(),
+                        splitLayout = true,
+                        selectedPage = activePage.value,
+                        homeListState = rememberLazyListState(),
+                        homeTopAppBarState = rememberTopAppBarState(),
+                        homeTitle = {},
+                        homeContent = {},
+                        detailContent = { page ->
+                            item {
+                                Box(
+                                    modifier = Modifier.testTag(
+                                        "settings-detail-${page.name}"
+                                    )
+                                )
+                            }
+                        },
+                        content = {}
+                    )
+                }
+            }
+
+            composeRule.waitForIdle()
+            composeRule.onNodeWithTag("settings-detail-Playback").assertExists()
+
+            composeRule.runOnIdle { activePage.value = SettingsPage.UsbExclusive }
+            repeat(3) { composeRule.mainClock.advanceTimeByFrame() }
+            composeRule.onNodeWithTag("settings-detail-Playback").assertExists()
+            composeRule.onNodeWithTag("settings-detail-UsbExclusive").assertExists()
+
+            composeRule.mainClock.advanceTimeBy(2_000)
+            composeRule.waitForIdle()
+            composeRule.onAllNodesWithTag("settings-detail-Playback").assertCountEquals(0)
+            composeRule.onNodeWithTag("settings-detail-UsbExclusive").assertExists()
+        } finally {
+            composeRule.mainClock.autoAdvance = true
+        }
+    }
+
+    private fun advanceRecompositionFrame() {
+        composeRule.mainClock.advanceTimeByFrame()
+        composeRule.waitForIdle()
+    }
+
+    private companion object {
+        const val NAVIGATION_PANE_TAG = "settings-navigation-pane"
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/SettingsScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/SettingsScreen.kt
@@ -36,10 +36,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.CreateDocument
 import androidx.activity.result.contract.ActivityResultContracts.OpenDocument
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.SizeTransform
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -257,6 +254,42 @@ private fun isForwardSettingsPageTransition(
     if (targetPage.backTargetPage() == initialPage) return true
     if (initialPage.backTargetPage() == targetPage) return false
     return targetPage.ordinal >= initialPage.ordinal
+}
+
+@Composable
+internal fun SettingsPageHost(
+    activePage: SettingsPage?,
+    splitLayout: Boolean,
+    isolateAdvancedGlassTransitions: Boolean,
+    content: @Composable (SettingsPage?) -> Unit
+) {
+    if (splitLayout) {
+        AdvancedGlassScene(active = true) {
+            content(activePage)
+        }
+        return
+    }
+
+    AnimatedContent(
+        targetState = activePage,
+        modifier = Modifier.fillMaxSize(),
+        label = "settings_page_switch",
+        transitionSpec = {
+            isolatedAdvancedGlassHorizontalTransition(
+                forward = isForwardSettingsPageTransition(initialState, targetState)
+            ).using(SizeTransform(clip = true))
+        }
+    ) { selectedPage ->
+        AdvancedGlassNavigationHandoff(
+            enabled = isolateAdvancedGlassTransitions && transition.isRunning
+        ) {
+            AdvancedGlassScene(
+                active = isolateAdvancedGlassTransitions || selectedPage == activePage
+            ) {
+                content(selectedPage)
+            }
+        }
+    }
 }
 
 private fun Context.neteaseQualityLabel(value: String): String {
@@ -1222,35 +1255,16 @@ fun SettingsScreen(
         }
     }
 
-    AnimatedContent(
-        targetState = activeSettingsPage,
-        modifier = Modifier.fillMaxSize(),
-        label = "settings_page_switch",
-        transitionSpec = {
-            if (isSettingsSplitLayout) {
-                EnterTransition.None togetherWith ExitTransition.None
-            } else {
-                isolatedAdvancedGlassHorizontalTransition(
-                    forward = isForwardSettingsPageTransition(initialState, targetState)
-                ).using(SizeTransform(clip = true))
-            }
-        }
-    ) { selectedPage ->
-        AdvancedGlassNavigationHandoff(
-            enabled = isolateAdvancedGlassTransitions && transition.isRunning
-        ) {
-            AdvancedGlassScene(
-                active = isolateAdvancedGlassTransitions || selectedPage == activeSettingsPage
-            ) {
-                if (selectedPage == null) {
-                    MiuixSettingsHomeScaffold(
-                        listState = listState,
-                        topAppBarState = homeTopAppBarState,
-                        title = settingsHomeTitle,
-                        content = settingsHomeContent
-                    )
-                } else {
-                    MiuixSettingsResponsiveDetailScaffold(
+    val settingsPageContent: @Composable (SettingsPage?) -> Unit = { selectedPage ->
+        if (selectedPage == null) {
+            MiuixSettingsHomeScaffold(
+                listState = listState,
+                topAppBarState = homeTopAppBarState,
+                title = settingsHomeTitle,
+                content = settingsHomeContent
+            )
+        } else {
+            MiuixSettingsResponsiveDetailScaffold(
                 title = stringResource(selectedPage.titleRes),
                 onBack = ::navigateBackFromActiveSettingsPage,
                 listState = detailListStates.getValue(selectedPage),
@@ -1262,7 +1276,7 @@ fun SettingsScreen(
                 homeTopAppBarState = homeTopAppBarState,
                 homeTitle = settingsHomeTitle,
                 homeContent = settingsHomeContent
-                ) {
+            ) {
                 item(key = "${selectedPage.name}:header") {
                     MiuixSettingsHeader(
                         icon = selectedPage.icon,
@@ -2110,12 +2124,17 @@ fun SettingsScreen(
                         )
                     }
                 }
-                    }
                 }
             }
         }
     }
-    }
+
+    SettingsPageHost(
+        activePage = activeSettingsPage,
+        splitLayout = isSettingsSplitLayout,
+        isolateAdvancedGlassTransitions = isolateAdvancedGlassTransitions,
+        content = settingsPageContent
+    )
 
     SettingsNeteaseAuthDialogs(
         showSheet = showNeteaseSheet,

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/page/MiuixSettingsScaffold.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/page/MiuixSettingsScaffold.kt
@@ -1,8 +1,11 @@
 package moe.ouom.neriplayer.ui.screen.tab.settings.page
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -54,7 +57,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
@@ -76,14 +82,21 @@ private val MiuixSettingsContentPadding = PaddingValues(horizontal = 4.dp, verti
 private val MiuixPageRowPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)
 private val MiuixSettingsTabletMaxWidth = 920.dp
 
-private fun isForwardSettingsDetailTransition(
+private fun shouldAnimateSettingsDetailTransition(
     initialPage: SettingsPage,
     targetPage: SettingsPage
 ): Boolean {
-    if (targetPage.backTargetPage() == initialPage) return true
-    if (initialPage.backTargetPage() == targetPage) return false
-    return targetPage.ordinal >= initialPage.ordinal
+    return targetPage.backTargetPage() == initialPage ||
+        initialPage.backTargetPage() == targetPage
 }
+
+private fun SettingsPage.participatesInSplitDetailTransition(): Boolean {
+    return backTargetPage() != null || SettingsPage.entries.any { page ->
+        page.backTargetPage() == this
+    }
+}
+
+internal fun settingsPageRowTestTag(page: SettingsPage): String = "settings-page-row-${page.name}"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -290,6 +303,10 @@ private fun MiuixSettingsPageRow(
         modifier = Modifier
             .fillMaxWidth()
             .heightIn(min = 76.dp)
+            .testTag(settingsPageRowTestTag(page))
+            .semantics {
+                this.selected = selected
+            }
             .background(
                 if (selected) {
                     MaterialTheme.colorScheme.primary.copy(alpha = 0.08f)
@@ -473,47 +490,67 @@ internal fun MiuixSettingsResponsiveDetailScaffold(
                 .weight(0.58f)
                 .fillMaxHeight()
         ) {
-            val targetPage = selectedPage
-            if (targetPage == null) {
-                MiuixSettingsDetailScaffold(
-                    title = title,
-                    onBack = onBack,
-                    listState = listState,
-                    topAppBarState = topAppBarState,
-                    showBackButton = false,
-                    content = content
-                )
-            } else {
-                AnimatedContent(
-                    targetState = targetPage,
-                    modifier = Modifier.fillMaxSize(),
-                    label = "settings_split_detail_switch",
-                    transitionSpec = {
-                        isolatedAdvancedGlassHorizontalTransition(
-                            forward = isForwardSettingsDetailTransition(
-                                initialPage = initialState,
-                                targetPage = targetState
-                            )
-                        ).using(SizeTransform(clip = true))
-                    }
-                ) { page ->
-                    AdvancedGlassNavigationHandoff(
-                        enabled = isolateAdvancedGlassTransitions && transition.isRunning
+            when {
+                selectedPage == null -> {
+                    MiuixSettingsDetailScaffold(
+                        title = title,
+                        onBack = onBack,
+                        listState = listState,
+                        topAppBarState = topAppBarState,
+                        showBackButton = false,
+                        content = content
+                    )
+                }
+
+                !selectedPage.participatesInSplitDetailTransition() -> {
+                    MiuixSettingsDetailScaffold(
+                        title = title,
+                        onBack = onBack,
+                        listState = listState,
+                        topAppBarState = topAppBarState,
+                        showBackButton = showSplitDetailBackButton
                     ) {
-                        AdvancedGlassScene(
-                            active = isolateAdvancedGlassTransitions || page == targetPage
+                        if (detailContent == null) {
+                            content()
+                        } else {
+                            detailContent(selectedPage)
+                        }
+                    }
+                }
+
+                else -> {
+                    AnimatedContent(
+                        targetState = selectedPage,
+                        modifier = Modifier.fillMaxSize(),
+                        label = "settings_split_detail_switch",
+                        transitionSpec = {
+                            if (shouldAnimateSettingsDetailTransition(initialState, targetState)) {
+                                isolatedAdvancedGlassHorizontalTransition(
+                                    forward = targetState.backTargetPage() == initialState
+                                ).using(SizeTransform(clip = true))
+                            } else {
+                                EnterTransition.None togetherWith ExitTransition.None
+                            }
+                        }
+                    ) { page ->
+                        AdvancedGlassNavigationHandoff(
+                            enabled = isolateAdvancedGlassTransitions && transition.isRunning
                         ) {
-                            MiuixSettingsDetailScaffold(
-                                title = stringResource(page.titleRes),
-                                onBack = onBack,
-                                listState = listState,
-                                topAppBarState = topAppBarState,
-                                showBackButton = showSplitDetailBackButton
+                            AdvancedGlassScene(
+                                active = isolateAdvancedGlassTransitions || page == selectedPage
                             ) {
-                                if (detailContent == null) {
-                                    content()
-                                } else {
-                                    detailContent(page)
+                                MiuixSettingsDetailScaffold(
+                                    title = stringResource(page.titleRes),
+                                    onBack = onBack,
+                                    listState = listState,
+                                    topAppBarState = topAppBarState,
+                                    showBackButton = showSplitDetailBackButton
+                                ) {
+                                    if (detailContent == null) {
+                                        content()
+                                    } else {
+                                        detailContent(page)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 优化设置页面在分屏布局下的切换行为，复用导航面板并清理离开的详情页。
- 仅在相邻页面之间播放横向过渡动画。
- 保留嵌套设置页面切换期间的动画效果。
- 为设置页面导航项补充选中状态和测试标签。
- 新增 Compose UI 测试，覆盖导航复用、详情页切换、选中状态同步、动画保留和旧页面清理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->