### PR TITLE
fix: handle system back navigation in lyrics editor

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/NowPlayingDialogsTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/NowPlayingDialogsTest.kt
@@ -1,8 +1,13 @@
 package moe.ouom.neriplayer.ui.screen
 
+import androidx.activity.compose.BackHandler
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -27,7 +32,7 @@ import org.junit.runner.RunWith
 class NowPlayingDialogsTest {
 
     @get:Rule
-    val composeRule = createComposeRule()
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
 
     @Before
     fun assumeDeviceUnlocked() {
@@ -124,6 +129,47 @@ class NowPlayingDialogsTest {
 
         composeRule.waitUntil(timeoutMillis = 3_000) {
             composeRule.onAllNodesWithText("译文B").fetchSemanticsNodes().isEmpty()
+        }
+    }
+
+    @Test
+    fun lyricsEditorSheet_systemBackReturnsToSongInfoBeforeOuterMenu() {
+        var lyricsEditorDismissed = false
+        var outerMenuBackHandled = false
+
+        composeRule.setContent {
+            val lyricsEditorShown = remember { mutableStateOf(true) }
+            MaterialTheme {
+                Box {
+                    BackHandler {
+                        outerMenuBackHandled = true
+                    }
+                    if (lyricsEditorShown.value) {
+                        LyricsEditorSheet(
+                            originalSong = demoSongItem(),
+                            initialLyrics = "原文A",
+                            initialTranslatedLyrics = "译文B",
+                            onDismiss = {
+                                lyricsEditorDismissed = true
+                                lyricsEditorShown.value = false
+                            }
+                        )
+                    } else {
+                        Text("编辑歌曲信息仍在")
+                    }
+                }
+            }
+        }
+
+        waitForText("原文A")
+        composeRule.runOnIdle {
+            composeRule.activity.onBackPressedDispatcher.onBackPressed()
+        }
+        waitForText("编辑歌曲信息仍在")
+
+        composeRule.runOnIdle {
+            assertTrue(lyricsEditorDismissed)
+            assertTrue(!outerMenuBackHandled)
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
@@ -5334,6 +5334,14 @@ fun LyricsEditorSheet(
         source in searchedLyricMatchSources
     }
 
+    BackHandler {
+        when {
+            showLocalMetadataWriteBackConfirm -> showLocalMetadataWriteBackConfirm = false
+            showLyricMatchSheet -> showLyricMatchSheet = false
+            else -> dismissLyricsEditor()
+        }
+    }
+
     fun saveLyrics(writeLocalMetadata: Boolean) {
         isSaving = true
         coroutineScope.launch {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 歌词编辑器现在支持系统返回键。打开本地元数据写回确认框时，返回键先关闭确认框；打开歌词匹配页面时，返回键先返回编辑器；否则关闭歌词编辑器。
- 新增 Android Compose 测试，验证歌词编辑器关闭后显示歌曲信息，并防止外层菜单提前处理返回键。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->