### PR TITLE
fix: implement namespaced cache keys for Netease fallback and preview modes

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -2288,8 +2288,34 @@ object PlayerManager {
                     "bili-$biliSongId-${effectiveBiliQuality()}"
                 }
             }
-            else -> "netease-${song.id}-${effectiveNeteaseQuality()}"
+            else -> buildNeteasePlaybackCacheKey(
+                songId = song.id,
+                preferredQuality = effectiveNeteaseQuality(),
+                useFallbackNamespace = neteaseAutoSourceSwitchEnabled ||
+                    neteaseLocalSourceFallbackEnabled
+            )
         }
+    }
+
+    internal fun buildNeteasePlaybackCacheKey(
+        songId: Long,
+        preferredQuality: String,
+        useFallbackNamespace: Boolean
+    ): String {
+        val quality = preferredQuality.trim().lowercase().ifBlank { "exhigh" }
+        return if (useFallbackNamespace) {
+            "netease-$songId-$quality-fallback-v1"
+        } else {
+            "netease-$songId-$quality"
+        }
+    }
+
+    internal fun buildNeteasePreviewCacheKey(
+        songId: Long,
+        preferredQuality: String
+    ): String {
+        val quality = preferredQuality.trim().lowercase().ifBlank { "exhigh" }
+        return "netease-preview-v1-$songId-$quality"
     }
 
     /**

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
@@ -931,12 +931,26 @@ internal fun PlayerManager.initializeImpl(
         }
         ioScope.launch {
             settingsRepo.neteaseAutoSourceSwitchFlow.collect { enabled ->
+                val previousEnabled = neteaseAutoSourceSwitchEnabled
                 neteaseAutoSourceSwitchEnabled = enabled
+                if (!previousEnabled && enabled) {
+                    scheduleQualityRefresh(
+                        source = PlaybackAudioSource.NETEASE,
+                        reason = "netease_auto_source_switch_enabled"
+                    )
+                }
             }
         }
         ioScope.launch {
             settingsRepo.neteaseLocalSourceFallbackFlow.collect { enabled ->
+                val previousEnabled = neteaseLocalSourceFallbackEnabled
                 neteaseLocalSourceFallbackEnabled = enabled
+                if (!previousEnabled && enabled) {
+                    scheduleQualityRefresh(
+                        source = PlaybackAudioSource.NETEASE,
+                        reason = "netease_local_source_fallback_enabled"
+                    )
+                }
             }
         }
         ioScope.launch {

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerManagerUrlExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerManagerUrlExtensions.kt
@@ -1108,7 +1108,18 @@ private suspend fun PlayerManager.getNeteaseSongUrl(
                         resolvedQualityKey = quality,
                         fallbackDurationMs = song.durationMs,
                         getLocalizedString = { getLocalizedString(it) }
-                    )
+                    ).let { result ->
+                        if (parsed.notice == NeteasePlaybackResponseParser.Notice.PREVIEW_CLIP) {
+                            result.copy(
+                                cacheKeyOverride = buildNeteasePreviewCacheKey(
+                                    songId = song.id,
+                                    preferredQuality = quality
+                                )
+                            )
+                        } else {
+                            result
+                        }
+                    }
                     if (parsed.notice != NeteasePlaybackResponseParser.Notice.PREVIEW_CLIP) {
                         if (quality != effectiveQuality) {
                             NPLogger.w(

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerManagerNeteaseCacheKeyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerManagerNeteaseCacheKeyTest.kt
@@ -1,0 +1,73 @@
+package moe.ouom.neriplayer.core.player.url
+
+import moe.ouom.neriplayer.core.player.PlayerManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class PlayerManagerNeteaseCacheKeyTest {
+
+    @Test
+    fun fallbackNamespaceDoesNotReuseLegacyNeteaseCache() {
+        val legacyKey = PlayerManager.buildNeteasePlaybackCacheKey(
+            songId = 123L,
+            preferredQuality = "exhigh",
+            useFallbackNamespace = false
+        )
+        val fallbackKey = PlayerManager.buildNeteasePlaybackCacheKey(
+            songId = 123L,
+            preferredQuality = "exhigh",
+            useFallbackNamespace = true
+        )
+
+        assertEquals("netease-123-exhigh", legacyKey)
+        assertEquals("netease-123-exhigh-fallback-v1", fallbackKey)
+        assertNotEquals(legacyKey, fallbackKey)
+    }
+
+    @Test
+    fun blankQualityUsesStableDefaultInBothNamespaces() {
+        assertEquals(
+            "netease-123-exhigh",
+            PlayerManager.buildNeteasePlaybackCacheKey(
+                songId = 123L,
+                preferredQuality = "   ",
+                useFallbackNamespace = false
+            )
+        )
+        assertEquals(
+            "netease-123-exhigh-fallback-v1",
+            PlayerManager.buildNeteasePlaybackCacheKey(
+                songId = 123L,
+                preferredQuality = "   ",
+                useFallbackNamespace = true
+            )
+        )
+    }
+
+    @Test
+    fun previewCacheKeyDoesNotReusePlaybackCacheNamespaces() {
+        val previewKey = PlayerManager.buildNeteasePreviewCacheKey(
+            songId = 123L,
+            preferredQuality = "exhigh"
+        )
+
+        assertEquals("netease-preview-v1-123-exhigh", previewKey)
+        assertNotEquals(
+            previewKey,
+            PlayerManager.buildNeteasePlaybackCacheKey(
+                songId = 123L,
+                preferredQuality = "exhigh",
+                useFallbackNamespace = false
+            )
+        )
+        assertNotEquals(
+            previewKey,
+            PlayerManager.buildNeteasePlaybackCacheKey(
+                songId = 123L,
+                preferredQuality = "exhigh",
+                useFallbackNamespace = true
+            )
+        )
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 为网易云播放、回退播放和试听预览使用独立的缓存键命名空间，避免复用错误音频缓存。
- 音质参数会去除空格并转为小写；为空时使用 `exhigh`。
- 启用自动源切换或本地源回退后，会刷新网易云音频质量。
- 新增测试，覆盖缓存隔离和音质默认值处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->