### PR TITLE
fix: mute Listen Together listeners on audio route loss instead of pausing

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -223,7 +223,7 @@ import moe.ouom.neriplayer.listentogether.mapping.resolvedChannelId
 import moe.ouom.neriplayer.listentogether.mapping.resolvedPlaylistContextId
 import moe.ouom.neriplayer.listentogether.mapping.resolvedSubAudioId
 import moe.ouom.neriplayer.listentogether.playback.shouldHoldListenTogetherPlaybackForSafetyPause
-import moe.ouom.neriplayer.listentogether.playback.shouldUseListenTogetherListenerSafetyPause
+import moe.ouom.neriplayer.listentogether.playback.shouldMuteListenTogetherListenerForAudioRouteLoss
 import moe.ouom.neriplayer.listentogether.protocol.ListenTogetherChannels
 import moe.ouom.neriplayer.listentogether.session.resolveListenTogetherSessionRole
 import moe.ouom.neriplayer.ui.component.lyrics.LyricEntry
@@ -1220,9 +1220,9 @@ object PlayerManager {
         ) == "controller"
     }
 
-    internal fun shouldUseListenTogetherListenerSafetyPause(): Boolean {
+    internal fun shouldMuteListenTogetherListenerForAudioRouteLoss(): Boolean {
         val room = activeListenTogetherRoomState()
-        return shouldUseListenTogetherListenerSafetyPause(
+        return shouldMuteListenTogetherListenerForAudioRouteLoss(
             listenTogetherActive = isListenTogetherActive(),
             isCurrentUserController = isCurrentUserControllerInListenTogether(),
             allowMemberControl = room?.settings?.allowMemberControl

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
@@ -94,6 +94,7 @@ import moe.ouom.neriplayer.core.player.policy.usb.shouldDeferUsbExclusiveRecover
 import moe.ouom.neriplayer.core.player.policy.usb.shouldSkipRedundantUsbExclusiveReconfiguration
 import moe.ouom.neriplayer.core.player.playlist.PlayerFavoritesController
 import moe.ouom.neriplayer.core.player.policy.command.shouldClearResumePlaybackRequestOnPlayWhenReadyPause
+import moe.ouom.neriplayer.core.player.policy.command.shouldResumeSilentlyForListenTogetherNoisyPause
 import moe.ouom.neriplayer.core.player.playback.advanceAfterPlaybackFailure
 import moe.ouom.neriplayer.core.player.playback.clearAudioRouteMuteSuppression
 import moe.ouom.neriplayer.core.player.playback.pauseForAudioRouteLoss
@@ -563,6 +564,26 @@ internal fun PlayerManager.initializeImpl(
                         "NERI-PlayerManager",
                         "playWhenReady=false, reason=${playWhenReadyChangeReasonName(reason)}, state=${playbackStateName(player.playbackState)}, mediaId=${player.currentMediaItem?.mediaId}, stack=[${debugStackHint()}]"
                     )
+                    if (shouldResumeSilentlyForListenTogetherNoisyPause(
+                            playWhenReady = playWhenReady,
+                            playWhenReadyChangeReason = reason,
+                            muteListenTogetherListenerForAudioRouteLoss =
+                                shouldMuteListenTogetherListenerForAudioRouteLoss()
+                        )
+                    ) {
+                        NPLogger.d(
+                            "NERI-PlayerManager",
+                            "restore Listen Together listener playWhenReady after noisy route by muting locally"
+                        )
+                        suppressPlaybackForAudioRouteLoss(
+                            reason = "listen_together_exoplayer_becoming_noisy"
+                        )
+                        playImpl(
+                            commandSource = PlaybackCommandSource.LOCAL_SAFETY,
+                            allowFadeIn = false
+                        )
+                        return
+                    }
                     if (
                         shouldClearResumePlaybackRequestOnPlayWhenReadyPause(
                             playWhenReady = playWhenReady,
@@ -1284,6 +1305,14 @@ internal fun PlayerManager.handleAudioBecomingNoisyImpl(): Boolean {
         NPLogger.d("NERI-PlayerManager", "handleAudioBecomingNoisy(): ignored for USB exclusive route")
         return false
     }
+    if (shouldMuteListenTogetherListenerForAudioRouteLoss()) {
+        NPLogger.d(
+            "NERI-PlayerManager",
+            "handleAudioBecomingNoisy(): mute Listen Together listener without pausing"
+        )
+        suppressPlaybackForAudioRouteLoss(reason = "listen_together_becoming_noisy")
+        return true
+    }
     if (currentDevice != null && requiresDisconnectConfirmation(currentDevice.type)) {
         if (!shouldPauseForBluetoothDisconnect(currentDevice, null)) {
             NPLogger.d("NERI-PlayerManager", "handleAudioBecomingNoisy(): bluetooth confirmation rejected")
@@ -1414,7 +1443,15 @@ private fun PlayerManager.handleDeviceChange(
         "NERI-PlayerManager",
         "handleDeviceChange(): ${previousDevice?.type}:${previousDevice?.name} -> ${newDevice.type}:${newDevice.name}, isPlaying=${_isPlayingFlow.value}"
     )
-    if (shouldPauseForBluetoothDisconnect(previousDevice, newDevice)) {
+    if (shouldMuteListenTogetherListenerForOutputDisconnect(previousDevice, newDevice)) {
+        bluetoothDisconnectPauseJob?.cancel()
+        bluetoothDisconnectPauseJob = null
+        NPLogger.d(
+            "NERI-PlayerManager",
+            "Detected Listen Together listener output disconnect (${previousDevice?.type} -> ${newDevice.type}), muting without pausing."
+        )
+        suppressPlaybackForAudioRouteLoss(reason = "listen_together_output_disconnect")
+    } else if (shouldPauseForBluetoothDisconnect(previousDevice, newDevice)) {
         schedulePauseForBluetoothDisconnect(
             previousDevice = previousDevice,
             reason = "device_changed_to_${newDevice.type}"
@@ -3487,6 +3524,16 @@ private fun PlayerManager.shouldPauseForImmediateOutputDisconnect(
 ): Boolean {
     if (previousDevice == null || !isWiredOutputType(previousDevice.type)) return false
     if (usbExclusivePlaybackEnabled && isUsbOutputType(previousDevice.type)) return false
+    if (!_isPlayingFlow.value) return false
+    return newDevice == null || newDevice.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
+}
+
+private fun PlayerManager.shouldMuteListenTogetherListenerForOutputDisconnect(
+    previousDevice: AudioDevice?,
+    newDevice: AudioDevice?
+): Boolean {
+    if (!shouldMuteListenTogetherListenerForAudioRouteLoss()) return false
+    if (previousDevice?.type?.let(::isHeadsetLikeOutput) != true) return false
     if (!_isPlayingFlow.value) return false
     return newDevice == null || newDevice.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/playback/PlayerManagerPlaybackExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/playback/PlayerManagerPlaybackExtensions.kt
@@ -96,7 +96,7 @@ internal fun PlayerManager.cancelVolumeFadeImpl(resetToFull: Boolean = false) {
     }
     volumeFadeJob?.cancel()
     volumeFadeJob = null
-    if (resetToFull && isPlayerInitialized()) {
+    if (resetToFull && !isAudioRouteMuteSuppressed() && isPlayerInitialized()) {
         runPlayerActionOnMainThread {
             runCatching { player.volume = 1f }
         }
@@ -113,13 +113,26 @@ internal fun PlayerManager.cancelPendingPauseRequestImpl(resetVolumeToFull: Bool
     }
     pendingPauseJob?.cancel()
     pendingPauseJob = null
-    if (resetVolumeToFull && hadPendingPause && isPlayerInitialized()) {
+    if (
+        resetVolumeToFull &&
+        hadPendingPause &&
+        !isAudioRouteMuteSuppressed() &&
+        isPlayerInitialized()
+    ) {
         runPlayerActionOnMainThread {
             if (isPlayerInitialized()) {
                 player.volume = 1f
             }
         }
     }
+}
+
+private fun PlayerManager.isAudioRouteMuteSuppressed(): Boolean {
+    return audioRouteMuteRestoreVolume != null
+}
+
+private fun PlayerManager.volumeWhileAudioRouteMuted(volume: Float): Float {
+    return if (isAudioRouteMuteSuppressed()) 0f else volume
 }
 
 internal fun PlayerManager.clearAudioRouteMuteSuppression(reason: String) {
@@ -173,9 +186,12 @@ internal fun PlayerManager.restorePlaybackAfterTransientAudioRouteLoss(reason: S
 }
 
 internal fun PlayerManager.pauseForAudioRouteLoss(reason: String) {
-    val useListenTogetherSafetyPause = shouldUseListenTogetherListenerSafetyPause()
-    if (useListenTogetherSafetyPause) {
-        markListenTogetherSafetyPausePendingResume()
+    if (shouldMuteListenTogetherListenerForAudioRouteLoss()) {
+        NPLogger.d(
+            "NERI-PlayerManager",
+            "pauseForAudioRouteLoss(): keep Listen Together listener playing silently, reason=$reason, currentSong=${_currentSongFlow.value?.name}"
+        )
+        return
     }
     _playWhenReadyFlow.value = false
     _isPlayingFlow.value = false
@@ -185,11 +201,7 @@ internal fun PlayerManager.pauseForAudioRouteLoss(reason: String) {
     syncPlaybackControlPlayingState()
     pauseImpl(
         forcePersist = false,
-        commandSource = if (useListenTogetherSafetyPause) {
-            PlaybackCommandSource.LOCAL_SAFETY
-        } else {
-            PlaybackCommandSource.LOCAL
-        },
+        commandSource = PlaybackCommandSource.LOCAL,
         allowFadeOut = false,
         preserveMutedVolume = true,
         debugReason = "audio_route_loss:$reason"
@@ -208,7 +220,7 @@ internal fun PlayerManager.preparePlayerForManagedStart(plan: PlaybackStartPlan)
         "preparePlayerForManagedStart: useFadeIn=${effectivePlan.useFadeIn}, fadeDurationMs=${effectivePlan.fadeDurationMs}, initialVolume=${effectivePlan.initialVolume}, currentSong=${_currentSongFlow.value?.name}"
     )
     player.playWhenReady = false
-    player.volume = effectivePlan.initialVolume
+    player.volume = volumeWhileAudioRouteMuted(effectivePlan.initialVolume)
 }
 
 internal suspend fun PlayerManager.fadeOutCurrentPlaybackIfNeeded(
@@ -284,11 +296,11 @@ internal fun PlayerManager.startPlayerPlaybackWithFade(plan: PlaybackStartPlan) 
             return@runPlayerActionOnMainThread
         }
         applyAudioFocusPolicyOnMainThread()
-        player.volume = effectivePlan.initialVolume
+        player.volume = volumeWhileAudioRouteMuted(effectivePlan.initialVolume)
         player.playWhenReady = true
         player.play()
     }
-    if (!effectivePlan.useFadeIn) {
+    if (!effectivePlan.useFadeIn || isAudioRouteMuteSuppressed()) {
         return
     }
 
@@ -299,10 +311,12 @@ internal fun PlayerManager.startPlayerPlaybackWithFade(plan: PlaybackStartPlan) 
         repeat(steps) { step ->
             delay(stepDelay)
             if (!isPlayerInitialized()) return@launch
-            player.volume = ((step + 1).toFloat() / steps).coerceAtMost(1f)
+            player.volume = volumeWhileAudioRouteMuted(
+                ((step + 1).toFloat() / steps).coerceAtMost(1f)
+            )
         }
         if (isPlayerInitialized()) {
-            player.volume = 1f
+            player.volume = volumeWhileAudioRouteMuted(1f)
         }
         volumeFadeJob = null
     }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/policy/command/PlayerPlaybackPolicy.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/policy/command/PlayerPlaybackPolicy.kt
@@ -283,6 +283,16 @@ internal fun shouldClearResumePlaybackRequestOnPlayWhenReadyPause(
     }
 }
 
+internal fun shouldResumeSilentlyForListenTogetherNoisyPause(
+    playWhenReady: Boolean,
+    playWhenReadyChangeReason: Int,
+    muteListenTogetherListenerForAudioRouteLoss: Boolean
+): Boolean {
+    return !playWhenReady &&
+        muteListenTogetherListenerForAudioRouteLoss &&
+        playWhenReadyChangeReason == Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_BECOMING_NOISY
+}
+
 internal fun shouldPausePlaybackWhenToggling(
     resumePlaybackRequested: Boolean,
     pendingPauseJobActive: Boolean,

--- a/app/src/main/java/moe/ouom/neriplayer/listentogether/playback/ListenTogetherListenerSafetyPausePolicy.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/listentogether/playback/ListenTogetherListenerSafetyPausePolicy.kt
@@ -3,7 +3,7 @@ package moe.ouom.neriplayer.listentogether.playback
 internal const val LISTEN_TOGETHER_LISTENER_SAFETY_RESUME_CAUSE =
     "LISTENER_SAFETY_RESUME"
 
-internal fun shouldUseListenTogetherListenerSafetyPause(
+internal fun shouldMuteListenTogetherListenerForAudioRouteLoss(
     listenTogetherActive: Boolean,
     isCurrentUserController: Boolean,
     allowMemberControl: Boolean?

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/policy/command/PlayerManagerPlaybackControlStateTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/policy/command/PlayerManagerPlaybackControlStateTest.kt
@@ -85,4 +85,29 @@ class PlayerManagerPlaybackControlStateTest {
 
         assertFalse(shouldClear)
     }
+
+    @Test
+    fun `listen together noisy pause resumes silently only for muted listener route loss`() {
+        assertTrue(
+            shouldResumeSilentlyForListenTogetherNoisyPause(
+                playWhenReady = false,
+                playWhenReadyChangeReason = Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_BECOMING_NOISY,
+                muteListenTogetherListenerForAudioRouteLoss = true
+            )
+        )
+        assertFalse(
+            shouldResumeSilentlyForListenTogetherNoisyPause(
+                playWhenReady = false,
+                playWhenReadyChangeReason = Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS,
+                muteListenTogetherListenerForAudioRouteLoss = true
+            )
+        )
+        assertFalse(
+            shouldResumeSilentlyForListenTogetherNoisyPause(
+                playWhenReady = false,
+                playWhenReadyChangeReason = Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_BECOMING_NOISY,
+                muteListenTogetherListenerForAudioRouteLoss = false
+            )
+        )
+    }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/listentogether/ListenTogetherSessionPoliciesTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/listentogether/ListenTogetherSessionPoliciesTest.kt
@@ -17,7 +17,7 @@ import moe.ouom.neriplayer.listentogether.session.shouldDropListenTogetherContro
 import moe.ouom.neriplayer.listentogether.session.shouldRepairListenTogetherListenerState
 import moe.ouom.neriplayer.listentogether.playback.LISTEN_TOGETHER_LISTENER_SAFETY_RESUME_CAUSE
 import moe.ouom.neriplayer.listentogether.playback.shouldHoldListenTogetherPlaybackForSafetyPause
-import moe.ouom.neriplayer.listentogether.playback.shouldUseListenTogetherListenerSafetyPause
+import moe.ouom.neriplayer.listentogether.playback.shouldMuteListenTogetherListenerForAudioRouteLoss
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -313,23 +313,23 @@ class ListenTogetherSessionPoliciesTest {
     }
 
     @Test
-    fun `listener safety pause only applies when member control is disabled`() {
+    fun `listener audio route mute only applies when member control is disabled`() {
         assertTrue(
-            shouldUseListenTogetherListenerSafetyPause(
+            shouldMuteListenTogetherListenerForAudioRouteLoss(
                 listenTogetherActive = true,
                 isCurrentUserController = false,
                 allowMemberControl = false
             )
         )
         assertFalse(
-            shouldUseListenTogetherListenerSafetyPause(
+            shouldMuteListenTogetherListenerForAudioRouteLoss(
                 listenTogetherActive = true,
                 isCurrentUserController = true,
                 allowMemberControl = false
             )
         )
         assertFalse(
-            shouldUseListenTogetherListenerSafetyPause(
+            shouldMuteListenTogetherListenerForAudioRouteLoss(
                 listenTogetherActive = true,
                 isCurrentUserController = false,
                 allowMemberControl = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 用户可见行为

- Listen Together 监听者在音频路由丢失时保持播放，但输出静音。
- 音频路由恢复后，监听者可静默恢复播放。
- 音频焦点丢失不会触发该静默恢复逻辑。
- 普通暂停行为保持不变。

## 测试

- 新增测试，验证音频路由丢失时的静默恢复条件。
- 更新 Listen Together 策略测试，验证音频路由丢失时的静音行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->