### PR TITLE
fix(library): support local translated lyric sidecar files

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProvider.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProvider.kt
@@ -388,6 +388,27 @@ internal object PlayerLyricsProvider {
         )
     }
 
+    private fun loadOnDemandLocalTranslatedLyrics(
+        application: Application,
+        song: SongItem
+    ): List<LyricEntry>? {
+        if (!song.isLocalSong()) {
+            return null
+        }
+
+        val localTranslatedLyric = runCatching {
+            LocalMediaSupport.inspect(application, song)?.translatedLyricContent
+        }.onFailure {
+            NPLogger.w("NERI-PlayerManager", "本地翻译歌词懒加载失败: ${it.message}")
+        }.getOrNull()
+
+        return parseLocalLyricOverride(
+            rawLyric = localTranslatedLyric,
+            durationMs = song.durationMs,
+            logPrefix = "本地翻译歌词解析失败"
+        )
+    }
+
     suspend fun getNeteaseLyrics(
         songId: Long,
         neteaseClient: NeteaseClient,
@@ -512,6 +533,13 @@ internal object PlayerLyricsProvider {
                 )?.let { return@withContext it }
             } else {
                 NPLogger.w("NERI-PlayerManager", "已忽略下载的 YouTube 全零翻译时间轴: ${song.name}")
+            }
+
+            loadOnDemandLocalTranslatedLyrics(application, song)?.let { entries ->
+                if (entries.isEmpty()) {
+                    return@withContext emptyList()
+                }
+                return@withContext entries
             }
 
             if (isYouTubeMusicTrack) {

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManager.kt
@@ -130,31 +130,24 @@ internal fun buildNearbySidecarCopyPlans(
             }
         }
 
-        fun addLyricSidecars(translated: Boolean) {
-            val prefixForSource = if (translated) "${sourceBase}_trans" else sourceBase
-            val prefixForTarget = if (translated) "${targetBase}_trans" else targetBase
-            val suffixes = buildList {
-                lyricExtensions.forEach { extension ->
-                    add(".$extension")
-                }
-                if ("lrc" in lyricExtensions) {
-                    add(".lrc.txt")
-                }
-            }
-            suffixes.forEach { suffix ->
-                addIfExists(
-                    File(sourceDir, "$prefixForSource$suffix"),
-                    File(targetDir, "$prefixForTarget$suffix")
-                )
-                addIfExists(
-                    File(File(sourceDir, "Lyrics"), "$prefixForSource$suffix"),
-                    File(targetDir, "$prefixForTarget$suffix")
-                )
-            }
+        val nearbyLyricFiles = LocalMediaSupport.findNearbyLyricFiles(
+            file = sourceFile,
+            extensions = lyricExtensions
+        )
+
+        fun addSelectedLyricSidecar(source: File?, translated: Boolean) {
+            source ?: return
+            val sourcePrefix = if (translated) "${sourceBase}_trans" else sourceBase
+            val targetPrefix = if (translated) "${targetBase}_trans" else targetBase
+            val suffix = source.name
+                .removePrefix(sourcePrefix)
+                .takeIf { it.startsWith('.') }
+                ?: return
+            addIfExists(source, File(targetDir, "$targetPrefix$suffix"))
         }
 
-        addLyricSidecars(translated = false)
-        addLyricSidecars(translated = true)
+        addSelectedLyricSidecar(nearbyLyricFiles.original, translated = false)
+        addSelectedLyricSidecar(nearbyLyricFiles.translated, translated = true)
 
         imageExtensions.forEach { extension ->
             addIfExists(File(sourceDir, "$sourceBase.$extension"), File(targetDir, "$targetBase.$extension"))

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManager.kt
@@ -130,13 +130,31 @@ internal fun buildNearbySidecarCopyPlans(
             }
         }
 
-        lyricExtensions.forEach { extension ->
-            addIfExists(File(sourceDir, "$sourceBase.$extension"), File(targetDir, "$targetBase.$extension"))
-            addIfExists(
-                File(File(sourceDir, "Lyrics"), "$sourceBase.$extension"),
-                File(targetDir, "$targetBase.$extension")
-            )
+        fun addLyricSidecars(translated: Boolean) {
+            val prefixForSource = if (translated) "${sourceBase}_trans" else sourceBase
+            val prefixForTarget = if (translated) "${targetBase}_trans" else targetBase
+            val suffixes = buildList {
+                lyricExtensions.forEach { extension ->
+                    add(".$extension")
+                }
+                if ("lrc" in lyricExtensions) {
+                    add(".lrc.txt")
+                }
+            }
+            suffixes.forEach { suffix ->
+                addIfExists(
+                    File(sourceDir, "$prefixForSource$suffix"),
+                    File(targetDir, "$prefixForTarget$suffix")
+                )
+                addIfExists(
+                    File(File(sourceDir, "Lyrics"), "$prefixForSource$suffix"),
+                    File(targetDir, "$prefixForTarget$suffix")
+                )
+            }
         }
+
+        addLyricSidecars(translated = false)
+        addLyricSidecars(translated = true)
 
         imageExtensions.forEach { extension ->
             addIfExists(File(sourceDir, "$sourceBase.$extension"), File(targetDir, "$targetBase.$extension"))

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
@@ -1257,9 +1257,15 @@ object LocalMediaSupport {
             nearbyLyricFiles.translated,
             "translated lyric"
         )
-        val effectiveLyricContent = nearbyLyricContent ?: tagLibMetadata?.lyrics?.takeIf { it.isNotBlank() }
-        val effectiveTranslatedLyricContent = nearbyTranslatedLyricContent
-            ?: tagLibMetadata?.translatedLyrics?.takeIf { it.isNotBlank() }
+        val hasEffectiveExternalLyric = !nearbyLyricContent.isNullOrBlank()
+        val effectiveLyricContent = resolveEffectiveLocalLyricContent(
+            sidecarContent = nearbyLyricContent,
+            embeddedContent = tagLibMetadata?.lyrics
+        )
+        val effectiveTranslatedLyricContent = resolveEffectiveLocalLyricContent(
+            sidecarContent = nearbyTranslatedLyricContent,
+            embeddedContent = tagLibMetadata?.translatedLyrics
+        )
 
         val retriever = MediaMetadataRetriever()
         return try {
@@ -1392,9 +1398,9 @@ object LocalMediaSupport {
                     else -> null
                 },
                 lyricContent = effectiveLyricContent,
-                lyricPath = nearbyLyricFiles.original?.absolutePath,
+                lyricPath = nearbyLyricFiles.original?.absolutePath?.takeIf { hasEffectiveExternalLyric },
                 lyricSource = when {
-                    nearbyLyricFiles.original != null -> context.getString(R.string.local_song_lyric_external)
+                    hasEffectiveExternalLyric -> context.getString(R.string.local_song_lyric_external)
                     !effectiveLyricContent.isNullOrBlank() -> context.getString(R.string.local_song_lyric_embedded)
                     else -> null
                 },
@@ -1458,9 +1464,9 @@ object LocalMediaSupport {
                     else -> null
                 },
                 lyricContent = effectiveLyricContent,
-                lyricPath = nearbyLyricFiles.original?.absolutePath,
+                lyricPath = nearbyLyricFiles.original?.absolutePath?.takeIf { hasEffectiveExternalLyric },
                 lyricSource = when {
-                    nearbyLyricFiles.original != null -> context.getString(R.string.local_song_lyric_external)
+                    hasEffectiveExternalLyric -> context.getString(R.string.local_song_lyric_external)
                     !effectiveLyricContent.isNullOrBlank() -> context.getString(R.string.local_song_lyric_embedded)
                     else -> null
                 },
@@ -2252,22 +2258,7 @@ object LocalMediaSupport {
     private sealed class EditableCoverWritePlan {
         data object Unchanged : EditableCoverWritePlan()
         data object Unreadable : EditableCoverWritePlan()
-        data class Update(val pictures: Array<Picture>) : EditableCoverWritePlan() {
-            override fun equals(other: Any?): Boolean {
-                if (this === other) return true
-                if (javaClass != other?.javaClass) return false
-
-                other as Update
-
-                if (!pictures.contentEquals(other.pictures)) return false
-
-                return true
-            }
-
-            override fun hashCode(): Int {
-                return pictures.contentHashCode()
-            }
-        }
+        data class Update(val pictures: Array<Picture>) : EditableCoverWritePlan()
     }
 
     private data class EditableMetadataSnapshot(
@@ -2387,11 +2378,7 @@ object LocalMediaSupport {
         audioExtension: String?
     ): Array<Picture> {
         if (usesRolelessEditableCoverPictures(audioExtension)) {
-            return if (replacementPicture == null) {
-                emptyArray()
-            } else {
-                arrayOf(replacementPicture)
-            }
+            return replacementPicture?.let(::arrayOf) ?: emptyArray()
         }
         val retainedPictures = existingPictures.filterNot(::isFrontCoverPicture)
         return if (replacementPicture == null) {
@@ -3078,12 +3065,20 @@ object LocalMediaSupport {
         }
     }
 
+    internal fun resolveEffectiveLocalLyricContent(
+        sidecarContent: String?,
+        embeddedContent: String?
+    ): String? {
+        return sidecarContent?.takeIf(String::isNotBlank)
+            ?: embeddedContent?.takeIf(String::isNotBlank)
+    }
+
     private fun findFirstLyricSidecar(
         searchDirectories: List<File>,
         fileNames: List<String>
     ): File? {
-        return fileNames.asSequence()
-            .flatMap { fileName -> searchDirectories.asSequence().map { File(it, fileName) } }
+        return searchDirectories.asSequence()
+            .flatMap { directory -> fileNames.asSequence().map { File(directory, it) } }
             .firstOrNull(File::isFile)
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
@@ -3038,7 +3038,10 @@ object LocalMediaSupport {
         return file.toURI().toString()
     }
 
-    internal fun findNearbyLyricFiles(file: File?): NearbyLyricFiles {
+    internal fun findNearbyLyricFiles(
+        file: File?,
+        extensions: List<String> = lyricExtensions
+    ): NearbyLyricFiles {
         val actualFile = file ?: return NearbyLyricFiles(null, null)
         val parent = actualFile.parentFile ?: return NearbyLyricFiles(null, null)
         val baseName = actualFile.nameWithoutExtension
@@ -3048,11 +3051,19 @@ object LocalMediaSupport {
         return NearbyLyricFiles(
             original = findFirstLyricSidecar(
                 searchDirectories = searchDirectories,
-                fileNames = lyricSidecarNames(baseName, translated = false)
+                fileNames = lyricSidecarNames(
+                    baseName = baseName,
+                    translated = false,
+                    extensions = extensions
+                )
             ),
             translated = findFirstLyricSidecar(
                 searchDirectories = searchDirectories,
-                fileNames = lyricSidecarNames(baseName, translated = true)
+                fileNames = lyricSidecarNames(
+                    baseName = baseName,
+                    translated = true,
+                    extensions = extensions
+                )
             )
         )
     }
@@ -3076,13 +3087,17 @@ object LocalMediaSupport {
             .firstOrNull(File::isFile)
     }
 
-    private fun lyricSidecarNames(baseName: String, translated: Boolean): List<String> {
+    private fun lyricSidecarNames(
+        baseName: String,
+        translated: Boolean,
+        extensions: List<String>
+    ): List<String> {
         val prefix = if (translated) "${baseName}_trans" else baseName
         return buildList {
-            lyricExtensions.forEach { extension ->
+            extensions.forEach { extension ->
                 add("$prefix.$extension")
             }
-            if ("lrc" in lyricExtensions) {
+            if ("lrc" in extensions) {
                 add("$prefix.lrc.txt")
             }
         }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
@@ -3082,8 +3082,8 @@ object LocalMediaSupport {
         searchDirectories: List<File>,
         fileNames: List<String>
     ): File? {
-        return searchDirectories.asSequence()
-            .flatMap { directory -> fileNames.asSequence().map { File(directory, it) } }
+        return fileNames.asSequence()
+            .flatMap { fileName -> searchDirectories.asSequence().map { File(it, fileName) } }
             .firstOrNull(File::isFile)
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
@@ -134,6 +134,11 @@ data class LocalMediaDetails(
     val translatedLyricContent: String? = null
 )
 
+internal data class NearbyLyricFiles(
+    val original: File?,
+    val translated: File?
+)
+
 internal enum class EditableCoverMutation {
     UNCHANGED,
     CLEAR,
@@ -181,8 +186,7 @@ private fun SongItem.localMediaUriCandidates(): List<Uri> {
         localFilePath = localFilePath,
         mediaUri = mediaUri
     )
-    return listOf(preferredSource, localFilePath, mediaUri)
-        .filterNotNull()
+    return listOfNotNull(preferredSource, localFilePath, mediaUri)
         .mapNotNull { source ->
             val localUri = if (source.startsWith("/")) {
                 Uri.fromFile(File(source))
@@ -585,16 +589,14 @@ object LocalMediaSupport {
             song.localFilePath,
             sourcePathSegment,
             song.mediaUri
-        ).asSequence()
-            .mapNotNull { reference ->
-                reference
-                    ?.substringBefore('?')
-                    ?.substringBefore('#')
-                    ?.substringAfterLast('.', "")
-                    ?.lowercase(Locale.ROOT)
-                    ?.takeIf(String::isNotBlank)
-            }
-            .firstOrNull()
+        ).firstNotNullOfOrNull { reference ->
+            reference
+                ?.substringBefore('?')
+                ?.substringBefore('#')
+                ?.substringAfterLast('.', "")
+                ?.lowercase(Locale.ROOT)
+                ?.takeIf(String::isNotBlank)
+        }
             ?: "bin"
     }
 
@@ -1249,15 +1251,15 @@ object LocalMediaSupport {
             file = file
         )
         val nearbyCover = findNearbyCover(file)
-        val nearbyLyrics = findNearbyLyrics(file)
-        val nearbyLyricContent = nearbyLyrics?.let {
-            readTextFile(it)
-                ?: run {
-                    NPLogger.w(TAG, "read lyric failed for ${it.absolutePath}")
-                    null
-                }
-        }
+        val nearbyLyricFiles = findNearbyLyricFiles(file)
+        val nearbyLyricContent = readNearbyLyricContent(nearbyLyricFiles.original, "lyric")
+        val nearbyTranslatedLyricContent = readNearbyLyricContent(
+            nearbyLyricFiles.translated,
+            "translated lyric"
+        )
         val effectiveLyricContent = nearbyLyricContent ?: tagLibMetadata?.lyrics?.takeIf { it.isNotBlank() }
+        val effectiveTranslatedLyricContent = nearbyTranslatedLyricContent
+            ?: tagLibMetadata?.translatedLyrics?.takeIf { it.isNotBlank() }
 
         val retriever = MediaMetadataRetriever()
         return try {
@@ -1390,13 +1392,13 @@ object LocalMediaSupport {
                     else -> null
                 },
                 lyricContent = effectiveLyricContent,
-                lyricPath = nearbyLyrics?.absolutePath,
+                lyricPath = nearbyLyricFiles.original?.absolutePath,
                 lyricSource = when {
-                    nearbyLyrics != null -> context.getString(R.string.local_song_lyric_external)
+                    nearbyLyricFiles.original != null -> context.getString(R.string.local_song_lyric_external)
                     !effectiveLyricContent.isNullOrBlank() -> context.getString(R.string.local_song_lyric_embedded)
                     else -> null
                 },
-                translatedLyricContent = tagLibMetadata?.translatedLyrics,
+                translatedLyricContent = effectiveTranslatedLyricContent,
                 originalTitle = title,
                 originalArtist = tagLibMetadata?.artist ?: containerMetadata?.artist ?: queried.artist ?: artist,
                 embeddedCover = embeddedCover || tagLibCoverUri != null,
@@ -1456,13 +1458,13 @@ object LocalMediaSupport {
                     else -> null
                 },
                 lyricContent = effectiveLyricContent,
-                lyricPath = nearbyLyrics?.absolutePath,
+                lyricPath = nearbyLyricFiles.original?.absolutePath,
                 lyricSource = when {
-                    nearbyLyrics != null -> context.getString(R.string.local_song_lyric_external)
+                    nearbyLyricFiles.original != null -> context.getString(R.string.local_song_lyric_external)
                     !effectiveLyricContent.isNullOrBlank() -> context.getString(R.string.local_song_lyric_embedded)
                     else -> null
                 },
-                translatedLyricContent = tagLibMetadata?.translatedLyrics,
+                translatedLyricContent = effectiveTranslatedLyricContent,
                 originalTitle = title,
                 originalArtist = tagLibMetadata?.artist
                     ?: containerMetadata?.artist?.takeIf { it.isNotBlank() }
@@ -1738,7 +1740,7 @@ object LocalMediaSupport {
     }
 
     private fun readLimitedTextStream(input: InputStream): ByteArray {
-        val output = java.io.ByteArrayOutputStream()
+        val output = ByteArrayOutputStream()
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
         var total = 0L
         while (true) {
@@ -2250,7 +2252,22 @@ object LocalMediaSupport {
     private sealed class EditableCoverWritePlan {
         data object Unchanged : EditableCoverWritePlan()
         data object Unreadable : EditableCoverWritePlan()
-        data class Update(val pictures: Array<Picture>) : EditableCoverWritePlan()
+        data class Update(val pictures: Array<Picture>) : EditableCoverWritePlan() {
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (javaClass != other?.javaClass) return false
+
+                other as Update
+
+                if (!pictures.contentEquals(other.pictures)) return false
+
+                return true
+            }
+
+            override fun hashCode(): Int {
+                return pictures.contentHashCode()
+            }
+        }
     }
 
     private data class EditableMetadataSnapshot(
@@ -2370,7 +2387,11 @@ object LocalMediaSupport {
         audioExtension: String?
     ): Array<Picture> {
         if (usesRolelessEditableCoverPictures(audioExtension)) {
-            return replacementPicture?.let(::arrayOf) ?: emptyArray()
+            return if (replacementPicture == null) {
+                emptyArray()
+            } else {
+                arrayOf(replacementPicture)
+            }
         }
         val retainedPictures = existingPictures.filterNot(::isFrontCoverPicture)
         return if (replacementPicture == null) {
@@ -3017,25 +3038,54 @@ object LocalMediaSupport {
         return file.toURI().toString()
     }
 
-    private fun findNearbyLyrics(file: File?): File? {
-        val actualFile = file ?: return null
-        val parent = actualFile.parentFile ?: return null
+    internal fun findNearbyLyricFiles(file: File?): NearbyLyricFiles {
+        val actualFile = file ?: return NearbyLyricFiles(null, null)
+        val parent = actualFile.parentFile ?: return NearbyLyricFiles(null, null)
         val baseName = actualFile.nameWithoutExtension
+        val searchDirectories = listOf(parent, File(parent, "Lyrics"))
+            .filter(File::isDirectory)
 
-        lyricExtensions.forEach { ext ->
-            val sibling = File(parent, "$baseName.$ext")
-            if (sibling.exists()) return sibling
+        return NearbyLyricFiles(
+            original = findFirstLyricSidecar(
+                searchDirectories = searchDirectories,
+                fileNames = lyricSidecarNames(baseName, translated = false)
+            ),
+            translated = findFirstLyricSidecar(
+                searchDirectories = searchDirectories,
+                fileNames = lyricSidecarNames(baseName, translated = true)
+            )
+        )
+    }
+
+    private fun readNearbyLyricContent(file: File?, label: String): String? {
+        return file?.let {
+            readTextFile(it)
+                ?: run {
+                    NPLogger.w(TAG, "read $label failed for ${it.absolutePath}")
+                    null
+                }
         }
+    }
 
-        val lyricsDir = File(parent, "Lyrics")
-        if (lyricsDir.exists()) {
-            lyricExtensions.forEach { ext ->
-                val nested = File(lyricsDir, "$baseName.$ext")
-                if (nested.exists()) return nested
+    private fun findFirstLyricSidecar(
+        searchDirectories: List<File>,
+        fileNames: List<String>
+    ): File? {
+        return searchDirectories.asSequence()
+            .flatMap { directory -> fileNames.asSequence().map { File(directory, it) } }
+            .firstOrNull(File::isFile)
+    }
+
+    private fun lyricSidecarNames(baseName: String, translated: Boolean): List<String> {
+        val prefix = if (translated) "${baseName}_trans" else baseName
+        return buildList {
+            lyricExtensions.forEach { extension ->
+                add("$prefix.$extension")
+            }
+            if ("lrc" in lyricExtensions) {
+                add("$prefix.lrc.txt")
             }
         }
-
-        return null
     }
 
     internal fun findNearbyCover(file: File?): File? {

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
@@ -92,6 +92,22 @@ class LocalAudioImportManagerTest {
     }
 
     @Test
+    fun `copyNearbySidecars preserves translated lyric sidecar`() {
+        val sourceDir = tempFolder.newFolder("source-translated-lyrics")
+        val sourceAudio = File(sourceDir, "song.flac").apply { writeText("audio") }
+        File(sourceDir, "song_trans.lrc").writeText("translated")
+
+        val targetDir = tempFolder.newFolder("imports-translated-lyrics")
+        val targetAudio = File(targetDir, "imported_song.flac").apply { writeText("audio") }
+
+        LocalAudioImportManager.copyNearbySidecars(sourceAudio, targetAudio)
+
+        val copiedTranslated = File(targetDir, "imported_song_trans.lrc")
+        assertTrue(copiedTranslated.exists())
+        assertEquals("translated", copiedTranslated.readText())
+    }
+
+    @Test
     fun `buildQuickImportedSong falls back to file name and local placeholder metadata`() {
         val importedFile = tempFolder.newFile("001_demo_track.flac")
 

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
@@ -124,7 +124,7 @@ class LocalAudioImportManagerTest {
     }
 
     @Test
-    fun `copyNearbySidecars preserves legacy lyric selection priority`() {
+    fun `copyNearbySidecars preserves source directory lyric selection priority`() {
         val sourceDir = tempFolder.newFolder("source-lyrics-priority")
         val sourceAudio = File(sourceDir, "song.flac").apply { writeText("audio") }
         File(sourceDir, "song.txt").writeText("source original")
@@ -138,13 +138,10 @@ class LocalAudioImportManagerTest {
 
         LocalAudioImportManager.copyNearbySidecars(sourceAudio, targetAudio)
 
-        assertEquals("nested original", File(targetDir, "imported_song.lrc").readText())
-        assertFalse(File(targetDir, "imported_song.txt").exists())
-        assertEquals(
-            "nested translation",
-            File(targetDir, "imported_song_trans.lrc").readText()
-        )
-        assertFalse(File(targetDir, "imported_song_trans.txt").exists())
+        assertEquals("source original", File(targetDir, "imported_song.txt").readText())
+        assertFalse(File(targetDir, "imported_song.lrc").exists())
+        assertEquals("source translation", File(targetDir, "imported_song_trans.txt").readText())
+        assertFalse(File(targetDir, "imported_song_trans.lrc").exists())
     }
 
     @Test

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
@@ -124,7 +124,7 @@ class LocalAudioImportManagerTest {
     }
 
     @Test
-    fun `copyNearbySidecars preserves lyric selection priority for original and translated files`() {
+    fun `copyNearbySidecars preserves legacy lyric selection priority`() {
         val sourceDir = tempFolder.newFolder("source-lyrics-priority")
         val sourceAudio = File(sourceDir, "song.flac").apply { writeText("audio") }
         File(sourceDir, "song.txt").writeText("source original")
@@ -138,13 +138,13 @@ class LocalAudioImportManagerTest {
 
         LocalAudioImportManager.copyNearbySidecars(sourceAudio, targetAudio)
 
-        assertEquals("source original", File(targetDir, "imported_song.txt").readText())
-        assertFalse(File(targetDir, "imported_song.lrc").exists())
+        assertEquals("nested original", File(targetDir, "imported_song.lrc").readText())
+        assertFalse(File(targetDir, "imported_song.txt").exists())
         assertEquals(
-            "source translation",
-            File(targetDir, "imported_song_trans.txt").readText()
+            "nested translation",
+            File(targetDir, "imported_song_trans.lrc").readText()
         )
-        assertFalse(File(targetDir, "imported_song_trans.lrc").exists())
+        assertFalse(File(targetDir, "imported_song_trans.txt").exists())
     }
 
     @Test

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
@@ -108,6 +108,46 @@ class LocalAudioImportManagerTest {
     }
 
     @Test
+    fun `copyNearbySidecars preserves translated lrc txt suffix`() {
+        val sourceDir = tempFolder.newFolder("source-translated-lrc-txt")
+        val sourceAudio = File(sourceDir, "song.flac").apply { writeText("audio") }
+        File(sourceDir, "song_trans.lrc.txt").writeText("translated")
+
+        val targetDir = tempFolder.newFolder("imports-translated-lrc-txt")
+        val targetAudio = File(targetDir, "imported_song.flac").apply { writeText("audio") }
+
+        LocalAudioImportManager.copyNearbySidecars(sourceAudio, targetAudio)
+
+        val copiedTranslated = File(targetDir, "imported_song_trans.lrc.txt")
+        assertTrue(copiedTranslated.exists())
+        assertEquals("translated", copiedTranslated.readText())
+    }
+
+    @Test
+    fun `copyNearbySidecars preserves lyric selection priority for original and translated files`() {
+        val sourceDir = tempFolder.newFolder("source-lyrics-priority")
+        val sourceAudio = File(sourceDir, "song.flac").apply { writeText("audio") }
+        File(sourceDir, "song.txt").writeText("source original")
+        File(sourceDir, "song_trans.txt").writeText("source translation")
+        val lyricsDir = File(sourceDir, "Lyrics").apply { mkdirs() }
+        File(lyricsDir, "song.lrc").writeText("nested original")
+        File(lyricsDir, "song_trans.lrc").writeText("nested translation")
+
+        val targetDir = tempFolder.newFolder("imports-lyrics-priority")
+        val targetAudio = File(targetDir, "imported_song.flac").apply { writeText("audio") }
+
+        LocalAudioImportManager.copyNearbySidecars(sourceAudio, targetAudio)
+
+        assertEquals("source original", File(targetDir, "imported_song.txt").readText())
+        assertFalse(File(targetDir, "imported_song.lrc").exists())
+        assertEquals(
+            "source translation",
+            File(targetDir, "imported_song_trans.txt").readText()
+        )
+        assertFalse(File(targetDir, "imported_song_trans.lrc").exists())
+    }
+
+    @Test
     fun `buildQuickImportedSong falls back to file name and local placeholder metadata`() {
         val importedFile = tempFolder.newFile("001_demo_track.flac")
 

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
@@ -179,14 +179,39 @@ class LocalMediaSupportTest {
     }
 
     @Test
-    fun `findNearbyLyricFiles keeps lrc priority across source and Lyrics directory`() {
+    fun `resolveEffectiveLocalLyricContent falls back to embedded lyrics for blank sidecar`() {
+        assertEquals(
+            "[00:00.00]embedded",
+            LocalMediaSupport.resolveEffectiveLocalLyricContent(
+                sidecarContent = "  \n",
+                embeddedContent = "[00:00.00]embedded"
+            )
+        )
+        assertEquals(
+            "[00:00.00]sidecar",
+            LocalMediaSupport.resolveEffectiveLocalLyricContent(
+                sidecarContent = "[00:00.00]sidecar",
+                embeddedContent = "[00:00.00]embedded"
+            )
+        )
+        assertEquals(
+            null,
+            LocalMediaSupport.resolveEffectiveLocalLyricContent(
+                sidecarContent = "",
+                embeddedContent = " "
+            )
+        )
+    }
+
+    @Test
+    fun `findNearbyLyricFiles keeps source directory priority over Lyrics fallback`() {
         val sourceDir = tempFolder.newFolder("nearby-lyrics-priority")
         val audioFile = File(sourceDir, "song.flac").apply { writeText("audio") }
-        File(sourceDir, "song.txt").writeText("source original")
-        File(sourceDir, "song_trans.txt").writeText("source translation")
+        val original = File(sourceDir, "song.txt").apply { writeText("source original") }
+        val translated = File(sourceDir, "song_trans.txt").apply { writeText("source translation") }
         val lyricsDir = File(sourceDir, "Lyrics").apply { mkdirs() }
-        val original = File(lyricsDir, "song.lrc").apply { writeText("nested original") }
-        val translated = File(lyricsDir, "song_trans.lrc").apply { writeText("nested translation") }
+        File(lyricsDir, "song.lrc").writeText("nested original")
+        File(lyricsDir, "song_trans.lrc").writeText("nested translation")
 
         val found = LocalMediaSupport.findNearbyLyricFiles(audioFile)
 

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
@@ -152,4 +152,29 @@ class LocalMediaSupportTest {
         assertEquals(false, selection.usesFallbackAlbum)
         assertEquals(0L, selection.durationMs)
     }
+
+    @Test
+    fun `findNearbyLyricFiles discovers original and translated sidecars separately`() {
+        val sourceDir = tempFolder.newFolder("nearby-lyrics")
+        val audioFile = File(sourceDir, "song.flac").apply { writeText("audio") }
+        val original = File(sourceDir, "song.lrc").apply { writeText("original") }
+        val lyricsDir = File(sourceDir, "Lyrics").apply { mkdirs() }
+        val translated = File(lyricsDir, "song_trans.lrc").apply { writeText("translated") }
+
+        val found = LocalMediaSupport.findNearbyLyricFiles(audioFile)
+
+        assertEquals(original.canonicalPath, found.original?.canonicalPath)
+        assertEquals(translated.canonicalPath, found.translated?.canonicalPath)
+    }
+
+    @Test
+    fun `findNearbyLyricFiles keeps lrc txt compatibility for translated sidecars`() {
+        val sourceDir = tempFolder.newFolder("nearby-lyrics-lrc-txt")
+        val audioFile = File(sourceDir, "song.flac").apply { writeText("audio") }
+        val translated = File(sourceDir, "song_trans.lrc.txt").apply { writeText("translated") }
+
+        val found = LocalMediaSupport.findNearbyLyricFiles(audioFile)
+
+        assertEquals(translated.canonicalPath, found.translated?.canonicalPath)
+    }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
@@ -177,4 +177,20 @@ class LocalMediaSupportTest {
 
         assertEquals(translated.canonicalPath, found.translated?.canonicalPath)
     }
+
+    @Test
+    fun `findNearbyLyricFiles keeps lrc priority across source and Lyrics directory`() {
+        val sourceDir = tempFolder.newFolder("nearby-lyrics-priority")
+        val audioFile = File(sourceDir, "song.flac").apply { writeText("audio") }
+        File(sourceDir, "song.txt").writeText("source original")
+        File(sourceDir, "song_trans.txt").writeText("source translation")
+        val lyricsDir = File(sourceDir, "Lyrics").apply { mkdirs() }
+        val original = File(lyricsDir, "song.lrc").apply { writeText("nested original") }
+        val translated = File(lyricsDir, "song_trans.lrc").apply { writeText("nested translation") }
+
+        val found = LocalMediaSupport.findNearbyLyricFiles(audioFile)
+
+        assertEquals(original.canonicalPath, found.original?.canonicalPath)
+        assertEquals(translated.canonicalPath, found.translated?.canonicalPath)
+    }
 }


### PR DESCRIPTION
fix #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 支持从音频同目录或 `Lyrics` 子目录懒加载本地翻译歌词。
- 支持 `_trans` 文件名及 `.lrc`、`.txt`、`.lrc.txt` 扩展名。
- 导入媒体时会复制翻译歌词 sidecar 文件，并保留翻译标记。
- 新增测试，覆盖翻译歌词复制、目录查找、`.lrc` 优先级和 `.lrc.txt` 兼容性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->