### PR TITLE
feat: add support for unlimited media cache size

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
@@ -25,6 +25,7 @@ import androidx.media3.database.StandaloneDatabaseProvider
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.NoOpCacheEvictor
 import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.DefaultRenderersFactory
@@ -130,6 +131,7 @@ import moe.ouom.neriplayer.core.player.watchdog.schedulePlaybackStartupWatchdog
 import moe.ouom.neriplayer.core.player.watchdog.trySwitchToNextPlaybackCandidateForRecovery
 import moe.ouom.neriplayer.data.settings.PlaybackPreferenceSnapshot
 import moe.ouom.neriplayer.data.settings.AutoSettingsSchema
+import moe.ouom.neriplayer.data.settings.CacheSizePolicy
 import moe.ouom.neriplayer.data.settings.UsbExclusivePreferences
 import moe.ouom.neriplayer.data.settings.readPlaybackPreferenceSnapshotSync
 import moe.ouom.neriplayer.data.settings.toUsbExclusivePreferences
@@ -154,16 +156,17 @@ internal fun PlayerManager.initializeImpl(
         }
         initializationInProgress = true
     }
+    val effectiveMaxCacheSize = CacheSizePolicy.normalizeCacheSizeBytes(maxCacheSize)
     try {
         runCatching {
             NPLogger.d(
                 "NERI-PlayerManager",
-                "initialize(): maxCacheSize=$maxCacheSize, app=${app.packageName}, stack=[${debugStackHint()}]"
+                "initialize(): maxCacheSize=$effectiveMaxCacheSize, app=${app.packageName}, stack=[${debugStackHint()}]"
             )
             application = app
             _localPlaylistsReadyFlow.value = false
             FloatingLyricsOverlayManager.initialize(app)
-            currentCacheSize = maxCacheSize
+            currentCacheSize = effectiveMaxCacheSize
 
             ioScope = newIoScope()
             mainScope = newMainScope()
@@ -250,13 +253,23 @@ internal fun PlayerManager.initializeImpl(
         )
         conditionalHttpFactory = conditionalFactory
 
-        val finalDataSourceFactory: androidx.media3.datasource.DataSource.Factory = if (maxCacheSize > 0) {
+        val finalDataSourceFactory: androidx.media3.datasource.DataSource.Factory = if (
+            effectiveMaxCacheSize > 0 ||
+                effectiveMaxCacheSize == CacheSizePolicy.UNLIMITED_CACHE_SIZE_BYTES
+        ) {
             val cacheDir = File(app.cacheDir, "media_cache")
             val dbProvider = StandaloneDatabaseProvider(app)
+            val cacheEvictor = if (
+                effectiveMaxCacheSize == CacheSizePolicy.UNLIMITED_CACHE_SIZE_BYTES
+            ) {
+                NoOpCacheEvictor()
+            } else {
+                LeastRecentlyUsedCacheEvictor(effectiveMaxCacheSize)
+            }
 
             cache = SimpleCache(
                 cacheDir,
-                LeastRecentlyUsedCacheEvictor(maxCacheSize),
+                cacheEvictor,
                 dbProvider
             )
 
@@ -1034,12 +1047,12 @@ internal fun PlayerManager.initializeImpl(
         initialized = true
         NPLogger.d(
             "NERI-PlayerManager",
-            "initialize(): success, cacheSize=$maxCacheSize, restoredQueueSize=${currentPlaylist.size}, currentIndex=$currentIndex, currentDevice=${_currentAudioDevice.value?.type}:${_currentAudioDevice.value?.name}"
+            "initialize(): success, cacheSize=$effectiveMaxCacheSize, restoredQueueSize=${currentPlaylist.size}, currentIndex=$currentIndex, currentDevice=${_currentAudioDevice.value?.type}:${_currentAudioDevice.value?.name}"
         )
     }.onFailure { e ->
         NPLogger.e(
             "NERI-PlayerManager",
-            "initialize(): failed, cacheSize=$maxCacheSize, currentPlaylistSize=${currentPlaylist.size}, currentIndex=$currentIndex",
+            "initialize(): failed, cacheSize=$effectiveMaxCacheSize, currentPlaylistSize=${currentPlaylist.size}, currentIndex=$currentIndex",
             e
         )
         NPLogger.w(

--- a/app/src/main/java/moe/ouom/neriplayer/data/config/ConfigSettingsSanitizer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/config/ConfigSettingsSanitizer.kt
@@ -17,6 +17,7 @@ import moe.ouom.neriplayer.core.player.model.normalizePlaybackPitch
 import moe.ouom.neriplayer.core.player.model.normalizePlaybackSpeed
 import moe.ouom.neriplayer.core.player.model.normalizePlaybackVolumeBalance
 import moe.ouom.neriplayer.data.settings.PlaybackServiceIdleShutdownPreference
+import moe.ouom.neriplayer.data.settings.CacheSizePolicy
 import moe.ouom.neriplayer.data.settings.SettingsKeys
 import moe.ouom.neriplayer.data.settings.ThemeDefaults
 import moe.ouom.neriplayer.data.settings.YouTubePlaybackSourcePreferencePolicy
@@ -174,7 +175,8 @@ internal class ConfigSettingsSanitizer(private val context: Context) {
                 SettingsKeys.PLAYBACK_CROSSFADE_IN_DURATION_MS.name,
                 SettingsKeys.PLAYBACK_CROSSFADE_OUT_DURATION_MS.name ->
                     value.coerceIn(PLAYBACK_FADE_DURATION_RANGE_MS)
-                SettingsKeys.MAX_CACHE_SIZE_BYTES.name -> value.coerceIn(CACHE_SIZE_RANGE_BYTES)
+                SettingsKeys.MAX_CACHE_SIZE_BYTES.name ->
+                    CacheSizePolicy.normalizeCacheSizeBytes(value)
                 else -> value
             }
             if (normalized != value) {
@@ -394,8 +396,6 @@ private val NOW_PLAYING_COVER_BLUR_AMOUNT_RANGE = 0f..500f
 private val NOW_PLAYING_COVER_BLUR_DARKEN_RANGE = 0f..0.8f
 private val LYRIC_BLUR_AMOUNT_RANGE = 0f..8f
 private val PLAYBACK_FADE_DURATION_RANGE_MS = 0L..3000L
-private val CACHE_SIZE_RANGE_BYTES = 0L..(10L * 1024L * 1024L * 1024L)
-
 private const val DEFAULT_NETEASE_AUDIO_QUALITY = "exhigh"
 private const val DEFAULT_YOUTUBE_AUDIO_QUALITY = "high"
 private const val DEFAULT_BILI_AUDIO_QUALITY = "high"

--- a/app/src/main/java/moe/ouom/neriplayer/data/settings/CacheSizePolicy.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/settings/CacheSizePolicy.kt
@@ -1,0 +1,44 @@
+package moe.ouom.neriplayer.data.settings
+
+/**
+ * keeps the cache setting representation shared by the settings UI and playback startup
+ */
+object CacheSizePolicy {
+    const val UNLIMITED_CACHE_SIZE_BYTES = -1L
+    const val MAX_FINITE_CACHE_SIZE_BYTES = 10L * 1024L * 1024L * 1024L
+    const val CACHE_SIZE_SLIDER_MAX_FINITE_MB = 10_240f
+    const val CACHE_SIZE_SLIDER_UNLIMITED_VALUE = 10_241f
+    const val CACHE_SIZE_SLIDER_NO_CACHE_THRESHOLD_MB = 10f
+
+    private const val BYTES_PER_MEGABYTE = 1024L * 1024L
+
+    fun normalizeCacheSizeBytes(bytes: Long): Long {
+        return if (bytes == UNLIMITED_CACHE_SIZE_BYTES) {
+            bytes
+        } else {
+            bytes.coerceIn(0L, MAX_FINITE_CACHE_SIZE_BYTES)
+        }
+    }
+
+    fun toSliderValue(bytes: Long): Float {
+        val normalized = normalizeCacheSizeBytes(bytes)
+        if (normalized == UNLIMITED_CACHE_SIZE_BYTES) {
+            return CACHE_SIZE_SLIDER_UNLIMITED_VALUE
+        }
+        return (normalized.toFloat() / BYTES_PER_MEGABYTE.toFloat())
+            .coerceIn(0f, CACHE_SIZE_SLIDER_MAX_FINITE_MB)
+    }
+
+    fun fromSliderValue(value: Float): Long {
+        if (value.isNaN()) return 0L
+        val normalized = value.coerceIn(0f, CACHE_SIZE_SLIDER_UNLIMITED_VALUE)
+        if (normalized >= CACHE_SIZE_SLIDER_UNLIMITED_VALUE) {
+            return UNLIMITED_CACHE_SIZE_BYTES
+        }
+        if (normalized < CACHE_SIZE_SLIDER_NO_CACHE_THRESHOLD_MB) {
+            return 0L
+        }
+        return (normalized * BYTES_PER_MEGABYTE.toFloat()).toLong()
+            .coerceIn(0L, MAX_FINITE_CACHE_SIZE_BYTES)
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/settings/PlaybackPreferenceSnapshot.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/settings/PlaybackPreferenceSnapshot.kt
@@ -204,7 +204,7 @@ data class PlaybackPreferenceSnapshot(
             ),
             cloudMusicLyricDefaultOffsetMs = normalizeLyricDefaultOffsetMs(cloudMusicLyricDefaultOffsetMs),
             qqMusicLyricDefaultOffsetMs = normalizeLyricDefaultOffsetMs(qqMusicLyricDefaultOffsetMs),
-            maxCacheSizeBytes = maxCacheSizeBytes.coerceAtLeast(0L)
+            maxCacheSizeBytes = CacheSizePolicy.normalizeCacheSizeBytes(maxCacheSizeBytes)
         )
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/settings/SettingsRepository.kt
@@ -407,7 +407,11 @@ class SettingsRepository(private val context: Context) {
         }
 
     val maxCacheSizeBytesFlow: Flow<Long> =
-        dataStoreSettingFlow { it[SettingsKeys.MAX_CACHE_SIZE_BYTES] ?: (1024L * 1024 * 1024) }
+        dataStoreSettingFlow {
+            CacheSizePolicy.normalizeCacheSizeBytes(
+                it[SettingsKeys.MAX_CACHE_SIZE_BYTES] ?: (1024L * 1024 * 1024)
+            )
+        }
 
     val showLyricTranslationFlow: Flow<Boolean> =
         autoSettingsRepository.showLyricTranslationFlow
@@ -1003,7 +1007,7 @@ class SettingsRepository(private val context: Context) {
     }
 
     suspend fun setMaxCacheSizeBytes(bytes: Long) {
-        val normalized = bytes.coerceAtLeast(0L)
+        val normalized = CacheSizePolicy.normalizeCacheSizeBytes(bytes)
         context.dataStore.edit { it[SettingsKeys.MAX_CACHE_SIZE_BYTES] = normalized }
         updatePlaybackPreferenceSnapshot(context) { it.copy(maxCacheSizeBytes = normalized) }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/SettingsStorageCacheSection.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/SettingsStorageCacheSection.kt
@@ -81,6 +81,7 @@ import moe.ouom.neriplayer.core.download.renderManagedDownloadBaseName
 import moe.ouom.neriplayer.data.settings.generated.AutoSettingsKeys
 import moe.ouom.neriplayer.data.settings.generated.AutoSettingsListItem
 import moe.ouom.neriplayer.data.settings.generated.AutoSettingsMetadata
+import moe.ouom.neriplayer.data.settings.CacheSizePolicy
 import moe.ouom.neriplayer.data.storage.StorageCacheClearOptions
 import moe.ouom.neriplayer.data.storage.StorageCacheKind
 import moe.ouom.neriplayer.data.storage.StorageUsageItem
@@ -350,17 +351,29 @@ internal fun SettingsStorageCacheSection(
                     setting = AutoSettingsMetadata.requireSetting(AutoSettingsKeys.MAX_CACHE_SIZE_BYTES),
                     showDefaultIcon = false,
                     supportingContent = {
-                        val sizeMb = maxCacheSizeBytes / (1024 * 1024).toFloat()
-                        var sliderValue by remember(sizeMb) { mutableFloatStateOf(sizeMb) }
-                        val displaySize = if (sliderValue >= 1024) {
-                            composeResources.getString(R.string.settings_cache_size_gb, sliderValue / 1024)
-                        } else {
-                            composeResources.getString(R.string.settings_cache_size_mb, sliderValue.toInt())
+                        var sliderValue by remember(maxCacheSizeBytes) {
+                            mutableFloatStateOf(CacheSizePolicy.toSliderValue(maxCacheSizeBytes))
+                        }
+                        val displaySize = when {
+                            sliderValue >= CacheSizePolicy.CACHE_SIZE_SLIDER_UNLIMITED_VALUE ->
+                                stringResource(R.string.settings_cache_unlimited)
+                            sliderValue >= 1024f ->
+                                composeResources.getString(
+                                    R.string.settings_cache_size_gb,
+                                    sliderValue / 1024
+                                )
+                            else ->
+                                composeResources.getString(
+                                    R.string.settings_cache_size_mb,
+                                    sliderValue.toInt()
+                                )
                         }
 
                         Column {
                             Text(
-                                text = if (sliderValue < 10f) {
+                                text = if (
+                                    sliderValue < CacheSizePolicy.CACHE_SIZE_SLIDER_NO_CACHE_THRESHOLD_MB
+                                ) {
                                     stringResource(R.string.settings_no_cache)
                                 } else {
                                     displaySize
@@ -372,14 +385,11 @@ internal fun SettingsStorageCacheSection(
                                 value = sliderValue,
                                 onValueChange = { sliderValue = it },
                                 onValueChangeFinished = {
-                                    val newBytes = if (sliderValue < 10f) {
-                                        0L
-                                    } else {
-                                        (sliderValue * 1024 * 1024).toLong()
-                                    }
-                                    onMaxCacheSizeBytesChange(newBytes)
+                                    onMaxCacheSizeBytesChange(
+                                        CacheSizePolicy.fromSliderValue(sliderValue)
+                                    )
                                 },
-                                valueRange = 0f..(10 * 1024f),
+                                valueRange = 0f..CacheSizePolicy.CACHE_SIZE_SLIDER_UNLIMITED_VALUE,
                                 steps = 0
                             )
                             Text(

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1251,6 +1251,7 @@
     <string name="settings_background_select">Select image</string>
     <string name="settings_network_expand">Network and proxy options</string>
     <string name="settings_no_cache">No cache</string>
+    <string name="settings_cache_unlimited">Unlimited</string>
     <string name="settings_download_management">Download Management</string>
     <string name="settings_download_expand">Location, file format, and download tasks</string>
     <string name="settings_download_progress">Download Progress</string>
@@ -1648,7 +1649,7 @@
     <string name="settings_cache_manage">Manage cache</string>
     <string name="settings_storage_cache">Storage &amp; Cache</string>
     <string name="settings_storage_expand">Cache size, cleanup, and storage use</string>
-    <string name="settings_cache_notice">Set to 0 MB to disable cache. Restart required after changing limit.</string>
+    <string name="settings_cache_notice">Set to 0 MB to disable cache, or move the slider to the end for unlimited. Restart required after changing the limit.</string>
     <string name="settings_cache_size_gb">%.1f GB</string>
     <string name="settings_cache_size_mb">%1$d MB</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1251,6 +1251,7 @@
     <string name="settings_background_select">选择一张图片</string>
     <string name="settings_network_expand">网络连接与代理选项</string>
     <string name="settings_no_cache">不缓存 (0 MB)</string>
+    <string name="settings_cache_unlimited">无上限</string>
     <string name="settings_download_management">下载管理</string>
     <string name="settings_download_expand">下载目录、保存格式与任务管理</string>
     <string name="settings_download_progress">下载进度</string>
@@ -1648,7 +1649,7 @@
     <string name="settings_cache_manage">管理缓存大小与清理</string>
     <string name="settings_storage_cache">存储与缓存</string>
     <string name="settings_storage_expand">缓存大小、清理与存储用量</string>
-    <string name="settings_cache_notice">设置为 0 MB 即禁用缓存。修改上限后需重启应用生效。</string>
+    <string name="settings_cache_notice">设置为 0 MB 即禁用缓存，滑到滑块末端为无上限。修改上限后需重启应用生效。</string>
     <string name="settings_cache_size_gb">%.1f GB</string>
     <string name="settings_cache_size_mb">%1$d MB</string>
 

--- a/app/src/test/java/moe/ouom/neriplayer/data/settings/CacheSizePolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/settings/CacheSizePolicyTest.kt
@@ -1,0 +1,56 @@
+package moe.ouom.neriplayer.data.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CacheSizePolicyTest {
+
+    @Test
+    fun `slider end maps to unlimited cache`() {
+        assertEquals(
+            CacheSizePolicy.UNLIMITED_CACHE_SIZE_BYTES,
+            CacheSizePolicy.fromSliderValue(CacheSizePolicy.CACHE_SIZE_SLIDER_UNLIMITED_VALUE)
+        )
+        assertEquals(
+            CacheSizePolicy.CACHE_SIZE_SLIDER_UNLIMITED_VALUE,
+            CacheSizePolicy.toSliderValue(CacheSizePolicy.UNLIMITED_CACHE_SIZE_BYTES)
+        )
+    }
+
+    @Test
+    fun `ten gigabytes remains the largest finite cache`() {
+        val maxFiniteSlider = CacheSizePolicy.CACHE_SIZE_SLIDER_MAX_FINITE_MB
+
+        assertEquals(
+            CacheSizePolicy.MAX_FINITE_CACHE_SIZE_BYTES,
+            CacheSizePolicy.fromSliderValue(maxFiniteSlider)
+        )
+        assertEquals(
+            maxFiniteSlider,
+            CacheSizePolicy.toSliderValue(CacheSizePolicy.MAX_FINITE_CACHE_SIZE_BYTES)
+        )
+    }
+
+    @Test
+    fun `small slider values keep the existing no cache option`() {
+        assertEquals(0L, CacheSizePolicy.fromSliderValue(0f))
+        assertEquals(0L, CacheSizePolicy.fromSliderValue(9.99f))
+        assertEquals(
+            10L * 1024L * 1024L,
+            CacheSizePolicy.fromSliderValue(CacheSizePolicy.CACHE_SIZE_SLIDER_NO_CACHE_THRESHOLD_MB)
+        )
+    }
+
+    @Test
+    fun `invalid persisted values are clamped without losing unlimited sentinel`() {
+        assertEquals(0L, CacheSizePolicy.normalizeCacheSizeBytes(-2L))
+        assertEquals(
+            CacheSizePolicy.MAX_FINITE_CACHE_SIZE_BYTES,
+            CacheSizePolicy.normalizeCacheSizeBytes(Long.MAX_VALUE)
+        )
+        assertEquals(
+            CacheSizePolicy.UNLIMITED_CACHE_SIZE_BYTES,
+            CacheSizePolicy.normalizeCacheSizeBytes(CacheSizePolicy.UNLIMITED_CACHE_SIZE_BYTES)
+        )
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/data/settings/PlaybackPreferenceSnapshotTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/settings/PlaybackPreferenceSnapshotTest.kt
@@ -73,6 +73,15 @@ class PlaybackPreferenceSnapshotTest {
     }
 
     @Test
+    fun `preferences preserve unlimited cache setting`() {
+        val snapshot = preferencesOf(
+            SettingsKeys.MAX_CACHE_SIZE_BYTES to CacheSizePolicy.UNLIMITED_CACHE_SIZE_BYTES
+        ).toPlaybackPreferenceSnapshot()
+
+        assertEquals(CacheSizePolicy.UNLIMITED_CACHE_SIZE_BYTES, snapshot.maxCacheSizeBytes)
+    }
+
+    @Test
     fun `sanitized normalizes playback runtime values`() {
         val snapshot = PlaybackPreferenceSnapshot(
             playbackFadeInDurationMs = -100L,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 新增“无限制”缓存选项。滑块末端表示无限缓存。
- 保留无缓存选项和 10 GB 的最大有限缓存值。
- 统一规范化缓存设置，兼容并修正非法持久化值。
- 播放器对无限缓存不执行缓存淘汰。
- 新增测试，覆盖无限缓存、最大有限值、无缓存阈值、非法值修正和设置持久化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->