### PR TITLE
feat: implement cross-process WebView state clearing and platform-specific logout

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,6 +102,15 @@
             android:process=":netease_login"
             android:theme="@style/Theme.Material3.DayNight.NoActionBar"
         />
+        <receiver
+            android:name=".data.auth.web.NeteaseWebViewLoginStateClearReceiver"
+            android:exported="false"
+            android:process=":netease_login"
+        >
+            <intent-filter>
+                <action android:name="moe.ouom.neriplayer.action.CLEAR_WEBVIEW_LOGIN_STATE" />
+            </intent-filter>
+        </receiver>
         <activity
             android:name=".activity.auth.BiliWebLoginActivity"
             android:exported="false"
@@ -114,12 +123,30 @@
             android:process=":bili_web_login"
             android:theme="@style/Theme.Material3.DayNight.NoActionBar"
             />
+        <receiver
+            android:name=".data.auth.web.BiliWebViewLoginStateClearReceiver"
+            android:exported="false"
+            android:process=":bili_web_login"
+        >
+            <intent-filter>
+                <action android:name="moe.ouom.neriplayer.action.CLEAR_WEBVIEW_LOGIN_STATE" />
+            </intent-filter>
+        </receiver>
         <activity
             android:name=".activity.auth.YouTubeWebLoginActivity"
             android:exported="false"
             android:process=":youtube_web_login"
             android:theme="@style/Theme.Material3.DayNight.NoActionBar"
             />
+        <receiver
+            android:name=".data.auth.web.YouTubeWebViewLoginStateClearReceiver"
+            android:exported="false"
+            android:process=":youtube_web_login"
+        >
+            <intent-filter>
+                <action android:name="moe.ouom.neriplayer.action.CLEAR_WEBVIEW_LOGIN_STATE" />
+            </intent-filter>
+        </receiver>
         <service
             android:name="moe.ouom.neriplayer.core.player.service.AudioPlayerService"
             android:exported="false"

--- a/app/src/main/java/moe/ouom/neriplayer/activity/auth/NeteaseWebLoginActivity.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/activity/auth/NeteaseWebLoginActivity.kt
@@ -47,12 +47,15 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.launch
 import moe.ouom.neriplayer.R
 import moe.ouom.neriplayer.data.auth.web.ForegroundWebLoginGuard
+import moe.ouom.neriplayer.data.auth.web.clearWebViewLoginState
 import moe.ouom.neriplayer.data.auth.web.normalizeNeteaseWebLoginCookies
 import moe.ouom.neriplayer.data.auth.web.shouldAutoCompleteNeteaseWebLogin
 import moe.ouom.neriplayer.core.logging.NPLogger
@@ -66,16 +69,11 @@ class NeteaseWebLoginActivity : ComponentActivity() {
     companion object {
         const val RESULT_COOKIE = "result_cookie_map_json"
         private const val LOG_TAG = "NERI-NeteaseLogin"
-        private const val TARGET_URL = "https://music.163.com/"
         private val ALLOWED_LOGIN_DOMAINS = setOf(
             "163.com",
             "126.net",
             "163yun.com"
         )
-        private const val DESKTOP_UA =
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
-                    "AppleWebKit/537.36 (KHTML, like Gecko) " +
-                    "Chrome/124.0.0.0 Safari/537.36"
     }
 
     private lateinit var webView: WebView
@@ -92,6 +90,10 @@ class NeteaseWebLoginActivity : ComponentActivity() {
         enableEdgeToEdge()
         WindowCompat.setDecorFitsSystemWindows(window, false)
         foregroundWebLoginToken = ForegroundWebLoginGuard.enter("netease")
+        val webLoginSettings = resolveNeteaseWebLoginWebSettings(
+            smallestScreenWidthDp = resources.configuration.smallestScreenWidthDp,
+            defaultUserAgent = WebSettings.getDefaultUserAgent(this)
+        )
 
         val root = CoordinatorLayout(this).apply {
             fitsSystemWindows = false
@@ -139,9 +141,10 @@ class NeteaseWebLoginActivity : ComponentActivity() {
                 mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
                 allowFileAccess = false
                 allowContentAccess = false
-                userAgentString = DESKTOP_UA
-                useWideViewPort = true
-                loadWithOverviewMode = true
+                cacheMode = WebSettings.LOAD_NO_CACHE
+                userAgentString = webLoginSettings.userAgent
+                useWideViewPort = webLoginSettings.useWideViewPort
+                loadWithOverviewMode = webLoginSettings.loadWithOverviewMode
                 setSupportZoom(true)
                 builtInZoomControls = true
                 displayZoomControls = false
@@ -181,9 +184,15 @@ class NeteaseWebLoginActivity : ComponentActivity() {
             }
         )
 
-        initialCookies = readCookieMap()
-        loginCompletionWatcher.start()
-        webView.loadUrl(TARGET_URL)
+        lifecycleScope.launch {
+            // 登录页位于独立进程，打开时先清掉上一次的浏览器会话
+            clearWebViewLoginState()
+            webView.clearCache(true)
+            webView.clearHistory()
+            initialCookies = readCookieMap()
+            loginCompletionWatcher.start()
+            webView.loadUrl(webLoginSettings.url)
+        }
     }
 
     override fun onResume() {
@@ -267,9 +276,12 @@ class NeteaseWebLoginActivity : ComponentActivity() {
     private fun readCookieMap(): Map<String, String> {
         val cm = CookieManager.getInstance()
         val main = cm.getCookie("https://music.163.com").orEmpty()
+        val mobile = cm.getCookie("https://y.music.163.com").orEmpty()
         val api = cm.getCookie("https://interface.music.163.com").orEmpty()
         val api3 = cm.getCookie("https://interface3.music.163.com").orEmpty()
-        val merged = listOf(main, api, api3).filter { it.isNotBlank() }.joinToString("; ")
+        val merged = listOf(main, mobile, api, api3)
+            .filter { it.isNotBlank() }
+            .joinToString("; ")
         if (merged.isBlank()) {
             return emptyMap()
         }

--- a/app/src/main/java/moe/ouom/neriplayer/activity/auth/NeteaseWebLoginUrl.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/activity/auth/NeteaseWebLoginUrl.kt
@@ -1,0 +1,63 @@
+package moe.ouom.neriplayer.activity.auth
+
+import moe.ouom.neriplayer.util.platform.PHONE_SMALLEST_SCREEN_WIDTH_DP
+
+internal const val NETEASE_MOBILE_LOGIN_URL = "https://music.163.com/m/login"
+internal const val NETEASE_DESKTOP_LOGIN_URL = "https://music.163.com/"
+internal const val NETEASE_MOBILE_WEB_USER_AGENT =
+    "Mozilla/5.0 (Linux; Android 10; NeriPlayer) AppleWebKit/537.36 " +
+        "(KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36"
+internal const val NETEASE_DESKTOP_WEB_USER_AGENT =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+
+internal data class NeteaseWebLoginWebSettings(
+    val url: String,
+    val userAgent: String,
+    val useWideViewPort: Boolean,
+    val loadWithOverviewMode: Boolean
+)
+
+internal fun resolveNeteaseWebLoginWebSettings(
+    smallestScreenWidthDp: Int,
+    defaultUserAgent: String? = null
+): NeteaseWebLoginWebSettings {
+    val isPhone = smallestScreenWidthDp < PHONE_SMALLEST_SCREEN_WIDTH_DP
+    return if (isPhone) {
+        NeteaseWebLoginWebSettings(
+            url = NETEASE_MOBILE_LOGIN_URL,
+            userAgent = resolveNeteaseMobileUserAgent(defaultUserAgent),
+            // the mobile page has its own viewport meta tag; a wide viewport makes it
+            // match the desktop breakpoint even when the device is a phone
+            useWideViewPort = false,
+            loadWithOverviewMode = false
+        )
+    } else {
+        NeteaseWebLoginWebSettings(
+            url = NETEASE_DESKTOP_LOGIN_URL,
+            userAgent = NETEASE_DESKTOP_WEB_USER_AGENT,
+            useWideViewPort = true,
+            loadWithOverviewMode = true
+        )
+    }
+}
+
+internal fun resolveNeteaseWebLoginUrl(smallestScreenWidthDp: Int): String {
+    return resolveNeteaseWebLoginWebSettings(smallestScreenWidthDp).url
+}
+
+internal fun resolveNeteaseWebLoginUserAgent(smallestScreenWidthDp: Int): String {
+    return resolveNeteaseWebLoginWebSettings(smallestScreenWidthDp).userAgent
+}
+
+private fun resolveNeteaseMobileUserAgent(defaultUserAgent: String?): String {
+    val sanitized = defaultUserAgent
+        ?.replace("; wv", "")
+        ?.replace("Version/4.0 ", "")
+        ?.trim()
+        ?.takeIf { userAgent ->
+            userAgent.contains("Android", ignoreCase = true) &&
+                userAgent.contains("Mobile", ignoreCase = true)
+        }
+    return sanitized ?: NETEASE_MOBILE_WEB_USER_AGENT
+}

--- a/app/src/main/java/moe/ouom/neriplayer/core/startup/safemode/SafeModeResetActions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/startup/safemode/SafeModeResetActions.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import moe.ouom.neriplayer.data.auth.bili.BiliCookieRepository
 import moe.ouom.neriplayer.data.auth.netease.NeteaseCookieRepository
-import moe.ouom.neriplayer.data.auth.web.clearWebViewLoginState
+import moe.ouom.neriplayer.data.auth.web.clearAllWebViewLoginState
 import moe.ouom.neriplayer.data.auth.youtube.YouTubeAuthRepository
 import moe.ouom.neriplayer.data.settings.BootstrapSettingsSnapshot
 import moe.ouom.neriplayer.data.settings.PlaybackPreferenceSnapshot
@@ -27,7 +27,7 @@ internal class SafeModeResetActions(
             BiliCookieRepository(appContext).clear()
             YouTubeAuthRepository(appContext).clear()
         }
-        clearWebViewLoginState()
+        clearAllWebViewLoginState(appContext)
     }
 
     suspend fun resetAppSettings() {

--- a/app/src/main/java/moe/ouom/neriplayer/data/auth/web/WebViewLoginStateCleaner.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/auth/web/WebViewLoginStateCleaner.kt
@@ -1,20 +1,329 @@
 package moe.ouom.neriplayer.data.auth.web
 
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.webkit.CookieManager
 import android.webkit.WebStorage
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.UUID
 import kotlin.coroutines.resume
 
+internal const val ACTION_CLEAR_WEBVIEW_LOGIN_STATE =
+    "moe.ouom.neriplayer.action.CLEAR_WEBVIEW_LOGIN_STATE"
+internal const val ACTION_WEBVIEW_LOGIN_STATE_CLEARED =
+    "moe.ouom.neriplayer.action.WEBVIEW_LOGIN_STATE_CLEARED"
+internal const val EXTRA_WEBVIEW_CLEAR_REQUEST_ID =
+    "moe.ouom.neriplayer.extra.WEBVIEW_CLEAR_REQUEST_ID"
+internal const val EXTRA_WEBVIEW_CLEAR_RECEIVER =
+    "moe.ouom.neriplayer.extra.WEBVIEW_CLEAR_RECEIVER"
+internal const val EXTRA_WEBVIEW_CLEAR_SUCCEEDED =
+    "moe.ouom.neriplayer.extra.WEBVIEW_CLEAR_SUCCEEDED"
+
+private const val WEBVIEW_CLEAR_TIMEOUT_MS = 5_000L
+private const val COOKIE_EXPIRED = "; Expires=Thu, 01 Jan 1970 00:00:00 GMT; " +
+    "Max-Age=0; Path=/"
+
+internal enum class WebLoginPlatform {
+    NETEASE,
+    BILI,
+    YOUTUBE
+}
+
+private data class WebViewLoginStateClearTarget(
+    val platform: WebLoginPlatform,
+    val receiverClass: Class<out BroadcastReceiver>
+)
+
+private data class WebViewCookieScope(
+    val urls: List<String>,
+    val domains: List<String>,
+    val storageOrigins: List<String>
+)
+
+private val webViewLoginStateClearTargets = listOf(
+    WebViewLoginStateClearTarget(
+        platform = WebLoginPlatform.NETEASE,
+        receiverClass = NeteaseWebViewLoginStateClearReceiver::class.java
+    ),
+    WebViewLoginStateClearTarget(
+        platform = WebLoginPlatform.BILI,
+        receiverClass = BiliWebViewLoginStateClearReceiver::class.java
+    ),
+    WebViewLoginStateClearTarget(
+        platform = WebLoginPlatform.YOUTUBE,
+        receiverClass = YouTubeWebViewLoginStateClearReceiver::class.java
+    )
+)
+
+private val webViewCookieScopes = mapOf(
+    WebLoginPlatform.NETEASE to WebViewCookieScope(
+        urls = listOf(
+            "https://music.163.com",
+            "https://y.music.163.com",
+            "https://interface.music.163.com",
+            "https://interface3.music.163.com",
+            "https://api.music.163.com",
+            "https://163.com",
+            "https://126.net",
+            "https://163yun.com"
+        ),
+        domains = listOf(
+            ".music.163.com",
+            "music.163.com",
+            ".163.com",
+            "163.com",
+            ".126.net",
+            "126.net",
+            ".163yun.com",
+            "163yun.com"
+        ),
+        storageOrigins = listOf(
+            "https://music.163.com",
+            "https://y.music.163.com",
+            "https://interface.music.163.com",
+            "https://interface3.music.163.com",
+            "https://api.music.163.com"
+        )
+    ),
+    WebLoginPlatform.BILI to WebViewCookieScope(
+        urls = listOf(
+            "https://bilibili.com",
+            "https://passport.bilibili.com",
+            "https://www.bilibili.com",
+            "https://m.bilibili.com"
+        ),
+        domains = listOf(".bilibili.com"),
+        storageOrigins = listOf(
+            "https://bilibili.com",
+            "https://passport.bilibili.com",
+            "https://www.bilibili.com",
+            "https://m.bilibili.com"
+        )
+    ),
+    WebLoginPlatform.YOUTUBE to WebViewCookieScope(
+        urls = listOf(
+            "https://accounts.google.com",
+            "https://www.google.com",
+            "https://google.com",
+            "https://music.youtube.com",
+            "https://www.youtube.com",
+            "https://m.youtube.com",
+            "https://youtube.com"
+        ),
+        domains = listOf(".google.com", ".youtube.com"),
+        storageOrigins = listOf(
+            "https://accounts.google.com",
+            "https://www.google.com",
+            "https://google.com",
+            "https://music.youtube.com",
+            "https://www.youtube.com",
+            "https://m.youtube.com",
+            "https://youtube.com"
+        )
+    )
+)
+
 internal suspend fun clearWebViewLoginState() {
+    clearCurrentProcessWebViewLoginState(platform = null)
+}
+
+internal suspend fun clearWebViewLoginState(platform: WebLoginPlatform) {
+    clearCurrentProcessWebViewLoginState(platform)
+}
+
+internal suspend fun clearWebViewLoginStateInDedicatedProcess() {
+    clearCurrentProcessWebViewLoginState(platform = null)
+}
+
+internal suspend fun clearWebViewLoginState(
+    context: Context,
+    platform: WebLoginPlatform
+) {
+    clearWebViewLoginState(platform)
+    requestRemoteWebViewLoginStateClear(
+        context = context,
+        platforms = setOf(platform)
+    )
+}
+
+internal suspend fun clearAllWebViewLoginState(context: Context) {
+    clearWebViewLoginState()
+    requestRemoteWebViewLoginStateClear(
+        context = context,
+        platforms = WebLoginPlatform.entries.toSet()
+    )
+}
+
+internal fun remoteWebViewLoginStateClearReceiverNames(
+    platforms: Set<WebLoginPlatform>
+): List<String> {
+    return webViewLoginStateClearTargets
+        .filter { it.platform in platforms }
+        .map { it.receiverClass.name }
+}
+
+private suspend fun clearCurrentProcessWebViewLoginState(
+    platform: WebLoginPlatform?
+) {
     withContext(Dispatchers.Main.immediate) {
         val cookieManager = CookieManager.getInstance()
-        cookieManager.removeAllCookiesAwait()
-        cookieManager.removeSessionCookiesAwait()
+        val knownCookies = runCatching {
+            collectKnownCookieNames(
+                platforms = platform?.let { setOf(it) }
+                    ?: WebLoginPlatform.entries.toSet()
+            )
+        }.onFailure { error ->
+            moe.ouom.neriplayer.core.logging.NPLogger.w(
+                "NERI-WebLoginState",
+                "Could not snapshot WebView cookies before clearing",
+                error
+            )
+        }.getOrDefault(emptyMap())
+        if (platform == null) {
+            cookieManager.removeAllCookiesAwait()
+            cookieManager.removeSessionCookiesAwait()
+            runCatching { clearKnownCookies(cookieManager, knownCookies) }
+                .onFailure { error ->
+                    moe.ouom.neriplayer.core.logging.NPLogger.w(
+                        "NERI-WebLoginState",
+                        "Could not expire known WebView cookies after full clear",
+                        error
+                    )
+                }
+            WebStorage.getInstance().deleteAllData()
+        } else {
+            clearKnownCookies(cookieManager, knownCookies)
+            webViewCookieScopes.getValue(platform).storageOrigins.forEach { origin ->
+                WebStorage.getInstance().deleteOrigin(origin)
+            }
+        }
         cookieManager.flush()
-        WebStorage.getInstance().deleteAllData()
     }
+}
+
+private fun collectKnownCookieNames(
+    platforms: Set<WebLoginPlatform>
+): Map<WebLoginPlatform, Map<String, List<String>>> {
+    val result = linkedMapOf<WebLoginPlatform, Map<String, List<String>>>()
+    val cookieManager = CookieManager.getInstance()
+    platforms.forEach { platform ->
+        result[platform] = webViewCookieScopes.getValue(platform).urls.associateWith { url ->
+            cookieNames(cookieManager.getCookie(url).orEmpty())
+        }
+    }
+    return result
+}
+
+private suspend fun clearKnownCookies(
+    cookieManager: CookieManager,
+    knownCookies: Map<WebLoginPlatform, Map<String, List<String>>>
+) {
+    knownCookies.forEach { (platform, cookiesByUrl) ->
+        val scope = webViewCookieScopes.getValue(platform)
+        cookiesByUrl.forEach { (url, names) ->
+            names.forEach { name ->
+                cookieManager.setCookieAwait(url, "$name=$COOKIE_EXPIRED")
+                scope.domains.forEach { domain ->
+                    cookieManager.setCookieAwait(
+                        url,
+                        "$name=$COOKIE_EXPIRED; Domain=$domain"
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun cookieNames(rawCookieHeader: String): List<String> {
+    return rawCookieHeader
+        .split(';')
+        .mapNotNull { item ->
+            val separator = item.indexOf('=')
+            item.takeIf { separator > 0 }
+                ?.substring(0, separator)
+                ?.trim()
+                ?.takeIf(String::isNotBlank)
+        }
+        .distinct()
+}
+
+private suspend fun requestRemoteWebViewLoginStateClear(
+    context: Context,
+    platforms: Set<WebLoginPlatform>
+) {
+    val appContext = context.applicationContext
+    val targets = webViewLoginStateClearTargets.filter { it.platform in platforms }
+    if (targets.isEmpty()) {
+        return
+    }
+
+    withContext(Dispatchers.Main.immediate) {
+        val requestId = UUID.randomUUID().toString()
+        val targetComponents = targets.map { target ->
+            ComponentName(appContext.packageName, target.receiverClass.name)
+        }
+        val completedTargets = linkedSetOf<ComponentName>()
+        val completed = CompletableDeferred<Unit>()
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                if (intent.getStringExtra(EXTRA_WEBVIEW_CLEAR_REQUEST_ID) != requestId) {
+                    return
+                }
+                val receiverName = intent.getStringExtra(EXTRA_WEBVIEW_CLEAR_RECEIVER)
+                    ?: return
+                val component = ComponentName(appContext.packageName, receiverName)
+                if (!intent.getBooleanExtra(EXTRA_WEBVIEW_CLEAR_SUCCEEDED, false)) {
+                    moe.ouom.neriplayer.core.logging.NPLogger.w(
+                        "NERI-WebLoginState",
+                        "Remote WebView state clear failed: $receiverName"
+                    )
+                }
+                completedTargets += component
+                if (completedTargets.containsAll(targetComponents)) {
+                    completed.complete(Unit)
+                }
+            }
+        }
+        ContextCompat.registerReceiver(
+            appContext,
+            receiver,
+            IntentFilter(ACTION_WEBVIEW_LOGIN_STATE_CLEARED),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
+        try {
+            targets.forEachIndexed { index, _ ->
+                appContext.sendBroadcast(
+                    Intent(ACTION_CLEAR_WEBVIEW_LOGIN_STATE)
+                        .addFlags(Intent.FLAG_RECEIVER_FOREGROUND)
+                        .setComponent(targetComponents[index])
+                        .putExtra(EXTRA_WEBVIEW_CLEAR_REQUEST_ID, requestId)
+                )
+            }
+            if (withTimeoutOrNull(WEBVIEW_CLEAR_TIMEOUT_MS) { completed.await() } == null) {
+                val missing = targetComponents
+                    .map { it.className }
+                    .filterNot { className -> completedTargets.containsClassName(className) }
+                moe.ouom.neriplayer.core.logging.NPLogger.w(
+                    "NERI-WebLoginState",
+                    "Timed out clearing remote WebView state: ${missing.joinToString()}"
+                )
+            }
+        } finally {
+            appContext.unregisterReceiver(receiver)
+        }
+    }
+}
+
+private fun Set<ComponentName>.containsClassName(className: String): Boolean {
+    return any { component -> component.className == className }
 }
 
 private suspend fun CookieManager.removeAllCookiesAwait() {
@@ -30,6 +339,19 @@ private suspend fun CookieManager.removeAllCookiesAwait() {
 private suspend fun CookieManager.removeSessionCookiesAwait() {
     suspendCancellableCoroutine { continuation ->
         removeSessionCookies {
+            if (continuation.isActive) {
+                continuation.resume(Unit)
+            }
+        }
+    }
+}
+
+private suspend fun CookieManager.setCookieAwait(
+    url: String,
+    value: String
+) {
+    suspendCancellableCoroutine { continuation ->
+        setCookie(url, value) {
             if (continuation.isActive) {
                 continuation.resume(Unit)
             }

--- a/app/src/main/java/moe/ouom/neriplayer/data/auth/web/WebViewLoginStateClearReceiver.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/auth/web/WebViewLoginStateClearReceiver.kt
@@ -1,0 +1,63 @@
+package moe.ouom.neriplayer.data.auth.web
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import moe.ouom.neriplayer.core.logging.NPLogger
+
+internal abstract class WebViewLoginStateClearReceiver(
+    private val platform: WebLoginPlatform
+) : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_CLEAR_WEBVIEW_LOGIN_STATE) {
+            return
+        }
+        val requestId = intent.getStringExtra(EXTRA_WEBVIEW_CLEAR_REQUEST_ID) ?: return
+        NPLogger.d(
+            "NERI-WebLoginState",
+            "Received WebView state clear request for $platform"
+        )
+        val pendingResult = goAsync()
+        CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate).launch {
+            val succeeded = runCatching {
+                // 每个登录接收器都有独立的 WebView 数据目录，因此可以完整清理
+                // 这样也能覆盖未知域名或路径的 Cookie
+                clearWebViewLoginStateInDedicatedProcess()
+            }.onFailure { error ->
+                NPLogger.e(
+                    "NERI-WebLoginState",
+                    "Failed to clear $platform WebView state in login process",
+                    error
+                )
+            }.isSuccess
+            NPLogger.d(
+                "NERI-WebLoginState",
+                "Finished WebView state clear for $platform succeeded=$succeeded"
+            )
+            try {
+                context.sendBroadcast(
+                    Intent(ACTION_WEBVIEW_LOGIN_STATE_CLEARED)
+                        .setPackage(context.packageName)
+                        .putExtra(EXTRA_WEBVIEW_CLEAR_REQUEST_ID, requestId)
+                        .putExtra(EXTRA_WEBVIEW_CLEAR_RECEIVER, javaClass.name)
+                        .putExtra(EXTRA_WEBVIEW_CLEAR_SUCCEEDED, succeeded)
+                )
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+}
+
+internal class NeteaseWebViewLoginStateClearReceiver :
+    WebViewLoginStateClearReceiver(WebLoginPlatform.NETEASE)
+
+internal class BiliWebViewLoginStateClearReceiver :
+    WebViewLoginStateClearReceiver(WebLoginPlatform.BILI)
+
+internal class YouTubeWebViewLoginStateClearReceiver :
+    WebViewLoginStateClearReceiver(WebLoginPlatform.YOUTUBE)

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/auth/BiliAuthViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/auth/BiliAuthViewModel.kt
@@ -39,6 +39,7 @@ import moe.ouom.neriplayer.core.di.AppContainer
 import moe.ouom.neriplayer.data.auth.common.parseRawCookieText
 import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthHealth
 import moe.ouom.neriplayer.data.auth.web.clearWebViewLoginState
+import moe.ouom.neriplayer.data.auth.web.WebLoginPlatform
 import org.json.JSONObject
 
 data class BiliAuthUiState(
@@ -99,7 +100,10 @@ class BiliAuthViewModel(app: Application) : AndroidViewModel(app) {
     fun clearCookies() {
         viewModelScope.launch(Dispatchers.IO) {
             repo.clear()
-            clearWebViewLoginState()
+            clearWebViewLoginState(
+                context = getApplication(),
+                platform = WebLoginPlatform.BILI
+            )
             _events.send(
                 BiliAuthEvent.ShowSnack(
                     getApplication<Application>().getString(R.string.auth_cookie_cleared)

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/auth/YouTubeAuthViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/auth/YouTubeAuthViewModel.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.launch
 import moe.ouom.neriplayer.R
 import moe.ouom.neriplayer.core.di.AppContainer
 import moe.ouom.neriplayer.data.auth.web.clearWebViewLoginState
+import moe.ouom.neriplayer.data.auth.web.WebLoginPlatform
 import moe.ouom.neriplayer.data.auth.youtube.YouTubeAuthBundle
 import moe.ouom.neriplayer.data.auth.youtube.YouTubeAuthHealth
 import moe.ouom.neriplayer.data.auth.youtube.YouTubeAuthState
@@ -102,7 +103,10 @@ class YouTubeAuthViewModel(app: Application) : AndroidViewModel(app) {
     fun clearAuth() {
         viewModelScope.launch(Dispatchers.IO) {
             repo.clear()
-            clearWebViewLoginState()
+            clearWebViewLoginState(
+                context = getApplication<Application>(),
+                platform = WebLoginPlatform.YOUTUBE
+            )
             _events.send(
                 YouTubeAuthEvent.ShowSnack(
                     getApplication<Application>().getString(R.string.auth_cookie_cleared)

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/debug/NeteaseAuthViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/debug/NeteaseAuthViewModel.kt
@@ -39,6 +39,7 @@ import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthHealth
 import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthState
 import moe.ouom.neriplayer.data.auth.common.parseRawCookieText
 import moe.ouom.neriplayer.data.auth.web.clearWebViewLoginState
+import moe.ouom.neriplayer.data.auth.web.WebLoginPlatform
 import org.json.JSONObject
 
 data class NeteaseAuthUiState(
@@ -115,7 +116,10 @@ class NeteaseAuthViewModel(app: Application) : AndroidViewModel(app) {
             runCatching { api.logout() }
             cookieStore.clear()
             cookieRepo.clear()
-            clearWebViewLoginState()
+            clearWebViewLoginState(
+                context = getApplication<Application>(),
+                platform = WebLoginPlatform.NETEASE
+            )
             _events.tryEmit(
                 NeteaseAuthEvent.ShowSnack(
                     getApplication<Application>().getString(R.string.auth_cookie_cleared)

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/debug/YouTubeApiProbeViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/debug/YouTubeApiProbeViewModel.kt
@@ -41,6 +41,7 @@ import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicDebugProbeResult
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicLocaleResolver
 import moe.ouom.neriplayer.core.di.AppContainer
 import moe.ouom.neriplayer.data.auth.web.clearWebViewLoginState
+import moe.ouom.neriplayer.data.auth.web.WebLoginPlatform
 import moe.ouom.neriplayer.data.auth.youtube.YouTubeAuthState
 
 data class YouTubeApiProbeUiState(
@@ -191,7 +192,10 @@ class YouTubeApiProbeViewModel(app: Application) : AndroidViewModel(app) {
         viewModelScope.launch(Dispatchers.IO) {
             authRepo.clear()
             client.clearBootstrapCache()
-            clearWebViewLoginState()
+            clearWebViewLoginState(
+                context = getApplication<Application>(),
+                platform = WebLoginPlatform.YOUTUBE
+            )
             _ui.value = _ui.value.copy(
                 running = false,
                 authSummary = buildAuthSummary(),

--- a/app/src/main/java/moe/ouom/neriplayer/util/platform/DeviceUtil.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/util/platform/DeviceUtil.kt
@@ -34,6 +34,7 @@ import kotlin.math.roundToInt
 
 internal const val ONEPLUS_HIGH_DENSITY_DPI_THRESHOLD = 500
 internal const val ONEPLUS_HIGH_DENSITY_UI_SCALE = 0.95f
+internal const val PHONE_SMALLEST_SCREEN_WIDTH_DP = 600
 
 internal fun isOnePlusHighDensityDisplay(
     manufacturer: String?,
@@ -112,7 +113,7 @@ private fun Context.hasOnePlusHighDensityCorrection(): Boolean {
  * 仅对手机锁定竖屏，平板等大屏设备保持系统默认方向
  */
 fun Activity.lockPortraitIfPhone() {
-    val isPhone = resources.configuration.smallestScreenWidthDp < 600
+    val isPhone = resources.configuration.smallestScreenWidthDp < PHONE_SMALLEST_SCREEN_WIDTH_DP
     requestedOrientation = if (isPhone) {
         ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     } else {

--- a/app/src/test/java/moe/ouom/neriplayer/activity/auth/NeteaseWebLoginUrlTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/activity/auth/NeteaseWebLoginUrlTest.kt
@@ -1,0 +1,78 @@
+package moe.ouom.neriplayer.activity.auth
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NeteaseWebLoginUrlTest {
+    @Test
+    fun phoneUsesMobileLoginPage() {
+        assertEquals(
+            NETEASE_MOBILE_LOGIN_URL,
+            resolveNeteaseWebLoginUrl(smallestScreenWidthDp = 599)
+        )
+    }
+
+    @Test
+    fun tabletUsesDesktopLoginPageAtTabletBoundary() {
+        assertEquals(
+            NETEASE_DESKTOP_LOGIN_URL,
+            resolveNeteaseWebLoginUrl(smallestScreenWidthDp = 600)
+        )
+    }
+
+    @Test
+    fun largeTabletUsesDesktopLoginPage() {
+        assertEquals(
+            NETEASE_DESKTOP_LOGIN_URL,
+            resolveNeteaseWebLoginUrl(smallestScreenWidthDp = 840)
+        )
+    }
+
+    @Test
+    fun phoneUsesMobileBrowserUserAgent() {
+        val userAgent = resolveNeteaseWebLoginUserAgent(smallestScreenWidthDp = 599)
+
+        assertEquals(NETEASE_MOBILE_WEB_USER_AGENT, userAgent)
+        org.junit.Assert.assertTrue(userAgent.contains("Android"))
+        org.junit.Assert.assertTrue(userAgent.contains("Mobile"))
+        org.junit.Assert.assertFalse(userAgent.contains("Windows"))
+    }
+
+    @Test
+    fun phoneUsesDeviceMobileUserAgentWithoutWebViewMarkers() {
+        val settings = resolveNeteaseWebLoginWebSettings(
+            smallestScreenWidthDp = 411,
+            defaultUserAgent =
+                "Mozilla/5.0 (Linux; Android 14; Pixel 8) " +
+                    "AppleWebKit/537.36 (KHTML, like Gecko) " +
+                    "Version/4.0 Chrome/140.0 Mobile Safari/537.36; wv"
+        )
+
+        org.junit.Assert.assertEquals(
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8) " +
+                "AppleWebKit/537.36 (KHTML, like Gecko) " +
+                "Chrome/140.0 Mobile Safari/537.36",
+            settings.userAgent
+        )
+        org.junit.Assert.assertFalse(settings.userAgent.contains("; wv"))
+        org.junit.Assert.assertFalse(settings.userAgent.contains("Version/4.0"))
+    }
+
+    @Test
+    fun phoneUsesDeviceViewportInsteadOfDesktopWideViewport() {
+        val settings = resolveNeteaseWebLoginWebSettings(smallestScreenWidthDp = 411)
+
+        org.junit.Assert.assertEquals(NETEASE_MOBILE_LOGIN_URL, settings.url)
+        org.junit.Assert.assertFalse(settings.useWideViewPort)
+        org.junit.Assert.assertFalse(settings.loadWithOverviewMode)
+    }
+
+    @Test
+    fun tabletUsesDesktopBrowserUserAgent() {
+        val settings = resolveNeteaseWebLoginWebSettings(smallestScreenWidthDp = 600)
+
+        assertEquals(NETEASE_DESKTOP_WEB_USER_AGENT, settings.userAgent)
+        org.junit.Assert.assertTrue(settings.useWideViewPort)
+        org.junit.Assert.assertTrue(settings.loadWithOverviewMode)
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/data/auth/web/WebViewLoginStateCleanerTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/auth/web/WebViewLoginStateCleanerTest.kt
@@ -1,0 +1,34 @@
+package moe.ouom.neriplayer.data.auth.web
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WebViewLoginStateCleanerTest {
+    @Test
+    fun platformLogoutTargetsOnlyItsLoginProcess() {
+        assertEquals(
+            listOf(NeteaseWebViewLoginStateClearReceiver::class.java.name),
+            remoteWebViewLoginStateClearReceiverNames(setOf(WebLoginPlatform.NETEASE))
+        )
+        assertEquals(
+            listOf(BiliWebViewLoginStateClearReceiver::class.java.name),
+            remoteWebViewLoginStateClearReceiverNames(setOf(WebLoginPlatform.BILI))
+        )
+        assertEquals(
+            listOf(YouTubeWebViewLoginStateClearReceiver::class.java.name),
+            remoteWebViewLoginStateClearReceiverNames(setOf(WebLoginPlatform.YOUTUBE))
+        )
+    }
+
+    @Test
+    fun fullLoginResetTargetsAllLoginProcesses() {
+        assertEquals(
+            listOf(
+                NeteaseWebViewLoginStateClearReceiver::class.java.name,
+                BiliWebViewLoginStateClearReceiver::class.java.name,
+                YouTubeWebViewLoginStateClearReceiver::class.java.name
+            ),
+            remoteWebViewLoginStateClearReceiverNames(WebLoginPlatform.entries.toSet())
+        )
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 用户可见行为
- 退出登录时按平台清理对应 WebView 的 Cookie、WebStorage、缓存和历史记录。
- 完整登录重置会同时清理网易云、哔哩哔哩和 YouTube 的 WebView 状态。
- 网易云登录页会根据设备尺寸选择移动端或桌面端配置。

## 兼容性影响
- WebView 状态清理支持跨登录进程执行。
- 仅允许应用内部广播触发清理，避免外部应用调用。
- 599dp 使用移动端配置，600dp 及以上使用桌面端配置。

## 测试
- 新增网易云登录页配置测试。
- 新增平台退出登录和完整登录重置的进程清理测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->