### PR TITLE
feat: implement legacy JSON fallback for Room persistence and add database migration tests

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogRoomStoreTest.kt
@@ -79,7 +79,7 @@ class DownloadedSongCatalogRoomStoreTest {
             )
 
             assertEquals(
-                listOf(song.copy(matchedLyric = null, matchedTranslatedLyric = null)),
+                listOf(song),
                 store.restore()
             )
             assertTrue(cacheFile.exists())

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogRoomStoreTest.kt
@@ -13,6 +13,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.IOException
 
 @RunWith(AndroidJUnit4::class)
 class DownloadedSongCatalogRoomStoreTest {
@@ -96,6 +97,58 @@ class DownloadedSongCatalogRoomStoreTest {
         }
     }
 
+    @Test
+    fun roomPersistFailureFallsBackToLegacyCatalogForNextRestore() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        val cacheFileName = "downloaded-song-catalog-fallback-test.json"
+        val cacheFile = File(context.filesDir, cacheFileName)
+
+        try {
+            val store = DownloadedSongCatalogRoomStore(
+                context = context,
+                database = database,
+                cacheFileName = cacheFileName,
+                snapshotCacheKeyProvider = { "root-a" },
+                loggerTag = "DownloadedSongCatalogRoomStoreTest"
+            )
+            val oldSong = song("old-room", "/music/old.mp3")
+            val newSong = song("new-legacy", "/music/new.mp3")
+            store.persist(listOf(oldSong))
+
+            val target = persistDownloadedSongCatalogWithFallback(
+                store = FailingRoomCatalogStore(store),
+                songs = listOf(newSong)
+            )
+
+            assertEquals(DownloadedSongCatalogPersistTarget.LEGACY_JSON, target)
+            assertTrue(cacheFile.exists())
+            assertEquals(
+                DownloadedSongCatalogRoomStore.LEGACY_JSON_STATE,
+                database.syncMetadataDao()
+                    .getMigrationMetadata(
+                        DownloadedSongCatalogRoomStore.CUTOVER_STATE_METADATA_KEY
+                    )
+                    ?.value
+            )
+            assertEquals(listOf(newSong), store.restore())
+            assertEquals(
+                DownloadedSongCatalogRoomStore.ROOM_PRIMARY_STATE,
+                database.syncMetadataDao()
+                    .getMigrationMetadata(
+                        DownloadedSongCatalogRoomStore.CUTOVER_STATE_METADATA_KEY
+                    )
+                    ?.value
+            )
+        } finally {
+            cacheFile.delete()
+            database.close()
+        }
+    }
+
     private fun song(name: String, filePath: String): DownloadedSong {
         return DownloadedSong(
             id = 1L,
@@ -110,5 +163,17 @@ class DownloadedSongCatalogRoomStoreTest {
             durationMs = 180_000L,
             stableKey = "1|netease|"
         )
+    }
+
+    private class FailingRoomCatalogStore(
+        private val delegate: DownloadedSongCatalogRoomStore
+    ) : DownloadedSongCatalogPersistenceStore {
+        override suspend fun persistCatalog(songs: List<DownloadedSong>) {
+            throw IOException("forced Room catalog failure")
+        }
+
+        override suspend fun persistLegacyFallback(songs: List<DownloadedSong>) {
+            delegate.persistLegacyFallback(songs)
+        }
     }
 }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStoreTest.kt
@@ -216,6 +216,34 @@ class PlaybackQueueRoomStoreTest {
     }
 
     @Test
+    fun restoredPlaybackStatePrefersNewerLegacyJsonWhenRoomMarkerStayedPrimary() {
+        val oldRoomState = PersistedState(
+            playlist = listOf(song(1L, "old-room")),
+            index = 0,
+            positionMs = 1_000L
+        )
+        val newerLegacyState = PersistedState(
+            playlist = listOf(song(2L, "newer-legacy")),
+            index = 0,
+            positionMs = 2_000L
+        )
+
+        val restored = selectRestoredPlaybackState(
+            roomPrimary = true,
+            roomSnapshot = PlaybackQueueRoomSnapshot(
+                state = oldRoomState,
+                updatedAt = 100L
+            ),
+            legacySnapshot = PlaybackQueueLegacySnapshot(
+                state = newerLegacyState,
+                updatedAt = 200L
+            )
+        )
+
+        assertEquals(newerLegacyState, restored)
+    }
+
+    @Test
     fun noOpPersistDoesNotClearNonEmptyQueue() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val dir = File(context.cacheDir, "playback-queue-noop-${System.nanoTime()}")

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStoreTest.kt
@@ -179,6 +179,43 @@ class PlaybackQueueRoomStoreTest {
     }
 
     @Test
+    fun legacyJsonRemainsUsableWhenRoomMarkerWriteFails() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        val dir = File(context.cacheDir, "playback-queue-marker-failure-${System.nanoTime()}")
+        val legacyStore = PlaybackQueueLegacyStore(
+            stateFile = File(dir, "last_playlist.json"),
+            playbackStateFile = File(dir, "last_playback_state.json"),
+            gson = Gson()
+        )
+
+        try {
+            val state = PersistedState(
+                playlist = listOf(song(3L, "marker-failure")),
+                index = 0,
+                positionMs = 3_000L
+            )
+            val target = persistPlaybackQueueWithRoomFallback(
+                roomStore = MarkerFailingPlaybackQueueStateStore(),
+                legacyStore = legacyStore,
+                queueState = state,
+                playbackState = PersistedPlaybackState(index = 0, positionMs = 3_000L),
+                shouldWriteQueueState = true,
+                shouldWritePlaybackState = true
+            )
+
+            assertEquals(PlaybackQueuePersistTarget.LEGACY_JSON, target)
+            assertEquals(state, legacyStore.read())
+        } finally {
+            database.close()
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
     fun noOpPersistDoesNotClearNonEmptyQueue() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val dir = File(context.cacheDir, "playback-queue-noop-${System.nanoTime()}")
@@ -273,5 +310,23 @@ class PlaybackQueueRoomStoreTest {
         }
 
         override suspend fun markLegacyJsonPrimary(now: Long) = Unit
+    }
+
+    private class MarkerFailingPlaybackQueueStateStore : PlaybackQueueStateStore {
+        override suspend fun replaceSnapshot(state: PersistedState, now: Long) {
+            throw IOException("forced Room snapshot failure")
+        }
+
+        override suspend fun updatePlaybackState(state: PersistedPlaybackState, now: Long) {
+            throw IOException("forced Room playback failure")
+        }
+
+        override suspend fun clear(now: Long) {
+            throw IOException("forced Room clear failure")
+        }
+
+        override suspend fun markLegacyJsonPrimary(now: Long) {
+            throw IOException("forced Room marker failure")
+        }
     }
 }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStoreTest.kt
@@ -4,17 +4,22 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.gson.Gson
 import kotlinx.coroutines.test.runTest
 import moe.ouom.neriplayer.core.api.search.MusicPlatform
 import moe.ouom.neriplayer.core.player.model.PersistedPlaybackState
 import moe.ouom.neriplayer.core.player.model.PersistedSongItem
 import moe.ouom.neriplayer.core.player.model.PersistedState
+import moe.ouom.neriplayer.core.player.model.withPlaybackState
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
+import java.io.IOException
 
 @RunWith(AndroidJUnit4::class)
 class PlaybackQueueRoomStoreTest {
@@ -115,6 +120,97 @@ class PlaybackQueueRoomStoreTest {
         }
     }
 
+    @Test
+    fun roomSnapshotFailureFallsBackToLegacyJsonAndMarksLegacyPrimary() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+        val dir = File(context.cacheDir, "playback-queue-fallback-${System.nanoTime()}")
+        val legacyStore = PlaybackQueueLegacyStore(
+            stateFile = File(dir, "last_playlist.json"),
+            playbackStateFile = File(dir, "last_playback_state.json"),
+            gson = Gson()
+        )
+
+        try {
+            val state = PersistedState(
+                playlist = listOf(song(1L, "first"), song(2L, "second")),
+                index = 0,
+                mediaUrl = "https://example.test/old",
+                positionMs = 1_000L,
+                shouldResumePlayback = false,
+                repeatMode = 0,
+                shuffleEnabled = false
+            )
+            val playbackState = PersistedPlaybackState(
+                index = 1,
+                mediaUrl = "https://example.test/current",
+                positionMs = 8_000L,
+                shouldResumePlayback = true,
+                repeatMode = 2,
+                shuffleEnabled = true
+            )
+            val failingStore = FailingPlaybackQueueStateStore(database)
+
+            val target = persistPlaybackQueueWithRoomFallback(
+                roomStore = failingStore,
+                legacyStore = legacyStore,
+                queueState = state,
+                playbackState = playbackState,
+                shouldWriteQueueState = true,
+                shouldWritePlaybackState = true
+            )
+
+            assertEquals(PlaybackQueuePersistTarget.LEGACY_JSON, target)
+            assertEquals(1, failingStore.replaceCalls)
+            assertEquals(state.withPlaybackState(playbackState), legacyStore.read())
+            assertEquals(
+                PlaybackQueueRoomStore.LEGACY_JSON_STATE,
+                database.syncMetadataDao().getMigrationMetadata(
+                    PlaybackQueueRoomStore.CUTOVER_STATE_METADATA_KEY
+                )?.value
+            )
+        } finally {
+            database.close()
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun noOpPersistDoesNotClearNonEmptyQueue() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val dir = File(context.cacheDir, "playback-queue-noop-${System.nanoTime()}")
+        val legacyStore = PlaybackQueueLegacyStore(
+            stateFile = File(dir, "last_playlist.json"),
+            playbackStateFile = File(dir, "last_playback_state.json"),
+            gson = Gson()
+        )
+        val store = TrackingPlaybackQueueStateStore()
+
+        try {
+            val target = persistPlaybackQueueWithRoomFallback(
+                roomStore = store,
+                legacyStore = legacyStore,
+                queueState = PersistedState(
+                    playlist = listOf(song(1L, "first")),
+                    index = 0
+                ),
+                playbackState = PersistedPlaybackState(index = 0),
+                shouldWriteQueueState = false,
+                shouldWritePlaybackState = false
+            )
+
+            assertEquals(PlaybackQueuePersistTarget.NONE, target)
+            assertEquals(0, store.clearCalls)
+            assertEquals(0, store.replaceCalls)
+            assertEquals(0, store.updateCalls)
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
     private fun song(id: Long, name: String): PersistedSongItem {
         return PersistedSongItem(
             id = id,
@@ -128,5 +224,54 @@ class PlaybackQueueRoomStoreTest {
             channelId = "netease",
             audioId = id.toString()
         )
+    }
+
+    private class FailingPlaybackQueueStateStore(
+        private val database: NeriUserDataDatabase
+    ) : PlaybackQueueStateStore {
+        var replaceCalls = 0
+
+        override suspend fun replaceSnapshot(state: PersistedState, now: Long) {
+            replaceCalls += 1
+            throw IOException("forced Room snapshot failure")
+        }
+
+        override suspend fun updatePlaybackState(state: PersistedPlaybackState, now: Long) {
+            throw IOException("forced Room playback failure")
+        }
+
+        override suspend fun clear(now: Long) {
+            throw IOException("forced Room clear failure")
+        }
+
+        override suspend fun markLegacyJsonPrimary(now: Long) {
+            database.syncMetadataDao().upsertMigrationMetadata(
+                MigrationMetadataEntity(
+                    key = PlaybackQueueRoomStore.CUTOVER_STATE_METADATA_KEY,
+                    value = PlaybackQueueRoomStore.LEGACY_JSON_STATE,
+                    updatedAt = now
+                )
+            )
+        }
+    }
+
+    private class TrackingPlaybackQueueStateStore : PlaybackQueueStateStore {
+        var replaceCalls = 0
+        var updateCalls = 0
+        var clearCalls = 0
+
+        override suspend fun replaceSnapshot(state: PersistedState, now: Long) {
+            replaceCalls += 1
+        }
+
+        override suspend fun updatePlaybackState(state: PersistedPlaybackState, now: Long) {
+            updateCalls += 1
+        }
+
+        override suspend fun clear(now: Long) {
+            clearCalls += 1
+        }
+
+        override suspend fun markLegacyJsonPrimary(now: Long) = Unit
     }
 }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -76,6 +76,27 @@ class NeriUserDataDatabaseMigrationTest {
             assertEquals(1L, migrated.longFor("SELECT COUNT(*) FROM playlist_member"))
             assertEquals(1L, migrated.longFor("SELECT COUNT(*) FROM playlist_member_token"))
             assertEquals(
+                "old-device",
+                migrated.stringFor(
+                    "SELECT device_id FROM playlist_member_token " +
+                        "WHERE playlist_id = 601 AND identity_key = '9001|NeteaseAlbum|'"
+                )
+            )
+            assertEquals(
+                42L,
+                migrated.longFor(
+                    "SELECT counter FROM playlist_member_token " +
+                        "WHERE playlist_id = 601 AND identity_key = '9001|NeteaseAlbum|'"
+                )
+            )
+            assertEquals(
+                0L,
+                migrated.longFor(
+                    "SELECT token_index FROM playlist_member_token " +
+                        "WHERE playlist_id = 601 AND identity_key = '9001|NeteaseAlbum|'"
+                )
+            )
+            assertEquals(
                 "旧Room歌单",
                 migrated.stringFor("SELECT name FROM local_playlist WHERE playlist_id = 601")
             )

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -1,9 +1,11 @@
 package moe.ouom.neriplayer.data.local.database
 
+import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,7 +44,152 @@ class NeriUserDataDatabaseMigrationTest {
         ).close()
     }
 
+    @Test
+    fun migrateFromVersion1ToVersion14KeepsExistingLocalPlaylistRows() {
+        helper.createDatabase(TEST_DATABASE_WITH_DATA_NAME, 1).apply {
+            insertVersion1LocalPlaylistFixture()
+            close()
+        }
+
+        val migrated = helper.runMigrationsAndValidate(
+            TEST_DATABASE_WITH_DATA_NAME,
+            14,
+            true,
+            NeriUserDataDatabase.MIGRATION_1_2,
+            NeriUserDataDatabase.MIGRATION_2_3,
+            NeriUserDataDatabase.MIGRATION_3_4,
+            NeriUserDataDatabase.MIGRATION_4_5,
+            NeriUserDataDatabase.MIGRATION_5_6,
+            NeriUserDataDatabase.MIGRATION_6_7,
+            NeriUserDataDatabase.MIGRATION_7_8,
+            NeriUserDataDatabase.MIGRATION_8_9,
+            NeriUserDataDatabase.MIGRATION_9_10,
+            NeriUserDataDatabase.MIGRATION_10_11,
+            NeriUserDataDatabase.MIGRATION_11_12,
+            NeriUserDataDatabase.MIGRATION_12_13,
+            NeriUserDataDatabase.MIGRATION_13_14
+        )
+
+        try {
+            assertEquals(1L, migrated.longFor("SELECT COUNT(*) FROM local_playlist"))
+            assertEquals(1L, migrated.longFor("SELECT COUNT(*) FROM track"))
+            assertEquals(1L, migrated.longFor("SELECT COUNT(*) FROM playlist_member"))
+            assertEquals(1L, migrated.longFor("SELECT COUNT(*) FROM playlist_member_token"))
+            assertEquals(
+                "旧Room歌单",
+                migrated.stringFor("SELECT name FROM local_playlist WHERE playlist_id = 601")
+            )
+            assertEquals(
+                "旧Room歌曲",
+                migrated.stringFor("SELECT name FROM track WHERE identity_key = '9001|NeteaseAlbum|'")
+            )
+            assertEquals(
+                "room_primary",
+                migrated.stringFor(
+                    "SELECT value FROM migration_metadata " +
+                        "WHERE key = 'local_playlist_cutover_state'"
+                )
+            )
+        } finally {
+            migrated.close()
+        }
+    }
+
+    private fun SupportSQLiteDatabase.insertVersion1LocalPlaylistFixture() {
+        val songPayload = sqlText(
+            """
+            {
+              "id": 9001,
+              "name": "旧Room歌曲",
+              "artist": "artist",
+              "album": "NeteaseAlbum",
+              "albumId": 7,
+              "durationMs": 180000,
+              "coverUrl": null,
+              "channelId": "netease",
+              "audioId": "9001",
+              "addedAt": 1700000000000
+            }
+            """.trimIndent()
+        )
+        execSQL(
+            """
+            INSERT INTO local_playlist (
+              playlist_id, name, display_position, custom_cover_url, modified_at,
+              song_order_version, is_system
+            ) VALUES (
+              601, ${sqlText("旧Room歌单")}, 0, NULL, 1700000000000, 1, 0
+            )
+            """.trimIndent()
+        )
+        execSQL(
+            """
+            INSERT INTO track (
+              identity_key, identity_id, identity_album, identity_media_uri,
+              song_id, name, artist, album, album_id, duration_ms, cover_url,
+              media_uri, channel_id, audio_id, sub_audio_id, source_stable_key,
+              local_file_name, local_file_path, payload_schema_version,
+              durable_payload_json
+            ) VALUES (
+              '9001|NeteaseAlbum|', 9001, 'NeteaseAlbum', NULL,
+              9001, ${sqlText("旧Room歌曲")}, 'artist', 'NeteaseAlbum',
+              7, 180000, NULL, NULL, 'netease', '9001', NULL, NULL,
+              NULL, NULL, 1, $songPayload
+            )
+            """.trimIndent()
+        )
+        execSQL(
+            """
+            INSERT INTO playlist_member (
+              playlist_id, identity_key, display_position, added_at,
+              order_tie_break, playlist_context_id, member_payload_schema_version,
+              member_payload_json
+            ) VALUES (
+              601, '9001|NeteaseAlbum|', 0, 1700000000000, 0,
+              NULL, 1, $songPayload
+            )
+            """.trimIndent()
+        )
+        execSQL(
+            """
+            INSERT INTO playlist_member_token (
+              playlist_id, identity_key, device_id, counter, token_index
+            ) VALUES (
+              601, '9001|NeteaseAlbum|', 'old-device', 42, 0
+            )
+            """.trimIndent()
+        )
+        execSQL(
+            """
+            INSERT INTO migration_metadata (
+              key, value, updated_at
+            ) VALUES (
+              'local_playlist_cutover_state', 'room_primary', 1700000000000
+            )
+            """.trimIndent()
+        )
+    }
+
+    private fun SupportSQLiteDatabase.longFor(query: String): Long {
+        return this.query(query).use { cursor ->
+            check(cursor.moveToFirst())
+            cursor.getLong(0)
+        }
+    }
+
+    private fun SupportSQLiteDatabase.stringFor(query: String): String {
+        return this.query(query).use { cursor ->
+            check(cursor.moveToFirst())
+            cursor.getString(0)
+        }
+    }
+
+    private fun sqlText(value: String): String {
+        return "'${value.replace("'", "''")}'"
+    }
+
     private companion object {
         const val TEST_DATABASE_NAME = "neri-user-data-migration-test"
+        const val TEST_DATABASE_WITH_DATA_NAME = "neri-user-data-migration-with-data-test"
     }
 }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinatorTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinatorTest.kt
@@ -22,6 +22,13 @@ class LegacyJsonCleanupCoordinatorTest {
     @Test
     fun cleanupDeletesEligibleFilesAndKeepsUnrelatedFiles() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
+        val originalFiles = snapshotFiles(
+            context,
+            "playback_stats_counters.json",
+            "last_playlist.json",
+            "managed_download_snapshot_v1.json",
+            "keep_me.json"
+        )
         val database = Room.inMemoryDatabaseBuilder(
             context,
             NeriUserDataDatabase::class.java
@@ -65,19 +72,18 @@ class LegacyJsonCleanupCoordinatorTest {
             assertTrue(audit?.value?.contains("last_playlist.json") == true)
         } finally {
             database.close()
-            cleanupFiles(
-                context,
-                "playback_stats_counters.json",
-                "last_playlist.json",
-                "managed_download_snapshot_v1.json",
-                "keep_me.json"
-            )
+            restoreFiles(context, originalFiles)
         }
     }
 
     @Test
     fun cleanupDeletesEligibleFilesEvenWhenOtherTargetsAreBlocked() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
+        val originalFiles = snapshotFiles(
+            context,
+            "playback_stats_counters.json",
+            "last_playback_state.json"
+        )
         val database = Room.inMemoryDatabaseBuilder(
             context,
             NeriUserDataDatabase::class.java
@@ -110,17 +116,19 @@ class LegacyJsonCleanupCoordinatorTest {
             assertTrue(audit?.value?.contains("last_playback_state.json") == true)
         } finally {
             database.close()
-            cleanupFiles(
-                context,
-                "playback_stats_counters.json",
-                "last_playback_state.json"
-            )
+            restoreFiles(context, originalFiles)
         }
     }
 
     @Test
     fun cleanupKeepsLegacyJsonFallbackFilesInMixedUpgradeState() = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
+        val originalFiles = snapshotFiles(
+            context,
+            "local_playlists.json",
+            "last_playlist.json",
+            "play_history.json"
+        )
         val database = Room.inMemoryDatabaseBuilder(
             context,
             NeriUserDataDatabase::class.java
@@ -139,6 +147,8 @@ class LegacyJsonCleanupCoordinatorTest {
             val promotedPlaylistFile = writeLegacyFile(context, "local_playlists.json")
             val fallbackQueueFile = writeLegacyFile(context, "last_playlist.json")
             val missingMarkerHistoryFile = writeLegacyFile(context, "play_history.json")
+            val fallbackQueueContent = fallbackQueueFile.readText()
+            val missingMarkerHistoryContent = missingMarkerHistoryFile.readText()
 
             val coordinator = LegacyJsonCleanupCoordinator(context, database)
             val plan = coordinator.buildPlan()
@@ -150,14 +160,11 @@ class LegacyJsonCleanupCoordinatorTest {
             assertTrue(missingMarkerHistoryFile.exists())
             assertTrue(result.blockedFiles.contains("last_playlist.json"))
             assertTrue(result.blockedFiles.contains("play_history.json"))
+            assertEquals(fallbackQueueContent, fallbackQueueFile.readText())
+            assertEquals(missingMarkerHistoryContent, missingMarkerHistoryFile.readText())
         } finally {
             database.close()
-            cleanupFiles(
-                context,
-                "local_playlists.json",
-                "last_playlist.json",
-                "play_history.json"
-            )
+            restoreFiles(context, originalFiles)
         }
     }
 
@@ -193,9 +200,20 @@ class LegacyJsonCleanupCoordinatorTest {
         }
     }
 
-    private fun cleanupFiles(context: Context, vararg fileNames: String) {
-        fileNames.forEach { fileName ->
-            File(context.filesDir, fileName).delete()
+    private fun snapshotFiles(context: Context, vararg fileNames: String): Map<String, String?> {
+        return fileNames.associateWith { fileName ->
+            File(context.filesDir, fileName).takeIf(File::exists)?.readText()
+        }
+    }
+
+    private fun restoreFiles(context: Context, files: Map<String, String?>) {
+        files.forEach { (fileName, content) ->
+            val file = File(context.filesDir, fileName)
+            if (content == null) {
+                file.delete()
+            } else {
+                file.writeText(content)
+            }
         }
     }
 }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinatorTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/store/LegacyJsonCleanupCoordinatorTest.kt
@@ -118,6 +118,49 @@ class LegacyJsonCleanupCoordinatorTest {
         }
     }
 
+    @Test
+    fun cleanupKeepsLegacyJsonFallbackFilesInMixedUpgradeState() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            setRoomPrimary(
+                database = database,
+                key = LocalPlaylistRoomStore.CUTOVER_STATE_METADATA_KEY
+            )
+            setLegacyJsonPrimary(
+                database = database,
+                key = PlaybackQueueRoomStore.CUTOVER_STATE_METADATA_KEY
+            )
+
+            val promotedPlaylistFile = writeLegacyFile(context, "local_playlists.json")
+            val fallbackQueueFile = writeLegacyFile(context, "last_playlist.json")
+            val missingMarkerHistoryFile = writeLegacyFile(context, "play_history.json")
+
+            val coordinator = LegacyJsonCleanupCoordinator(context, database)
+            val plan = coordinator.buildPlan()
+            val result = coordinator.execute(plan, confirmed = true)
+
+            assertEquals(LegacyJsonCleanupStatus.BLOCKED, result.status)
+            assertFalse(promotedPlaylistFile.exists())
+            assertTrue(fallbackQueueFile.exists())
+            assertTrue(missingMarkerHistoryFile.exists())
+            assertTrue(result.blockedFiles.contains("last_playlist.json"))
+            assertTrue(result.blockedFiles.contains("play_history.json"))
+        } finally {
+            database.close()
+            cleanupFiles(
+                context,
+                "local_playlists.json",
+                "last_playlist.json",
+                "play_history.json"
+            )
+        }
+    }
+
     private suspend fun setRoomPrimary(
         database: NeriUserDataDatabase,
         key: String
@@ -126,6 +169,19 @@ class LegacyJsonCleanupCoordinatorTest {
             MigrationMetadataEntity(
                 key = key,
                 value = LegacyJsonCleanupCoordinator.ROOM_PRIMARY_STATE,
+                updatedAt = System.currentTimeMillis()
+            )
+        )
+    }
+
+    private suspend fun setLegacyJsonPrimary(
+        database: NeriUserDataDatabase,
+        key: String
+    ) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = key,
+                value = PlaybackQueueRoomStore.LEGACY_JSON_STATE,
                 updatedAt = System.currentTimeMillis()
             )
         )

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepositoryRoomStoreTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/playlist/LocalPlaylistRepositoryRoomStoreTest.kt
@@ -1,0 +1,110 @@
+package moe.ouom.neriplayer.data.local.playlist
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.LocalPlaylistRoomStore
+import moe.ouom.neriplayer.data.local.playlist.model.LocalPlaylist
+import moe.ouom.neriplayer.data.sync.model.SyncCausalToken
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class LocalPlaylistRepositoryRoomStoreTest {
+    @Test
+    fun roomPrimaryOutboxReplaysAndClearsOnRepositoryStartup() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = Room.inMemoryDatabaseBuilder(
+            context,
+            NeriUserDataDatabase::class.java
+        ).allowMainThreadQueries().build()
+
+        try {
+            val playlists = listOf(LocalPlaylist(id = 401L, name = "restored"))
+            val committedDigest = LocalPlaylistRoomStore.domainDigest(playlists)
+            val roomStore = LocalPlaylistRoomStore(database)
+            val pendingMutation = LocalPlaylistSyncMutation(
+                expectedPrimaryDigest = committedDigest,
+                restoredPlaylistIds = listOf(401L)
+            )
+            roomStore.replacePlaylists(playlists, committedDigest)
+            roomStore.writePendingSyncMutationOutbox(
+                LocalPlaylistSyncMutationOutbox(mutations = listOf(pendingMutation))
+            )
+            val syncStore = RecordingSyncMutationStore()
+            val storage = EmptyStorage()
+
+            val repository = LocalPlaylistRepository.createForTest(
+                context = context,
+                file = File(context.cacheDir, "room_primary_outbox_unused.json"),
+                normalizePlaylists = { it },
+                autoSyncEnabled = false,
+                storage = storage,
+                syncMutationStore = syncStore,
+                roomStore = roomStore
+            )
+
+            assertEquals(playlists, repository.playlists.value)
+            assertEquals(listOf(pendingMutation), syncStore.applied)
+            assertEquals(1L, syncStore.mutationVersion)
+            assertNull(roomStore.readPendingSyncMutationOutbox())
+            assertTrue(storage.pendingCleared)
+        } finally {
+            database.close()
+        }
+    }
+
+    private class EmptyStorage : LocalPlaylistStorage {
+        var pendingCleared = false
+
+        override fun readPrimary(): String? = null
+
+        override fun readBackup(): String? = null
+
+        override fun commit(
+            text: String,
+            rotateBackup: Boolean,
+            replaceBackupWithCommittedPrimary: Boolean
+        ) = Unit
+
+        override fun quarantinePrimary(): File? = null
+
+        override fun clearPendingSyncMutation() {
+            pendingCleared = true
+        }
+    }
+
+    private class RecordingSyncMutationStore : LocalPlaylistSyncMutationStore {
+        val applied = mutableListOf<LocalPlaylistSyncMutation>()
+        var mutationVersion = 0L
+            private set
+        private var nextCounter = 1L
+
+        override fun getOrCreateDeviceId(): String = "room-replay-device"
+
+        override fun nextSyncCausalTokens(count: Int): List<SyncCausalToken> {
+            require(count >= 0)
+            return List(count) {
+                SyncCausalToken(getOrCreateDeviceId(), nextCounter++)
+            }
+        }
+
+        override fun getSyncMutationVersion(): Long = mutationVersion
+
+        override fun markSyncMutation(): Long {
+            mutationVersion += 1L
+            return mutationVersion
+        }
+
+        override fun apply(mutation: LocalPlaylistSyncMutation) {
+            applied += mutation
+        }
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/NeriPlayerApplication.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/NeriPlayerApplication.kt
@@ -116,6 +116,7 @@ class NeriPlayerApplication : Application() {
                 AppContainer.playlistUsageRepo
                 AppContainer.localPlaylistPlaybackStatsRepo
                 AppContainer.playbackStatsRepo
+                AppContainer.trafficStatsRepo
             }
             AppContainer.launchBackgroundIo {
                 AppContainer.neteasePlaylistCacheRepo.importLegacyCaches()

--- a/app/src/main/java/moe/ouom/neriplayer/core/api/netease/NeteaseClient.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/api/netease/NeteaseClient.kt
@@ -852,6 +852,30 @@ class NeteaseClient {
     }
 
     /**
+     * 批量添加歌曲到网易云歌单
+     * 网易云接口允许一次提交多个歌曲 ID，调用方应控制批次大小并检查返回 code
+     */
+    @Throws(IOException::class)
+    fun addSongsToPlaylist(playlistId: Long, songIds: List<Long>): String {
+        require(playlistId > 0L) { "playlistId must be positive" }
+        require(songIds.isNotEmpty()) { "songIds must not be empty" }
+        val ids = songIds.asSequence()
+            .filter { it > 0L }
+            .distinct()
+            .joinToString(",")
+        require(ids.isNotEmpty()) { "songIds must contain a positive id" }
+        return callWeApi(
+            "/playlist/manipulate/tracks",
+            mapOf(
+                "op" to "add",
+                "pid" to playlistId.toString(),
+                "tracks" to ids
+            ),
+            usePersistedCookies = true
+        )
+    }
+
+    /**
      * 获取当前登录用户的账户信息 (包含 userId)
      */
     @Throws(IOException::class)

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/GlobalDownloadManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/GlobalDownloadManager.kt
@@ -2118,7 +2118,10 @@ object GlobalDownloadManager {
         context: Context,
         songs: List<DownloadedSong>
     ) {
-        downloadedSongCatalogStore.persist(context, songs)
+        val persisted = downloadedSongCatalogStore.persist(context, songs)
+        if (!persisted) {
+            scheduleCatalogReconcile(context, forceRefresh = true)
+        }
     }
 
     fun startDownload(context: Context, song: SongItem) {

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogModels.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogModels.kt
@@ -295,6 +295,8 @@ internal fun serializeDownloadedSongsCatalog(
                         put("downloadTime", song.downloadTime)
                         put("coverPath", song.coverPath)
                         put("coverUrl", song.coverUrl)
+                        put("matchedLyric", song.matchedLyric)
+                        put("matchedTranslatedLyric", song.matchedTranslatedLyric)
                         put("matchedLyricSource", song.matchedLyricSource)
                         put("matchedSongId", song.matchedSongId)
                         put("userLyricOffsetMs", song.userLyricOffsetMs)

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogRoomStore.kt
@@ -11,6 +11,7 @@ import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.local.database.entity.DownloadedSongCatalogEntity
 import moe.ouom.neriplayer.data.local.database.entity.MigrationMetadataEntity
+import moe.ouom.neriplayer.util.io.writeTextAtomically
 
 internal class DownloadedSongCatalogRoomStore(
     private val context: Context,
@@ -18,7 +19,7 @@ internal class DownloadedSongCatalogRoomStore(
     private val cacheFileName: String,
     private val snapshotCacheKeyProvider: (Context) -> String,
     private val loggerTag: String
-) {
+) : DownloadedSongCatalogPersistenceStore {
     suspend fun restore(): List<DownloadedSong>? {
         globalMutex.withLock {
             val rootKey = snapshotCacheKeyProvider(context)
@@ -41,12 +42,24 @@ internal class DownloadedSongCatalogRoomStore(
     }
 
     suspend fun persist(songs: List<DownloadedSong>) {
+        persistCatalog(songs)
+    }
+
+    override suspend fun persistCatalog(songs: List<DownloadedSong>) {
         globalMutex.withLock {
             val rootKey = snapshotCacheKeyProvider(context)
             database.withTransaction {
                 replaceCatalog(rootKey, songs)
                 markRoomPrimary(rootKey)
             }
+        }
+    }
+
+    override suspend fun persistLegacyFallback(songs: List<DownloadedSong>) {
+        globalMutex.withLock {
+            val rootKey = snapshotCacheKeyProvider(context)
+            writeLegacyCatalog(rootKey, songs)
+            markLegacyJsonPrimary(rootKey)
         }
     }
 
@@ -93,6 +106,33 @@ internal class DownloadedSongCatalogRoomStore(
         )
     }
 
+    private suspend fun markLegacyJsonPrimary(rootKey: String) {
+        val nowMs = System.currentTimeMillis()
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = CUTOVER_STATE_METADATA_KEY,
+                value = LEGACY_JSON_STATE,
+                updatedAt = nowMs
+            )
+        )
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = ROOT_KEY_METADATA_KEY,
+                value = rootKey,
+                updatedAt = nowMs
+            )
+        )
+    }
+
+    private fun writeLegacyCatalog(rootKey: String, songs: List<DownloadedSong>) {
+        File(context.filesDir, cacheFileName).writeTextAtomically(
+            serializeDownloadedSongsCatalog(
+                cacheKey = rootKey,
+                songs = songs
+            )
+        )
+    }
+
     private fun readLegacyCatalog(rootKey: String): List<DownloadedSong>? {
         val file = File(context.filesDir, cacheFileName)
         if (!file.exists()) {
@@ -121,6 +161,7 @@ internal class DownloadedSongCatalogRoomStore(
         const val CUTOVER_STATE_METADATA_KEY = "downloaded_song_catalog_cutover_state"
         const val ROOT_KEY_METADATA_KEY = "downloaded_song_catalog_root_key"
         const val ROOM_PRIMARY_STATE = "room_primary"
+        const val LEGACY_JSON_STATE = "legacy_json"
         private val globalMutex = Mutex()
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/catalog/DownloadedSongCatalogStore.kt
@@ -22,14 +22,24 @@ internal class DownloadedSongCatalogStore(
         }.getOrNull()
     }
 
-    fun persist(context: Context, songs: List<DownloadedSong>) {
-        runCatching {
+    fun persist(context: Context, songs: List<DownloadedSong>): Boolean {
+        return runCatching {
             runBlocking(Dispatchers.IO) {
-                roomStore(context).persist(songs)
+                persistDownloadedSongCatalogWithFallback(
+                    store = roomStore(context),
+                    songs = songs,
+                    onRoomFailure = { error ->
+                        NPLogger.e(
+                            loggerTag,
+                            "写入 Room 下载歌曲目录失败，降级写旧 JSON",
+                            error
+                        )
+                    }
+                )
             }
         }.onFailure {
             NPLogger.e(loggerTag, "写入下载歌曲目录失败", it)
-        }
+        }.isSuccess
     }
 
     private fun roomStore(context: Context): DownloadedSongCatalogRoomStore {
@@ -41,5 +51,31 @@ internal class DownloadedSongCatalogStore(
             snapshotCacheKeyProvider = snapshotCacheKeyProvider,
             loggerTag = loggerTag
         )
+    }
+}
+
+internal enum class DownloadedSongCatalogPersistTarget {
+    ROOM,
+    LEGACY_JSON
+}
+
+internal interface DownloadedSongCatalogPersistenceStore {
+    suspend fun persistCatalog(songs: List<DownloadedSong>)
+
+    suspend fun persistLegacyFallback(songs: List<DownloadedSong>)
+}
+
+internal suspend fun persistDownloadedSongCatalogWithFallback(
+    store: DownloadedSongCatalogPersistenceStore,
+    songs: List<DownloadedSong>,
+    onRoomFailure: (Throwable) -> Unit = {}
+): DownloadedSongCatalogPersistTarget {
+    return runCatching {
+        store.persistCatalog(songs)
+        DownloadedSongCatalogPersistTarget.ROOM
+    }.getOrElse { error ->
+        onRoomFailure(error)
+        store.persistLegacyFallback(songs)
+        DownloadedSongCatalogPersistTarget.LEGACY_JSON
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotCacheStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotCacheStore.kt
@@ -24,6 +24,15 @@ internal class ManagedDownloadSnapshotCacheStore(
     @Volatile
     private var snapshotPersistJob: Job? = null
 
+    @Volatile
+    private var snapshotClearJob: Job? = null
+
+    @Volatile
+    private var snapshotClearInFlight: Boolean = false
+
+    @Volatile
+    private var snapshotGeneration: Long = 0L
+
     private val snapshotPersistenceLock = Any()
 
     fun currentKey(context: Context): String {
@@ -74,9 +83,20 @@ internal class ManagedDownloadSnapshotCacheStore(
         expectedKey: String? = null
     ): ManagedDownloadStorage.DownloadLibrarySnapshot? {
         val appContext = context.applicationContext
+        val generation = synchronized(snapshotPersistenceLock) {
+            if (snapshotClearInFlight) {
+                return null
+            }
+            snapshotGeneration
+        }
         val restored = runBlocking {
             ManagedDownloadSnapshotRoomStore(appContext).restore(expectedKey)
         } ?: return null
+        synchronized(snapshotPersistenceLock) {
+            if (generation != snapshotGeneration || snapshotClearInFlight) {
+                return null
+            }
+        }
         snapshotCache = SnapshotCache(key = restored.first, snapshot = restored.second)
         return restored.second
     }
@@ -147,13 +167,37 @@ internal class ManagedDownloadSnapshotCacheStore(
 
     fun invalidate(context: Context? = null) {
         snapshotCache = null
+        val appContext = context?.applicationContext
         synchronized(snapshotPersistenceLock) {
+            snapshotGeneration += 1L
             snapshotPersistJob?.cancel()
             snapshotPersistJob = null
+            snapshotClearJob?.cancel()
+            snapshotClearJob = null
+            if (appContext == null) {
+                snapshotClearInFlight = false
+            } else {
+                snapshotClearInFlight = true
+            }
         }
-        val appContext = context?.applicationContext ?: return
-        scope.launch {
+        appContext ?: return
+        val clearJob = scope.launch {
             ManagedDownloadSnapshotRoomStore(appContext).clear()
+        }
+        synchronized(snapshotPersistenceLock) {
+            snapshotClearJob = clearJob
+            if (clearJob.isCompleted) {
+                snapshotClearJob = null
+                snapshotClearInFlight = false
+            }
+        }
+        clearJob.invokeOnCompletion {
+            synchronized(snapshotPersistenceLock) {
+                if (snapshotClearJob === clearJob) {
+                    snapshotClearJob = null
+                    snapshotClearInFlight = false
+                }
+            }
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotCacheStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotCacheStore.kt
@@ -9,9 +9,24 @@ import kotlinx.coroutines.runBlocking
 import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
 import moe.ouom.neriplayer.core.download.storage.SNAPSHOT_CACHE_PERSIST_DEBOUNCE_MS
 
+internal interface ManagedDownloadSnapshotPersistenceStore {
+    suspend fun restore(
+        expectedKey: String? = null
+    ): Pair<String, ManagedDownloadStorage.DownloadLibrarySnapshot>?
+
+    suspend fun persist(
+        cacheKey: String,
+        snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
+    ): Boolean
+
+    suspend fun clear()
+}
+
 internal class ManagedDownloadSnapshotCacheStore(
     private val scope: CoroutineScope,
-    private val cacheKeyProvider: (Context) -> String
+    private val cacheKeyProvider: (Context) -> String,
+    private val persistenceStoreProvider: (Context) -> ManagedDownloadSnapshotPersistenceStore =
+        { context -> ManagedDownloadSnapshotRoomStore(context) }
 ) {
     private data class SnapshotCache(
         val key: String,
@@ -90,7 +105,7 @@ internal class ManagedDownloadSnapshotCacheStore(
             snapshotGeneration
         }
         val restored = runBlocking {
-            ManagedDownloadSnapshotRoomStore(appContext).restore(expectedKey)
+            persistenceStoreProvider(appContext).restore(expectedKey)
         } ?: return null
         synchronized(snapshotPersistenceLock) {
             if (generation != snapshotGeneration || snapshotClearInFlight) {
@@ -182,7 +197,7 @@ internal class ManagedDownloadSnapshotCacheStore(
         }
         appContext ?: return
         val clearJob = scope.launch {
-            ManagedDownloadSnapshotRoomStore(appContext).clear()
+            persistenceStoreProvider(appContext).clear()
         }
         synchronized(snapshotPersistenceLock) {
             snapshotClearJob = clearJob
@@ -213,7 +228,7 @@ internal class ManagedDownloadSnapshotCacheStore(
                 val currentCache = snapshotCache
                     ?.takeIf { it.key == expectedKey }
                     ?: return@launch
-                if (ManagedDownloadSnapshotRoomStore(appContext).persist(
+                if (persistenceStoreProvider(appContext).persist(
                     cacheKey = currentCache.key,
                     snapshot = currentCache.snapshot
                 )) {

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotCacheStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotCacheStore.kt
@@ -152,7 +152,7 @@ internal class ManagedDownloadSnapshotCacheStore(
             snapshotPersistJob = null
         }
         val appContext = context?.applicationContext ?: return
-        runBlocking {
+        scope.launch {
             ManagedDownloadSnapshotRoomStore(appContext).clear()
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomStore.kt
@@ -13,9 +13,9 @@ internal class ManagedDownloadSnapshotRoomStore(
     private val context: Context,
     private val database: NeriUserDataDatabase =
         NeriUserDataDatabase.getInstance(context.applicationContext)
-) {
-    suspend fun restore(
-        expectedKey: String? = null
+) : ManagedDownloadSnapshotPersistenceStore {
+    override suspend fun restore(
+        expectedKey: String?
     ): Pair<String, ManagedDownloadStorage.DownloadLibrarySnapshot>? {
         return globalMutex.withLock {
             runCatching {
@@ -26,7 +26,7 @@ internal class ManagedDownloadSnapshotRoomStore(
         }
     }
 
-    suspend fun persist(
+    override suspend fun persist(
         cacheKey: String,
         snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
     ): Boolean {
@@ -35,7 +35,7 @@ internal class ManagedDownloadSnapshotRoomStore(
         }
     }
 
-    suspend fun clear() {
+    override suspend fun clear() {
         globalMutex.withLock {
             runCatching {
                 database.withTransaction {

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStore.kt
@@ -13,9 +13,25 @@ import moe.ouom.neriplayer.data.local.database.entity.PLAYBACK_QUEUE_STATE_ID
 import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueSongEntity
 import moe.ouom.neriplayer.data.local.database.entity.PlaybackQueueStateEntity
 
+internal interface PlaybackQueueStateStore {
+    suspend fun replaceSnapshot(
+        state: PersistedState,
+        now: Long
+    )
+
+    suspend fun updatePlaybackState(
+        state: PersistedPlaybackState,
+        now: Long
+    )
+
+    suspend fun clear(now: Long)
+
+    suspend fun markLegacyJsonPrimary(now: Long)
+}
+
 internal class PlaybackQueueRoomStore(
     private val database: NeriUserDataDatabase
-) {
+) : PlaybackQueueStateStore {
     suspend fun isRoomPrimary(): Boolean {
         return database.syncMetadataDao()
             .getMigrationMetadata(CUTOVER_STATE_METADATA_KEY)
@@ -29,9 +45,13 @@ internal class PlaybackQueueRoomStore(
         return readState()
     }
 
-    suspend fun replaceSnapshot(
+    suspend fun replaceSnapshot(state: PersistedState) {
+        replaceSnapshot(state, System.currentTimeMillis())
+    }
+
+    override suspend fun replaceSnapshot(
         state: PersistedState,
-        now: Long = System.currentTimeMillis()
+        now: Long
     ) {
         database.withTransaction {
             val dao = database.playbackQueueDao()
@@ -48,9 +68,13 @@ internal class PlaybackQueueRoomStore(
         }
     }
 
-    suspend fun updatePlaybackState(
+    suspend fun updatePlaybackState(state: PersistedPlaybackState) {
+        updatePlaybackState(state, System.currentTimeMillis())
+    }
+
+    override suspend fun updatePlaybackState(
         state: PersistedPlaybackState,
-        now: Long = System.currentTimeMillis()
+        now: Long
     ) {
         database.withTransaction {
             val dao = database.playbackQueueDao()
@@ -66,12 +90,30 @@ internal class PlaybackQueueRoomStore(
         }
     }
 
-    suspend fun clear(now: Long = System.currentTimeMillis()) {
+    suspend fun clear() {
+        clear(System.currentTimeMillis())
+    }
+
+    override suspend fun clear(now: Long) {
         database.withTransaction {
             database.playbackQueueDao().deleteState()
             database.playbackQueueDao().deleteSongs()
             markRoomPrimary(now)
         }
+    }
+
+    suspend fun markLegacyJsonPrimary() {
+        markLegacyJsonPrimary(System.currentTimeMillis())
+    }
+
+    override suspend fun markLegacyJsonPrimary(now: Long) {
+        database.syncMetadataDao().upsertMigrationMetadata(
+            MigrationMetadataEntity(
+                key = CUTOVER_STATE_METADATA_KEY,
+                value = LEGACY_JSON_STATE,
+                updatedAt = now
+            )
+        )
     }
 
     private suspend fun readState(): PersistedState? {
@@ -110,6 +152,7 @@ internal class PlaybackQueueRoomStore(
     companion object {
         const val CUTOVER_STATE_METADATA_KEY = "playback_queue_cutover_state"
         const val ROOM_PRIMARY_STATE = "room_primary"
+        const val LEGACY_JSON_STATE = "legacy_json"
     }
 }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlaybackQueueRoomStore.kt
@@ -29,6 +29,11 @@ internal interface PlaybackQueueStateStore {
     suspend fun markLegacyJsonPrimary(now: Long)
 }
 
+internal data class PlaybackQueueRoomSnapshot(
+    val state: PersistedState,
+    val updatedAt: Long
+)
+
 internal class PlaybackQueueRoomStore(
     private val database: NeriUserDataDatabase
 ) : PlaybackQueueStateStore {
@@ -39,10 +44,14 @@ internal class PlaybackQueueRoomStore(
     }
 
     suspend fun readIfRoomPrimary(): PersistedState? {
+        return readSnapshotIfRoomPrimary()?.state
+    }
+
+    suspend fun readSnapshotIfRoomPrimary(): PlaybackQueueRoomSnapshot? {
         if (!isRoomPrimary()) {
             return null
         }
-        return readState()
+        return readSnapshot()
     }
 
     suspend fun replaceSnapshot(state: PersistedState) {
@@ -116,25 +125,29 @@ internal class PlaybackQueueRoomStore(
         )
     }
 
-    private suspend fun readState(): PersistedState? {
+    private suspend fun readSnapshot(): PlaybackQueueRoomSnapshot? {
         return database.withTransaction {
             val dao = database.playbackQueueDao()
             val state = dao.getState() ?: return@withTransaction null
-            PersistedState(
-                playlist = dao.getSongs(PLAYBACK_QUEUE_MAIN).map(PlaybackQueueSongEntity::toPersistedSong),
-                index = state.currentIndex,
-                mediaUrl = state.mediaUrl,
-                positionMs = state.positionMs,
-                shouldResumePlayback = state.shouldResumePlayback,
-                repeatMode = state.repeatMode,
-                shuffleEnabled = state.shuffleEnabled,
-                shuffleRestorePlaylist = if (state.shuffleEnabled == true) {
-                    dao.getSongs(PLAYBACK_QUEUE_SHUFFLE_RESTORE)
-                        .map(PlaybackQueueSongEntity::toPersistedSong)
-                } else {
-                    null
-                },
-                shuffleRestoreIndex = state.shuffleRestoreIndex
+            PlaybackQueueRoomSnapshot(
+                state = PersistedState(
+                    playlist = dao.getSongs(PLAYBACK_QUEUE_MAIN)
+                        .map(PlaybackQueueSongEntity::toPersistedSong),
+                    index = state.currentIndex,
+                    mediaUrl = state.mediaUrl,
+                    positionMs = state.positionMs,
+                    shouldResumePlayback = state.shouldResumePlayback,
+                    repeatMode = state.repeatMode,
+                    shuffleEnabled = state.shuffleEnabled,
+                    shuffleRestorePlaylist = if (state.shuffleEnabled == true) {
+                        dao.getSongs(PLAYBACK_QUEUE_SHUFFLE_RESTORE)
+                            .map(PlaybackQueueSongEntity::toPersistedSong)
+                    } else {
+                        null
+                    },
+                    shuffleRestoreIndex = state.shuffleRestoreIndex
+                ),
+                updatedAt = state.updatedAt
             )
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -207,6 +207,13 @@ internal class PlaybackQueueLegacyStore(
         playbackStateFile.writeTextAtomically(gson.toJson(playbackState))
     }
 
+    fun lastModified(): Long {
+        return maxOf(
+            stateFile.takeIf(File::exists)?.lastModified() ?: 0L,
+            playbackStateFile.takeIf(File::exists)?.lastModified() ?: 0L
+        )
+    }
+
     fun clear() {
         runCatching { stateFile.delete() }
         runCatching { playbackStateFile.delete() }
@@ -239,7 +246,11 @@ internal suspend fun persistPlaybackQueueWithRoomFallback(
             PlaybackQueuePersistTarget.ROOM
         }.getOrElse { error ->
             onRoomFailure(error)
-            legacyStore.clear()
+            legacyStore.write(
+                PersistedState(playlist = emptyList(), index = -1)
+                    .withPlaybackState(playbackState),
+                playbackState
+            )
             runCatching { roomStore.markLegacyJsonPrimary(now) }
                 .onFailure { markerError ->
                     onRoomFailure(markerError)
@@ -267,22 +278,46 @@ internal suspend fun persistPlaybackQueueWithRoomFallback(
     }
 }
 
-private fun readLegacyPlaybackState(
+internal data class PlaybackQueueLegacySnapshot(
+    val state: PersistedState,
+    val updatedAt: Long
+)
+
+private fun readLegacyPlaybackStateSnapshot(
     stateFile: File,
     playbackStateFile: File
-): PersistedState? {
+): PlaybackQueueLegacySnapshot? {
     return runCatching {
-        PlaybackQueueLegacyStore(
+        val legacyStore = PlaybackQueueLegacyStore(
             stateFile = stateFile,
             playbackStateFile = playbackStateFile,
             gson = PlayerManager.gson
-        ).read()
+        )
+        val state = legacyStore.read() ?: return@runCatching null
+        PlaybackQueueLegacySnapshot(
+            state = state,
+            updatedAt = legacyStore.lastModified()
+        )
     }.onFailure { error ->
         NPLogger.w(
             "NERI-PlayerManager",
             "Failed to read legacy playback state: ${error.message}"
         )
     }.getOrNull()
+}
+
+internal fun selectRestoredPlaybackState(
+    roomPrimary: Boolean,
+    roomSnapshot: PlaybackQueueRoomSnapshot?,
+    legacySnapshot: PlaybackQueueLegacySnapshot?
+): PersistedState? {
+    if (!roomPrimary || roomSnapshot == null) {
+        return legacySnapshot?.state
+    }
+    if (legacySnapshot != null && legacySnapshot.updatedAt >= roomSnapshot.updatedAt) {
+        return legacySnapshot.state
+    }
+    return roomSnapshot.state
 }
 
 private fun buildRestoredStateSnapshot(
@@ -380,7 +415,7 @@ internal suspend fun preloadRestoredStateSnapshot(
         val roomStore = PlaybackQueueRoomStore(
             NeriUserDataDatabase.getInstance(app.applicationContext)
         )
-        val roomRead = runCatching { roomStore.readIfRoomPrimary() }
+        val roomRead = runCatching { roomStore.readSnapshotIfRoomPrimary() }
             .onFailure { error ->
                 NPLogger.w(
                     "NERI-PlayerManager",
@@ -395,13 +430,30 @@ internal suspend fun preloadRestoredStateSnapshot(
                 )
             }
             .getOrDefault(false)
-        val data = if (roomPrimary && roomRead.getOrNull() != null) {
-            roomRead.getOrNull()
-        } else {
-            readLegacyPlaybackState(
+        val roomSnapshot = roomRead.getOrNull()
+        val legacySnapshot = if (!roomPrimary ||
+            roomSnapshot == null ||
+            PlaybackQueueLegacyStore(
+                stateFile = startupStateFile,
+                playbackStateFile = startupPlaybackStateFile,
+                gson = PlayerManager.gson
+            ).lastModified() >= roomSnapshot.updatedAt
+        ) {
+            readLegacyPlaybackStateSnapshot(
                 stateFile = startupStateFile,
                 playbackStateFile = startupPlaybackStateFile
-            )?.also { legacyData ->
+            )
+        } else {
+            null
+        }
+        val data = selectRestoredPlaybackState(
+            roomPrimary = roomPrimary,
+            roomSnapshot = roomSnapshot,
+            legacySnapshot = legacySnapshot
+        )
+        val selectedLegacySnapshot = legacySnapshot
+        if (data != null && selectedLegacySnapshot != null && data === selectedLegacySnapshot.state) {
+            selectedLegacySnapshot.state.also { legacyData ->
                 runCatching {
                     roomStore.replaceSnapshot(legacyData)
                 }.onFailure { error ->
@@ -446,7 +498,7 @@ private fun loadRestoredStateSnapshot(
                 }
                 .getOrDefault(false)
             val roomRead = if (roomPrimary) {
-                runCatching { roomStore.readIfRoomPrimary() }
+                runCatching { roomStore.readSnapshotIfRoomPrimary() }
                     .onFailure { error ->
                         NPLogger.w(
                             "NERI-PlayerManager",
@@ -456,13 +508,30 @@ private fun loadRestoredStateSnapshot(
             } else {
                 null
             }
-            if (roomPrimary && roomRead?.getOrNull() != null) {
-                roomRead.getOrNull()
-            } else {
-                readLegacyPlaybackState(
+            val roomSnapshot = roomRead?.getOrNull()
+            val legacySnapshot = if (!roomPrimary ||
+                roomSnapshot == null ||
+                PlaybackQueueLegacyStore(
+                    stateFile = stateFile,
+                    playbackStateFile = playbackStateFile,
+                    gson = PlayerManager.gson
+                ).lastModified() >= roomSnapshot.updatedAt
+            ) {
+                readLegacyPlaybackStateSnapshot(
                     stateFile = stateFile,
                     playbackStateFile = playbackStateFile
-                )?.also { legacyData ->
+                )
+            } else {
+                null
+            }
+            val selected = selectRestoredPlaybackState(
+                roomPrimary = roomPrimary,
+                roomSnapshot = roomSnapshot,
+                legacySnapshot = legacySnapshot
+            )
+            val selectedLegacySnapshot = legacySnapshot
+            if (selected != null && selectedLegacySnapshot != null && selected === selectedLegacySnapshot.state) {
+                selectedLegacySnapshot.state.also { legacyData ->
                     runCatching {
                         roomStore.replaceSnapshot(legacyData)
                     }.onFailure { error ->
@@ -472,6 +541,8 @@ private fun loadRestoredStateSnapshot(
                         )
                     }
                 }
+            } else {
+                selected
             }
         } ?: return@runCatching null
         buildRestoredStateSnapshot(

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -63,6 +63,7 @@ import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.model.sameIdentityAs
 import moe.ouom.neriplayer.data.model.stableKey
 import moe.ouom.neriplayer.ui.feedback.AppFeedback
+import moe.ouom.neriplayer.util.io.writeTextAtomically
 import java.io.File
 import java.lang.reflect.Type
 import java.util.concurrent.atomic.AtomicBoolean
@@ -177,22 +178,87 @@ private fun <T> PlayerManager.readJson(file: File, type: Type): T {
     }
 }
 
-private fun loadPersistedStateFromLegacy(
-    stateFile: File,
-    playbackStateFile: File
-): PersistedState? {
-    if (!stateFile.exists()) {
-        return null
+internal class PlaybackQueueLegacyStore(
+    private val stateFile: File,
+    private val playbackStateFile: File,
+    private val gson: com.google.gson.Gson
+) {
+    fun read(): PersistedState? {
+        if (!stateFile.exists()) {
+            return null
+        }
+        val type = object : TypeToken<PersistedState>() {}.type
+        val legacyData: PersistedState = PlayerManager.readJson(stateFile, type)
+        val playbackState = playbackStateFile.takeIf(File::exists)?.runCatching {
+            PlayerManager.readJson<PersistedPlaybackState>(
+                this,
+                PersistedPlaybackState::class.java
+            )
+        }?.getOrNull()
+        return playbackState?.let(legacyData::withPlaybackState) ?: legacyData
     }
-    val type = object : TypeToken<PersistedState>() {}.type
-    val legacyData: PersistedState = PlayerManager.readJson(stateFile, type)
-    val playbackState = playbackStateFile.takeIf(File::exists)?.runCatching {
-        PlayerManager.readJson<PersistedPlaybackState>(
-            this,
-            PersistedPlaybackState::class.java
-        )
-    }?.getOrNull()
-    return playbackState?.let(legacyData::withPlaybackState) ?: legacyData
+
+    fun write(
+        state: PersistedState,
+        playbackState: PersistedPlaybackState
+    ) {
+        runCatching { playbackStateFile.delete() }
+        stateFile.writeTextAtomically(gson.toJson(state))
+        playbackStateFile.writeTextAtomically(gson.toJson(playbackState))
+    }
+
+    fun clear() {
+        runCatching { stateFile.delete() }
+        runCatching { playbackStateFile.delete() }
+    }
+}
+
+internal enum class PlaybackQueuePersistTarget {
+    ROOM,
+    LEGACY_JSON,
+    NONE
+}
+
+internal suspend fun persistPlaybackQueueWithRoomFallback(
+    roomStore: PlaybackQueueStateStore,
+    legacyStore: PlaybackQueueLegacyStore,
+    queueState: PersistedState?,
+    playbackState: PersistedPlaybackState,
+    shouldWriteQueueState: Boolean,
+    shouldWritePlaybackState: Boolean,
+    onRoomFailure: (Throwable) -> Unit = {}
+): PlaybackQueuePersistTarget {
+    if (!shouldWriteQueueState && !shouldWritePlaybackState) {
+        return PlaybackQueuePersistTarget.NONE
+    }
+    val now = System.currentTimeMillis()
+    if (queueState == null) {
+        return runCatching {
+            roomStore.clear(now)
+            legacyStore.clear()
+            PlaybackQueuePersistTarget.ROOM
+        }.getOrElse { error ->
+            onRoomFailure(error)
+            legacyStore.clear()
+            roomStore.markLegacyJsonPrimary(now)
+            PlaybackQueuePersistTarget.LEGACY_JSON
+        }
+    }
+
+    return runCatching {
+        if (shouldWriteQueueState) {
+            roomStore.replaceSnapshot(queueState, now)
+        }
+        if (shouldWritePlaybackState && !shouldWriteQueueState) {
+            roomStore.updatePlaybackState(playbackState, now)
+        }
+        PlaybackQueuePersistTarget.ROOM
+    }.getOrElse { error ->
+        onRoomFailure(error)
+        legacyStore.write(queueState, playbackState)
+        roomStore.markLegacyJsonPrimary(now)
+        PlaybackQueuePersistTarget.LEGACY_JSON
+    }
 }
 
 private fun buildRestoredStateSnapshot(
@@ -310,10 +376,11 @@ internal suspend fun preloadRestoredStateSnapshot(
             roomData
         } else {
             runCatching {
-                loadPersistedStateFromLegacy(
+                PlaybackQueueLegacyStore(
                     stateFile = startupStateFile,
-                    playbackStateFile = startupPlaybackStateFile
-                )
+                    playbackStateFile = startupPlaybackStateFile,
+                    gson = PlayerManager.gson
+                ).read()
             }.onFailure { error ->
                 NPLogger.w(
                     "NERI-PlayerManager",
@@ -366,10 +433,11 @@ private fun loadRestoredStateSnapshot(
             if (roomPrimary) {
                 roomStore.readIfRoomPrimary()
             } else {
-                loadPersistedStateFromLegacy(
-                    stateFile = stateFile,
-                    playbackStateFile = playbackStateFile
-                )?.also { legacyData ->
+                    PlaybackQueueLegacyStore(
+                        stateFile = stateFile,
+                        playbackStateFile = playbackStateFile,
+                        gson = PlayerManager.gson
+                    ).read()?.also { legacyData ->
                     runCatching {
                         roomStore.replaceSnapshot(legacyData)
                     }.onFailure { error ->
@@ -592,12 +660,29 @@ internal suspend fun PlayerManager.persistStateImpl(
                 val roomStore = PlaybackQueueRoomStore(
                     NeriUserDataDatabase.getInstance(application.applicationContext)
                 )
+                val legacyStore = PlaybackQueueLegacyStore(
+                    stateFile = stateFile,
+                    playbackStateFile = playbackStateFile,
+                    gson = gson
+                )
                 if (playlistReference.isEmpty()) {
                     restoredResumePositionMs = 0L
                     restoredShouldResumePlayback = false
-                    roomStore.clear()
-                    stateFile.delete()
-                    playbackStateFile.delete()
+                    val persistTarget = persistPlaybackQueueWithRoomFallback(
+                        roomStore = roomStore,
+                        legacyStore = legacyStore,
+                        queueState = null,
+                        playbackState = playbackStateSnapshot,
+                        shouldWriteQueueState = true,
+                        shouldWritePlaybackState = true,
+                        onRoomFailure = { error ->
+                            NPLogger.e(
+                                "NERI-PlayerManager",
+                                "persistState: Room clear failed; falling back to legacy JSON",
+                                error
+                            )
+                        }
+                    )
                     shuffleRestorePlaylistReference = null
                     shuffleRestoreCurrentIndex = -1
                     lastPersistedPlaylistReference = null
@@ -605,38 +690,54 @@ internal suspend fun PlayerManager.persistStateImpl(
                     lastStatePersistAtMs = SystemClock.elapsedRealtime()
                     NPLogger.d(
                         "NERI-PlayerManager",
-                        "persistState: cleared persisted playback state because queue is empty"
+                        "persistState: cleared persisted playback state because queue is empty, target=$persistTarget"
                     )
                     return@withLock
                 }
 
-                val shouldWriteLegacyState = playlistReference !== lastPersistedPlaylistReference
+                val shouldWriteQueueState = playlistReference !== lastPersistedPlaylistReference
                 val shouldWritePlaybackState =
-                    shouldWriteLegacyState ||
+                    shouldWriteQueueState ||
                         playbackStateSnapshot != lastPersistedPlaybackState ||
                         lastPersistedPlaybackState == null
 
-                if (shouldWriteLegacyState) {
-                    val data = buildPersistedPlaylistState(
+                val queueState = if (shouldWriteQueueState || shouldWritePlaybackState) {
+                    buildPersistedPlaylistState(
                         playlistReference = playlistReference,
                         playbackStateSnapshot = playbackStateSnapshot
                     )
-                    roomStore.replaceSnapshot(data)
+                } else {
+                    null
+                }
+                val persistTarget = persistPlaybackQueueWithRoomFallback(
+                    roomStore = roomStore,
+                    legacyStore = legacyStore,
+                    queueState = queueState,
+                    playbackState = playbackStateSnapshot,
+                    shouldWriteQueueState = shouldWriteQueueState,
+                    shouldWritePlaybackState = shouldWritePlaybackState,
+                    onRoomFailure = { error ->
+                        NPLogger.e(
+                            "NERI-PlayerManager",
+                            "persistState: Room write failed; falling back to legacy JSON",
+                            error
+                        )
+                    }
+                )
+
+                if (shouldWriteQueueState) {
                     lastPersistedPlaylistReference = playlistReference
                     NPLogger.d(
                         "NERI-PlayerManager",
-                        "persistState: wrote Room queue state, queueSize=${playlistReference.size}, index=$currentIndexSnapshot"
+                        "persistState: wrote $persistTarget queue state, queueSize=${playlistReference.size}, index=$currentIndexSnapshot"
                     )
                 }
 
                 if (shouldWritePlaybackState) {
-                    if (!shouldWriteLegacyState) {
-                        roomStore.updatePlaybackState(playbackStateSnapshot)
-                    }
                     lastPersistedPlaybackState = playbackStateSnapshot
                 }
 
-                if (shouldWriteLegacyState || shouldWritePlaybackState) {
+                if (shouldWriteQueueState || shouldWritePlaybackState) {
                     lastStatePersistAtMs = SystemClock.elapsedRealtime()
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -240,7 +240,10 @@ internal suspend fun persistPlaybackQueueWithRoomFallback(
         }.getOrElse { error ->
             onRoomFailure(error)
             legacyStore.clear()
-            roomStore.markLegacyJsonPrimary(now)
+            runCatching { roomStore.markLegacyJsonPrimary(now) }
+                .onFailure { markerError ->
+                    onRoomFailure(markerError)
+                }
             PlaybackQueuePersistTarget.LEGACY_JSON
         }
     }
@@ -256,9 +259,30 @@ internal suspend fun persistPlaybackQueueWithRoomFallback(
     }.getOrElse { error ->
         onRoomFailure(error)
         legacyStore.write(queueState, playbackState)
-        roomStore.markLegacyJsonPrimary(now)
+        runCatching { roomStore.markLegacyJsonPrimary(now) }
+            .onFailure { markerError ->
+                onRoomFailure(markerError)
+            }
         PlaybackQueuePersistTarget.LEGACY_JSON
     }
+}
+
+private fun readLegacyPlaybackState(
+    stateFile: File,
+    playbackStateFile: File
+): PersistedState? {
+    return runCatching {
+        PlaybackQueueLegacyStore(
+            stateFile = stateFile,
+            playbackStateFile = playbackStateFile,
+            gson = PlayerManager.gson
+        ).read()
+    }.onFailure { error ->
+        NPLogger.w(
+            "NERI-PlayerManager",
+            "Failed to read legacy playback state: ${error.message}"
+        )
+    }.getOrNull()
 }
 
 private fun buildRestoredStateSnapshot(
@@ -356,14 +380,13 @@ internal suspend fun preloadRestoredStateSnapshot(
         val roomStore = PlaybackQueueRoomStore(
             NeriUserDataDatabase.getInstance(app.applicationContext)
         )
-        val roomData = runCatching { roomStore.readIfRoomPrimary() }
+        val roomRead = runCatching { roomStore.readIfRoomPrimary() }
             .onFailure { error ->
                 NPLogger.w(
                     "NERI-PlayerManager",
                     "restoreState: Room read failed, trying legacy JSON: ${error.message}"
                 )
             }
-            .getOrNull()
         val roomPrimary = runCatching { roomStore.isRoomPrimary() }
             .onFailure { error ->
                 NPLogger.w(
@@ -372,21 +395,13 @@ internal suspend fun preloadRestoredStateSnapshot(
                 )
             }
             .getOrDefault(false)
-        val data = if (roomPrimary) {
-            roomData
+        val data = if (roomPrimary && roomRead.getOrNull() != null) {
+            roomRead.getOrNull()
         } else {
-            runCatching {
-                PlaybackQueueLegacyStore(
-                    stateFile = startupStateFile,
-                    playbackStateFile = startupPlaybackStateFile,
-                    gson = PlayerManager.gson
-                ).read()
-            }.onFailure { error ->
-                NPLogger.w(
-                    "NERI-PlayerManager",
-                    "Failed to read legacy playback state: ${error.message}"
-                )
-            }.getOrNull()?.also { legacyData ->
+            readLegacyPlaybackState(
+                stateFile = startupStateFile,
+                playbackStateFile = startupPlaybackStateFile
+            )?.also { legacyData ->
                 runCatching {
                     roomStore.replaceSnapshot(legacyData)
                 }.onFailure { error ->
@@ -430,14 +445,24 @@ private fun loadRestoredStateSnapshot(
                     )
                 }
                 .getOrDefault(false)
-            if (roomPrimary) {
-                roomStore.readIfRoomPrimary()
+            val roomRead = if (roomPrimary) {
+                runCatching { roomStore.readIfRoomPrimary() }
+                    .onFailure { error ->
+                        NPLogger.w(
+                            "NERI-PlayerManager",
+                            "restoreState: Room read failed, trying legacy JSON: ${error.message}"
+                        )
+                    }
             } else {
-                    PlaybackQueueLegacyStore(
-                        stateFile = stateFile,
-                        playbackStateFile = playbackStateFile,
-                        gson = PlayerManager.gson
-                    ).read()?.also { legacyData ->
+                null
+            }
+            if (roomPrimary && roomRead?.getOrNull() != null) {
+                roomRead.getOrNull()
+            } else {
+                readLegacyPlaybackState(
+                    stateFile = stateFile,
+                    playbackStateFile = playbackStateFile
+                )?.also { legacyData ->
                     runCatching {
                         roomStore.replaceSnapshot(legacyData)
                     }.onFailure { error ->

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/sync/NeteaseLikeSyncResult.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/playlist/sync/NeteaseLikeSyncResult.kt
@@ -30,5 +30,6 @@ data class NeteaseLikeSyncResult(
     val skippedExisting: Int,
     val added: Int,
     val failed: Int,
-    val message: String? = null
+    val message: String? = null,
+    val targetPlaylistId: Long? = null
 )

--- a/app/src/test/java/moe/ouom/neriplayer/core/download/GlobalDownloadManagerStartupPolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/download/GlobalDownloadManagerStartupPolicyTest.kt
@@ -276,8 +276,6 @@ class GlobalDownloadManagerStartupPolicyTest {
         assertEquals(
             listOf(
                 song.copy(
-                    matchedLyric = null,
-                    matchedTranslatedLyric = null,
                     originalLyric = null,
                     originalTranslatedLyric = null
                 )

--- a/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorageSnapshotCacheTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorageSnapshotCacheTest.kt
@@ -1,5 +1,11 @@
 package moe.ouom.neriplayer.core.download
 
+import android.content.Context
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -7,8 +13,11 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import moe.ouom.neriplayer.core.download.storage.snapshot.ManagedDownloadSnapshotCacheStore
+import moe.ouom.neriplayer.core.download.storage.snapshot.ManagedDownloadSnapshotPersistenceStore
 import moe.ouom.neriplayer.core.download.storage.snapshot.ManagedDownloadSnapshotRoomMapper
 import moe.ouom.neriplayer.data.model.SongItem
+import org.mockito.Mockito
 
 class ManagedDownloadStorageSnapshotCacheTest {
 
@@ -176,6 +185,43 @@ class ManagedDownloadStorageSnapshotCacheTest {
         assertEquals(listOf(audioEntry), restored.audioEntriesByStableKey["room-stable"])
         assertEquals(listOf(audioEntry), restored.audioEntriesByRemoteTrackKey["netease|44|"])
         assertTrue(restored.knownReferences.contains(metadataEntry.reference))
+    }
+
+    @Test
+    fun `invalidation rejects stale persisted restore and resumes after clear`() {
+        val context = Mockito.mock(Context::class.java)
+        Mockito.`when`(context.applicationContext).thenReturn(context)
+        val snapshot = emptySnapshot()
+        val persistenceStore = BlockingSnapshotPersistenceStore("root" to snapshot)
+        val cacheStore = ManagedDownloadSnapshotCacheStore(
+            scope = CoroutineScope(Dispatchers.IO),
+            cacheKeyProvider = { "root" },
+            persistenceStoreProvider = { persistenceStore }
+        )
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            val restoreFuture = executor.submit<ManagedDownloadStorage.DownloadLibrarySnapshot?> {
+                cacheStore.restorePersisted(context, expectedKey = "root")
+            }
+            assertTrue(persistenceStore.restoreStarted.await(5, TimeUnit.SECONDS))
+
+            cacheStore.invalidate(context)
+
+            assertTrue(persistenceStore.clearStarted.await(5, TimeUnit.SECONDS))
+            persistenceStore.releaseRestore.countDown()
+
+            assertNull(restoreFuture.get(5, TimeUnit.SECONDS))
+            assertNull(cacheStore.peekSnapshot())
+
+            persistenceStore.releaseClear.countDown()
+            assertTrue(persistenceStore.clearFinished.await(5, TimeUnit.SECONDS))
+            assertEquals(snapshot, cacheStore.restorePersisted(context, expectedKey = "root"))
+        } finally {
+            executor.shutdownNow()
+            persistenceStore.releaseRestore.countDown()
+            persistenceStore.releaseClear.countDown()
+        }
     }
 
     @Test
@@ -752,5 +798,55 @@ class ManagedDownloadStorageSnapshotCacheTest {
         )
 
         assertNull(reusableCover)
+    }
+
+    private fun emptySnapshot(): ManagedDownloadStorage.DownloadLibrarySnapshot {
+        return ManagedDownloadStorage.DownloadLibrarySnapshot(
+            audioEntries = emptyList(),
+            audioEntriesByLookupKey = emptyMap(),
+            metadataEntriesByAudioName = emptyMap(),
+            metadataByAudioName = emptyMap(),
+            audioEntriesWithoutMetadata = emptyList(),
+            audioEntriesByStableKey = emptyMap(),
+            audioEntriesBySongId = emptyMap(),
+            audioEntriesByMediaUri = emptyMap(),
+            audioEntriesByRemoteTrackKey = emptyMap(),
+            coverEntriesByName = emptyMap(),
+            lyricEntriesByName = emptyMap(),
+            knownReferences = emptySet()
+        )
+    }
+
+    private class BlockingSnapshotPersistenceStore(
+        private val restoredSnapshot:
+            Pair<String, ManagedDownloadStorage.DownloadLibrarySnapshot>
+    ) : ManagedDownloadSnapshotPersistenceStore {
+        val restoreStarted = CountDownLatch(1)
+        val releaseRestore = CountDownLatch(1)
+        val clearStarted = CountDownLatch(1)
+        val releaseClear = CountDownLatch(1)
+        val clearFinished = CountDownLatch(1)
+
+        override suspend fun restore(
+            expectedKey: String?
+        ): Pair<String, ManagedDownloadStorage.DownloadLibrarySnapshot>? {
+            restoreStarted.countDown()
+            assertTrue(releaseRestore.await(5, TimeUnit.SECONDS))
+            return restoredSnapshot.takeIf { expectedKey == null || it.first == expectedKey }
+        }
+
+        override suspend fun persist(
+            cacheKey: String,
+            snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
+        ): Boolean = true
+
+        override suspend fun clear() {
+            clearStarted.countDown()
+            try {
+                assertTrue(releaseClear.await(5, TimeUnit.SECONDS))
+            } finally {
+                clearFinished.countDown()
+            }
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Room 持久化失败时，下载目录和播放队列会回退到 legacy JSON，并记录 JSON 为当前主数据源。
- 应用重启后可恢复 legacy JSON 数据。混合迁移状态下，仍在使用的 JSON 文件会保留。
- Room 持久化成功后，应用会清理对应的 legacy JSON 文件。
- 数据库从版本 1 迁移到版本 14 时，会保留歌单、歌曲、成员、令牌和迁移状态。
- 新增测试覆盖目录回退、播放队列回退、空队列处理、数据库迁移、JSON 清理及 Room outbox 重放。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->