### PR TITLE
fix: reset download file name template when dialog is canceled

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/SettingsStorageCacheSectionTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/SettingsStorageCacheSectionTest.kt
@@ -1,0 +1,94 @@
+package moe.ouom.neriplayer.ui.screen.tab.settings.component
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import moe.ouom.neriplayer.R
+import moe.ouom.neriplayer.data.storage.StorageCacheClearOptions
+import moe.ouom.neriplayer.data.storage.StorageUsageSummary
+import moe.ouom.neriplayer.testutil.assumeComposeHostAvailable
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SettingsStorageCacheSectionTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun assumeDeviceUnlocked() {
+        assumeComposeHostAvailable()
+    }
+
+    @Test
+    fun cancelingFileNameEditRestoresSavedTemplateInCard() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val savedTemplate = "%artist% - %title%"
+        var currentTemplate by mutableStateOf<String?>(savedTemplate)
+        var saveCallbackCount by mutableStateOf(0)
+
+        composeRule.setContent {
+            MaterialTheme {
+                SettingsStorageCacheSection(
+                    expanded = true,
+                    arrowRotation = 0f,
+                    onExpandedChange = {},
+                    showHeader = false,
+                    currentDownloadDirectorySummary = "",
+                    isCustomDownloadDirectory = false,
+                    downloadDirectoryChangeEnabled = true,
+                    onPickDownloadDirectory = {},
+                    onResetDownloadDirectory = {},
+                    downloadFileNameTemplate = currentTemplate,
+                    onDownloadFileNameTemplateChange = {
+                        currentTemplate = it
+                        saveCallbackCount++
+                    },
+                    maxCacheSizeBytes = 0L,
+                    onMaxCacheSizeBytesChange = {},
+                    showStorageDetails = false,
+                    onShowStorageDetailsChange = {},
+                    storageDetails = StorageUsageSummary.Empty,
+                    onStorageDetailsChange = {},
+                    showClearCacheDialog = false,
+                    onShowClearCacheDialogChange = {},
+                    clearAudioCache = false,
+                    onClearAudioCacheChange = {},
+                    clearImageCache = false,
+                    onClearImageCacheChange = {},
+                    clearDownloadStagingCache = false,
+                    onClearDownloadStagingCacheChange = {},
+                    clearSharedMediaCache = false,
+                    onClearSharedMediaCacheChange = {},
+                    clearPlatformListCache = false,
+                    onClearPlatformListCacheChange = {},
+                    downloadStagingClearEnabled = true,
+                    onClearCacheClick = { _: StorageCacheClearOptions -> },
+                    cardIndex = 1
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(savedTemplate).assertExists()
+        composeRule.onNodeWithText(context.getString(R.string.action_details)).performClick()
+        composeRule.onNode(hasSetTextAction()).performTextInput(" temporary")
+        composeRule.onNodeWithText(context.getString(R.string.action_cancel)).performClick()
+
+        composeRule.onNodeWithText(savedTemplate).assertExists()
+        composeRule.runOnIdle {
+            assertEquals(savedTemplate, currentTemplate)
+            assertEquals(0, saveCallbackCount)
+        }
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/SettingsStorageCacheSection.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/SettingsStorageCacheSection.kt
@@ -155,6 +155,10 @@ internal fun SettingsStorageCacheSection(
         pendingDownloadFileNameTemplate
     ) ?: DEFAULT_DOWNLOAD_FILE_NAME_TEMPLATE
     val currentSavedTemplate = downloadFileNameTemplate ?: DEFAULT_DOWNLOAD_FILE_NAME_TEMPLATE
+    fun dismissDownloadFileNameDialog() {
+        pendingDownloadFileNameTemplate = currentSavedTemplate
+        showDownloadFileNameDialog = false
+    }
     val samplePreview = renderManagedDownloadBaseName(
         title = "晴天",
         artist = "周杰伦",
@@ -638,7 +642,7 @@ internal fun SettingsStorageCacheSection(
 
     if (showDownloadFileNameDialog) {
         MiuixSettingsDialog(
-            onDismissRequest = { showDownloadFileNameDialog = false },
+            onDismissRequest = ::dismissDownloadFileNameDialog,
             title = { Text(stringResource(R.string.settings_download_file_name_format)) },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -692,7 +696,7 @@ internal fun SettingsStorageCacheSection(
                     ) {
                         Text(stringResource(R.string.action_reset))
                     }
-                    MiuixSettingsTextButton(onClick = { showDownloadFileNameDialog = false }) {
+                    MiuixSettingsTextButton(onClick = ::dismissDownloadFileNameDialog) {
                         Text(stringResource(R.string.action_cancel))
                     }
                 }


### PR DESCRIPTION
fix #325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

修复文件名格式对话框取消操作：

- 取消或关闭对话框时，恢复已保存的下载文件名模板。
- 卡片立即刷新并显示原始模板。
- 取消操作不会触发保存回调。
- 新增 Compose 仪器测试，覆盖上述行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->