### PR TITLE
refactor: enhance media cache lifecycle and playback recovery logic

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -283,7 +283,8 @@ object PlayerManager {
     @Volatile
     internal var interactiveNowPlayingVisible: Boolean = false
 
-    internal lateinit var cache: Cache
+    @Volatile
+    internal var cache: Cache? = null
     internal var conditionalHttpFactory: ConditionalHttpDataSourceFactory? = null
 
     // Helper function to get localized string
@@ -823,7 +824,7 @@ object PlayerManager {
 
     internal fun isPlayerInitialized(): Boolean = this::player.isInitialized
 
-    internal fun isCacheInitialized(): Boolean = this::cache.isInitialized
+    internal fun isCacheInitialized(): Boolean = cache != null
 
     internal fun syncPlaybackControlPlayingState() {
         _playbackControlPlayingFlow.value = shouldShowPauseButtonForPlaybackControls(

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
@@ -114,6 +114,7 @@ import moe.ouom.neriplayer.core.player.persistence.scheduleStatePersist
 import moe.ouom.neriplayer.core.player.resolver.youtube.YouTubeSeekRefreshPolicy
 import moe.ouom.neriplayer.core.player.url.currentPlaybackCacheKeyForRecovery
 import moe.ouom.neriplayer.core.player.url.invalidateCachedResourceForPlaybackRecovery
+import moe.ouom.neriplayer.core.player.url.shouldInvalidateCachedResourceForPlaybackRecovery
 import moe.ouom.neriplayer.core.player.url.shouldAttemptUrlRefresh
 import moe.ouom.neriplayer.core.player.url.youtubePlaybackRecoveryStrategyForError
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathTracker
@@ -218,6 +219,12 @@ private fun createVerifiedMediaCache(
             )
         }
         .getOrNull()
+}
+
+internal fun PlayerManager.releaseMediaCache() {
+    val mediaCache = cache
+    cache = null
+    mediaCache?.release()
 }
 
 internal fun PlayerManager.initializeImpl(
@@ -345,6 +352,7 @@ internal fun PlayerManager.initializeImpl(
                 databaseProvider = dbProvider
             )
             if (mediaCache == null) {
+                cache = null
                 androidx.media3.datasource.DefaultDataSource.Factory(app, conditionalFactory)
             } else {
                 cache = mediaCache
@@ -465,12 +473,17 @@ internal fun PlayerManager.initializeImpl(
                 val currentSong = _currentSongFlow.value
                 val currentUrl = _currentMediaUrl.value
                 val isOfflineCache = currentUrl?.startsWith("http://offline.cache/") == true
+                val shouldInvalidateCache =
+                    shouldInvalidateCachedResourceForPlaybackRecovery(error)
 
                 val cause = error.cause
                 val shouldResumeAfterRecovery = resumePlaybackRequested || player.playWhenReady || player.isPlaying
                 if (
                     shouldResumeAfterRecovery &&
-                    trySwitchToNextPlaybackCandidateForRecovery(reason = "player_error_${error.errorCodeName}")
+                    trySwitchToNextPlaybackCandidateForRecovery(
+                        reason = "player_error_${error.errorCodeName}",
+                        invalidateCurrentCache = shouldInvalidateCache
+                    )
                 ) {
                     return
                 }
@@ -481,8 +494,11 @@ internal fun PlayerManager.initializeImpl(
                         song = currentSong,
                         isOfflineCache = isOfflineCache
                     )
-                    val cacheKeyToInvalidateBeforeResolve =
+                    val cacheKeyToInvalidateBeforeResolve = if (shouldInvalidateCache) {
                         currentPlaybackCacheKeyForRecovery()
+                    } else {
+                        null
+                    }
                     val shouldBypassRefreshCooldown = (
                         pendingSeekPositionOrNull() != null &&
                             YouTubeSeekRefreshPolicy.shouldRefreshUrlBeforeSeek(
@@ -1182,10 +1198,8 @@ internal fun PlayerManager.initializeImpl(
             NPLogger.w("NERI-PlayerManager", "initialize(): rollback release effects failed: ${it.message}")
         }
         runCatching {
-            if (isCacheInitialized()) {
-                cache.release()
-                NPLogger.d("NERI-PlayerManager", "initialize(): rollback released cache")
-            }
+            releaseMediaCache()
+            NPLogger.d("NERI-PlayerManager", "initialize(): rollback released cache")
         }.onFailure {
             NPLogger.w("NERI-PlayerManager", "initialize(): rollback release cache failed: ${it.message}")
         }
@@ -1227,13 +1241,14 @@ internal suspend fun PlayerManager.clearCacheImpl(
 
         try {
             if (clearAudio) {
-                if (isCacheInitialized()) {
-                    val keysSnapshot = HashSet(cache.keys)
+                val mediaCache = cache
+                if (mediaCache != null) {
+                    val keysSnapshot = HashSet(mediaCache.keys)
                     keysSnapshot.forEach { key ->
                         try {
-                            val resource = cache.getCachedSpans(key)
+                            val resource = mediaCache.getCachedSpans(key)
                             resource.forEach { totalSpaceFreed += it.length }
-                            cache.removeResource(key)
+                            mediaCache.removeResource(key)
                             apiRemovedCount++
                         } catch (_: Exception) {
                         }
@@ -3763,9 +3778,7 @@ internal fun PlayerManager.releaseImpl() {
         _playbackSoundState.value = playbackEffectsController.release()
         _playWhenReadyFlow.value = false
         _playerPlaybackStateFlow.value = Player.STATE_IDLE
-        if (isCacheInitialized()) {
-            cache.release()
-        }
+        releaseMediaCache()
         conditionalHttpFactory?.close()
         conditionalHttpFactory = null
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
@@ -23,6 +23,7 @@ import androidx.media3.common.Timeline
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.database.StandaloneDatabaseProvider
 import androidx.media3.datasource.HttpDataSource
+import androidx.media3.datasource.cache.Cache.CacheException
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
 import androidx.media3.datasource.cache.NoOpCacheEvictor
@@ -114,8 +115,11 @@ import moe.ouom.neriplayer.core.player.persistence.scheduleStatePersist
 import moe.ouom.neriplayer.core.player.resolver.youtube.YouTubeSeekRefreshPolicy
 import moe.ouom.neriplayer.core.player.url.currentPlaybackCacheKeyForRecovery
 import moe.ouom.neriplayer.core.player.url.invalidateCachedResourceForPlaybackRecovery
-import moe.ouom.neriplayer.core.player.url.shouldInvalidateCachedResourceForPlaybackRecovery
+import moe.ouom.neriplayer.core.player.url.shouldInvalidateCacheAfterPlaybackFailure
+import moe.ouom.neriplayer.core.player.url.shouldInvalidateCacheForPlaybackRecovery
 import moe.ouom.neriplayer.core.player.url.shouldAttemptUrlRefresh
+import moe.ouom.neriplayer.core.player.url.shouldAdvanceAfterStuckTrackEnd
+import moe.ouom.neriplayer.core.player.url.shouldTreatPlaybackFailureAsTrackEnd
 import moe.ouom.neriplayer.core.player.url.youtubePlaybackRecoveryStrategyForError
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathTracker
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathState
@@ -153,6 +157,20 @@ private fun Throwable.isSimpleCacheFolderLocked(): Boolean {
         }
 }
 
+private fun Throwable.hasCacheInitializationFailure(): Boolean {
+    return generateSequence(this) { it.cause }
+        .any { it is CacheException }
+}
+
+internal fun shouldRebuildMediaCacheAfterInitializationFailure(error: Throwable): Boolean {
+    return !error.isSimpleCacheFolderLocked() && error.hasCacheInitializationFailure()
+}
+
+internal fun isMediaCacheDirectorySafeToOpen(cacheDir: File): Boolean {
+    return !cacheDir.exists() ||
+        (cacheDir.isDirectory && cacheDir.listFiles()?.isEmpty() == true)
+}
+
 private fun createVerifiedMediaCache(
     app: Application,
     maxCacheSize: Long,
@@ -186,10 +204,22 @@ private fun createVerifiedMediaCache(
     firstAttempt.getOrNull()?.let { return it }
 
     val firstError = firstAttempt.exceptionOrNull() ?: return null
-    if (firstError.isSimpleCacheFolderLocked()) {
+    if (
+        firstError.isSimpleCacheFolderLocked() ||
+            SimpleCache.isCacheFolderLocked(cacheDir)
+    ) {
         NPLogger.w(
             "NERI-PlayerManager",
             "media cache is already locked; continue without cache for this process",
+            firstError
+        )
+        return null
+    }
+
+    if (!shouldRebuildMediaCacheAfterInitializationFailure(firstError)) {
+        NPLogger.w(
+            "NERI-PlayerManager",
+            "media cache initialization failed outside the cache store; playback will bypass cache",
             firstError
         )
         return null
@@ -200,14 +230,22 @@ private fun createVerifiedMediaCache(
         "media cache initialization failed; rebuilding the cache directory",
         firstError
     )
-    runCatching {
+    val removedBrokenCache = runCatching {
         SimpleCache.delete(cacheDir, databaseProvider)
+        isMediaCacheDirectorySafeToOpen(cacheDir)
     }.onFailure { deleteError ->
         NPLogger.w(
             "NERI-PlayerManager",
             "failed to remove broken media cache; playback will bypass cache",
             deleteError
         )
+    }.getOrDefault(false)
+    if (!removedBrokenCache) {
+        NPLogger.w(
+            "NERI-PlayerManager",
+            "broken media cache could not be removed completely; playback will bypass cache"
+        )
+        return null
     }
 
     return runCatching { openCache() }
@@ -470,11 +508,27 @@ internal fun PlayerManager.initializeImpl(
                     return
                 }
 
+                if (shouldAdvanceAfterStuckTrackEnd(error, resumePlaybackRequested)) {
+                    NPLogger.w(
+                        "NERI-PlayerManager",
+                        "Media3 reported a track that did not end; advance the queue without invalidating cache"
+                    )
+                    handleTrackEndedIfNeeded(source = "media3_stuck_playing_not_ending")
+                    return
+                }
+                if (shouldTreatPlaybackFailureAsTrackEnd(error)) {
+                    NPLogger.d(
+                        "NERI-PlayerManager",
+                        "Ignore track-end timeout because playback is no longer requested"
+                    )
+                    return
+                }
+
                 val currentSong = _currentSongFlow.value
                 val currentUrl = _currentMediaUrl.value
                 val isOfflineCache = currentUrl?.startsWith("http://offline.cache/") == true
                 val shouldInvalidateCache =
-                    shouldInvalidateCachedResourceForPlaybackRecovery(error)
+                    shouldInvalidateCacheForPlaybackRecovery(error, isOfflineCache)
 
                 val cause = error.cause
                 val shouldResumeAfterRecovery = resumePlaybackRequested || player.playWhenReady || player.isPlaying
@@ -566,16 +620,21 @@ internal fun PlayerManager.initializeImpl(
                     return
                 }
 
-                val cacheKeyForFailure = currentPlaybackCacheKeyForRecovery()
                 if (isOfflineCache) {
                     pause()
                 } else {
                     mainScope.launch {
-                        cacheKeyForFailure?.let { cacheKey ->
-                            invalidateCachedResourceForPlaybackRecovery(
-                                cacheKey = cacheKey,
-                                reason = "unrecoverable_playback_${error.errorCodeName}"
+                        if (shouldInvalidateCacheAfterPlaybackFailure(
+                                shouldInvalidateCache = shouldInvalidateCache,
+                                isOfflineCache = isOfflineCache
                             )
+                        ) {
+                            currentPlaybackCacheKeyForRecovery()?.let { cacheKey ->
+                                invalidateCachedResourceForPlaybackRecovery(
+                                    cacheKey = cacheKey,
+                                    reason = "unrecoverable_playback_${error.errorCodeName}"
+                                )
+                            }
                         }
                         advanceAfterPlaybackFailure(
                             source = "playback_error_${error.errorCodeName}"
@@ -1236,8 +1295,6 @@ internal suspend fun PlayerManager.clearCacheImpl(
 ): Pair<Boolean, String> {
     return kotlinx.coroutines.withContext(Dispatchers.IO) {
         var apiRemovedCount = 0
-        var physicalDeletedCount = 0
-        var totalSpaceFreed = 0L
 
         try {
             if (clearAudio) {
@@ -1246,21 +1303,9 @@ internal suspend fun PlayerManager.clearCacheImpl(
                     val keysSnapshot = HashSet(mediaCache.keys)
                     keysSnapshot.forEach { key ->
                         try {
-                            val resource = mediaCache.getCachedSpans(key)
-                            resource.forEach { totalSpaceFreed += it.length }
                             mediaCache.removeResource(key)
                             apiRemovedCount++
                         } catch (_: Exception) {
-                        }
-                    }
-                }
-
-                val cacheDir = File(application.cacheDir, MEDIA_CACHE_DIRECTORY_NAME)
-                if (cacheDir.exists() && cacheDir.isDirectory) {
-                    val files = cacheDir.listFiles() ?: emptyArray()
-                    files.forEach { file ->
-                        if (file.isFile && file.name.endsWith(".exo") && file.delete()) {
-                            physicalDeletedCount++
                         }
                     }
                 }
@@ -1278,10 +1323,10 @@ internal suspend fun PlayerManager.clearCacheImpl(
 
             NPLogger.d(
                 "NERI-Player",
-                "Cache Clear: API removed $apiRemovedCount keys, Physically deleted $physicalDeletedCount .exo files."
+                "Cache Clear: removed $apiRemovedCount resources through SimpleCache."
             )
 
-            val msg = if (physicalDeletedCount > 0 || apiRemovedCount > 0 || clearImage) {
+            val msg = if (apiRemovedCount > 0 || clearImage) {
                 getLocalizedString(R.string.cache_clear_complete)
             } else {
                 getLocalizedString(R.string.settings_cache_empty)

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/PlayerManagerYouTubePrefetchExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/PlayerManagerYouTubePrefetchExtensions.kt
@@ -391,16 +391,14 @@ private suspend fun PlayerManager.prefetchIntoPlayerCache(
     cacheKey: String,
     targetBytes: Long
 ): Long = withContext(Dispatchers.IO) {
-    if (!isCacheInitialized()) {
-        return@withContext 0L
-    }
+    val mediaCache = cache ?: return@withContext 0L
     val upstreamFactory = conditionalHttpFactory ?: return@withContext 0L
     val requestedBytes = targetBytes.coerceAtLeast(YOUTUBE_WARMUP_MIN_PREFETCH_BYTES)
     if (playbackDemandArbiter.shouldYieldPrefetch(cacheKey)) {
         return@withContext 0L
     }
     val cacheDataSource = CacheDataSource.Factory()
-        .setCache(cache)
+        .setCache(mediaCache)
         .setUpstreamDataSourceFactory(upstreamFactory)
         .setFlags(
             CacheDataSource.FLAG_BLOCK_ON_CACHE or

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/PlayerManagerYouTubePrefetchExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/PlayerManagerYouTubePrefetchExtensions.kt
@@ -16,8 +16,10 @@ import moe.ouom.neriplayer.core.api.youtube.YouTubePlayableStreamType
 import moe.ouom.neriplayer.core.di.AppContainer
 import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.core.player.quality.effectiveYouTubeQuality
-import moe.ouom.neriplayer.core.player.url.checkExoPlayerCache
+import moe.ouom.neriplayer.core.player.url.CachePrefetchReadiness
+import moe.ouom.neriplayer.core.player.url.hasCompleteExoPlayerCache
 import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedResource
+import moe.ouom.neriplayer.core.player.url.prepareExoPlayerCacheForPrefetch
 import moe.ouom.neriplayer.core.player.policy.command.resolveYouTubeImmediatePlaybackWarmupTargets
 import moe.ouom.neriplayer.core.player.policy.command.resolveYouTubeWarmupTargets
 import moe.ouom.neriplayer.data.platform.youtube.extractYouTubeMusicVideoId
@@ -181,7 +183,7 @@ internal fun PlayerManager.kickoffYouTubePlaybackIntentWarmup(
         ?: return
     val preferredQuality = effectiveYouTubeQuality()
     val cacheKey = computeYouTubeCacheKey(videoId, preferredQuality)
-    if (checkExoPlayerCache(cacheKey)) {
+    if (hasCompleteExoPlayerCache(cacheKey)) {
         return
     }
     NPLogger.d(
@@ -260,6 +262,20 @@ private fun PlayerManager.canRunYouTubePrefetch(source: String): Boolean {
     return false
 }
 
+private suspend fun PlayerManager.shouldStartMediaCachePrefetch(cacheKey: String): Boolean {
+    return when (prepareExoPlayerCacheForPrefetch(cacheKey)) {
+        CachePrefetchReadiness.COMPLETE -> false
+        CachePrefetchReadiness.READY_FOR_PREFETCH -> true
+        CachePrefetchReadiness.UNAVAILABLE -> {
+            NPLogger.w(
+                "NERI-PlayerManager",
+                "skip YouTube media prefetch because the cache cannot be repaired safely: key=$cacheKey"
+            )
+            false
+        }
+    }
+}
+
 private fun PlayerManager.kickoffYouTubePlayableAudioPrefetches(
     videoIds: List<String>,
     preferredQuality: String,
@@ -288,7 +304,7 @@ private suspend fun PlayerManager.prefetchYouTubePlayableAudio(spec: YouTubePref
         )
         return
     }
-    if (checkExoPlayerCache(cacheKey)) {
+    if (!shouldStartMediaCachePrefetch(cacheKey)) {
         return
     }
     val existingJob = youtubeStreamWarmupJobs[cacheKey]
@@ -311,7 +327,10 @@ private suspend fun PlayerManager.prefetchYouTubePlayableAudio(spec: YouTubePref
         ) ?: return
         invalidateMismatchedCachedResource(
             cacheKey = cacheKey,
-            expectedContentLength = playableAudio.contentLength
+            expectedContentLength = playableAudio.contentLength,
+            shouldApplyMutation = {
+                !playbackDemandArbiter.shouldYieldPrefetch(cacheKey)
+            }
         )
         if (playbackDemandArbiter.shouldYieldPrefetch(cacheKey)) {
             NPLogger.d(
@@ -320,7 +339,7 @@ private suspend fun PlayerManager.prefetchYouTubePlayableAudio(spec: YouTubePref
             )
             return
         }
-        if (checkExoPlayerCache(cacheKey)) {
+        if (!shouldStartMediaCachePrefetch(cacheKey)) {
             return
         }
         if (playableAudio.streamType != YouTubePlayableStreamType.DIRECT) {

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerManagerUrlExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerManagerUrlExtensions.kt
@@ -507,6 +507,10 @@ internal fun shouldAttemptCachedPlaybackRepair(
     return isRecoverableRemotePlaybackCacheError(error)
 }
 
+internal fun shouldInvalidateCachedResourceForPlaybackRecovery(
+    error: PlaybackException
+): Boolean = isRecoverableRemotePlaybackCacheError(error)
+
 internal fun isRecoverableRemotePlaybackCacheError(error: PlaybackException): Boolean {
     return error.errorCode == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS ||
         error.errorCode == PlaybackException.ERROR_CODE_IO_INVALID_HTTP_CONTENT_TYPE ||
@@ -514,11 +518,7 @@ internal fun isRecoverableRemotePlaybackCacheError(error: PlaybackException): Bo
         error.errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED ||
         error.errorCode == PlaybackException.ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE ||
         error.errorCode == PlaybackException.ERROR_CODE_IO_UNSPECIFIED ||
-        error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT ||
-        error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_MALFORMED ||
-        error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED ||
-        error.errorCode == PlaybackException.ERROR_CODE_DECODING_FAILED ||
-        error.errorCode == PlaybackException.ERROR_CODE_DECODING_FORMAT_UNSUPPORTED
+        error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT
 }
 
 internal fun PlayerManager.youtubePlaybackRecoveryStrategyForError(
@@ -1080,17 +1080,16 @@ private fun PlayerManager.checkLocalCache(
 internal fun PlayerManager.inspectExoPlayerCache(
     cacheKey: String
 ): CachedResourceIntegrity {
+    val mediaCache = cache ?: return CachedResourceIntegrity(false, false, 0L)
     return try {
-        if (!isCacheInitialized()) {
-            return CachedResourceIntegrity(false, false, 0L)
-        }
-
-        val cachedSpans = cache.getCachedSpans(cacheKey)
+        val cachedSpans = mediaCache.getCachedSpans(cacheKey)
         if (cachedSpans.isEmpty()) {
             return CachedResourceIntegrity(false, false, 0L)
         }
 
-        val contentLength = ContentMetadata.getContentLength(cache.getContentMetadata(cacheKey))
+        val contentLength = ContentMetadata.getContentLength(
+            mediaCache.getContentMetadata(cacheKey)
+        )
         if (contentLength <= 0L) {
             NPLogger.d("NERI-PlayerManager", "缓存命中但缺少内容长度，视为未完成缓存: $cacheKey")
             return CachedResourceIntegrity(false, false, 0L)
@@ -1141,14 +1140,14 @@ internal suspend fun PlayerManager.invalidateMismatchedCachedResource(
     shouldApplyMutation: () -> Boolean = { true }
 ) = withContext(Dispatchers.IO) {
     val expectedLength = expectedContentLength?.takeIf { it > 0L } ?: return@withContext
-    if (!isCacheInitialized()) return@withContext
+    val mediaCache = cache ?: return@withContext
 
     try {
-        val cachedSpans = cache.getCachedSpans(cacheKey)
+        val cachedSpans = mediaCache.getCachedSpans(cacheKey)
         if (cachedSpans.isEmpty()) return@withContext
 
         val cachedContentLength = ContentMetadata.getContentLength(
-            cache.getContentMetadata(cacheKey)
+            mediaCache.getContentMetadata(cacheKey)
         )
         if (!shouldReplaceCachedPreviewResource(cachedContentLength, expectedLength)) {
             return@withContext
@@ -1159,7 +1158,7 @@ internal suspend fun PlayerManager.invalidateMismatchedCachedResource(
             "缓存疑似预览片段，移除旧缓存以便重新拉取完整资源: key=$cacheKey, cached=$cachedContentLength, expected=$expectedLength"
         )
         if (!shouldApplyMutation()) return@withContext
-        cache.removeResource(cacheKey)
+        mediaCache.removeResource(cacheKey)
     } catch (e: Exception) {
         NPLogger.w(
             "NERI-PlayerManager",
@@ -1189,9 +1188,9 @@ internal suspend fun PlayerManager.invalidateCachedResourceForPlaybackRecovery(
     reason: String
 ) = withContext(Dispatchers.IO) {
     if (cacheKey.isBlank()) return@withContext
-    if (!isCacheInitialized()) return@withContext
+    val mediaCache = cache ?: return@withContext
     try {
-        cache.removeResource(cacheKey)
+        mediaCache.removeResource(cacheKey)
         NPLogger.w(
             "NERI-PlayerManager",
             "已移除异常播放缓存: key=$cacheKey, reason=$reason"

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerManagerUrlExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerManagerUrlExtensions.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.SystemClock
 import androidx.core.net.toUri
 import androidx.media3.common.PlaybackException
+import androidx.media3.common.util.StuckPlayerException
 import androidx.media3.datasource.cache.CacheSpan
 import androidx.media3.datasource.cache.ContentMetadata
 import kotlinx.coroutines.CompletableDeferred
@@ -72,6 +73,12 @@ internal data class CachedResourceIntegrity(
     val requiresRepair: Boolean,
     val coveredLength: Long
 )
+
+internal enum class CachePrefetchReadiness {
+    COMPLETE,
+    READY_FOR_PREFETCH,
+    UNAVAILABLE
+}
 
 internal fun inspectCachedResourceSpans(
     spans: Collection<CacheSpan>,
@@ -511,6 +518,19 @@ internal fun shouldInvalidateCachedResourceForPlaybackRecovery(
     error: PlaybackException
 ): Boolean = isRecoverableRemotePlaybackCacheError(error)
 
+internal fun shouldInvalidateCacheForPlaybackRecovery(
+    error: PlaybackException,
+    isOfflineCache: Boolean
+): Boolean {
+    return shouldInvalidateCachedResourceForPlaybackRecovery(error) ||
+        (isOfflineCache && isRecoverableCachedMediaFormatError(error))
+}
+
+internal fun shouldInvalidateCacheAfterPlaybackFailure(
+    shouldInvalidateCache: Boolean,
+    isOfflineCache: Boolean
+): Boolean = shouldInvalidateCache && !isOfflineCache
+
 internal fun isRecoverableRemotePlaybackCacheError(error: PlaybackException): Boolean {
     return error.errorCode == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS ||
         error.errorCode == PlaybackException.ERROR_CODE_IO_INVALID_HTTP_CONTENT_TYPE ||
@@ -518,7 +538,26 @@ internal fun isRecoverableRemotePlaybackCacheError(error: PlaybackException): Bo
         error.errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED ||
         error.errorCode == PlaybackException.ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE ||
         error.errorCode == PlaybackException.ERROR_CODE_IO_UNSPECIFIED ||
-        error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT
+        (
+            error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT &&
+                !shouldTreatPlaybackFailureAsTrackEnd(error)
+            )
+}
+
+internal fun shouldTreatPlaybackFailureAsTrackEnd(error: PlaybackException): Boolean {
+    return error.stuckPlayerExceptionOrNull()?.stuckType ==
+        StuckPlayerException.STUCK_PLAYING_NOT_ENDING
+}
+
+internal fun shouldAdvanceAfterStuckTrackEnd(
+    error: PlaybackException,
+    playbackRequested: Boolean
+): Boolean = playbackRequested && shouldTreatPlaybackFailureAsTrackEnd(error)
+
+private fun PlaybackException.stuckPlayerExceptionOrNull(): StuckPlayerException? {
+    return generateSequence(cause) { it.cause }
+        .filterIsInstance<StuckPlayerException>()
+        .firstOrNull()
 }
 
 internal fun PlayerManager.youtubePlaybackRecoveryStrategyForError(
@@ -593,11 +632,14 @@ private fun isRecoverableYouTubeRemotePlaybackError(error: PlaybackException): B
         error.errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED ||
         error.errorCode == PlaybackException.ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE ||
         error.errorCode == PlaybackException.ERROR_CODE_IO_UNSPECIFIED ||
-        error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT ||
-        isRecoverableYouTubeFormatError(error)
+        (
+            error.errorCode == PlaybackException.ERROR_CODE_TIMEOUT &&
+                !shouldTreatPlaybackFailureAsTrackEnd(error)
+            ) ||
+        isRecoverableCachedMediaFormatError(error)
 }
 
-private fun isRecoverableYouTubeFormatError(error: PlaybackException): Boolean {
+private fun isRecoverableCachedMediaFormatError(error: PlaybackException): Boolean {
     return error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_MALFORMED ||
         error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED ||
         error.errorCode == PlaybackException.ERROR_CODE_DECODER_INIT_FAILED ||
@@ -1121,17 +1163,30 @@ internal fun PlayerManager.inspectExoPlayerCache(
     }
 }
 
-internal fun PlayerManager.checkExoPlayerCache(cacheKey: String): Boolean {
+internal fun PlayerManager.hasCompleteExoPlayerCache(cacheKey: String): Boolean {
+    return inspectExoPlayerCache(cacheKey).isComplete
+}
+
+internal suspend fun PlayerManager.prepareExoPlayerCacheForPrefetch(
+    cacheKey: String
+): CachePrefetchReadiness {
+    val currentCache = cache ?: return CachePrefetchReadiness.UNAVAILABLE
+
     val integrity = inspectExoPlayerCache(cacheKey)
-    if (integrity.requiresRepair) {
-        ioScope.launch {
-            invalidateCachedResourceForPlaybackRecovery(
-                cacheKey = cacheKey,
-                reason = "integrity_check"
-            )
-        }
+    if (cache !== currentCache) return CachePrefetchReadiness.UNAVAILABLE
+    if (integrity.isComplete) return CachePrefetchReadiness.COMPLETE
+    if (!integrity.requiresRepair) return CachePrefetchReadiness.READY_FOR_PREFETCH
+
+    return if (
+        invalidateCachedResourceForPlaybackRecovery(
+            cacheKey = cacheKey,
+            reason = "prefetch_integrity_check"
+        )
+    ) {
+        CachePrefetchReadiness.READY_FOR_PREFETCH
+    } else {
+        CachePrefetchReadiness.UNAVAILABLE
     }
-    return integrity.isComplete
 }
 
 internal suspend fun PlayerManager.invalidateMismatchedCachedResource(
@@ -1186,20 +1241,22 @@ internal fun PlayerManager.currentPlaybackCacheKeyForRecovery(): String? {
 internal suspend fun PlayerManager.invalidateCachedResourceForPlaybackRecovery(
     cacheKey: String,
     reason: String
-) = withContext(Dispatchers.IO) {
-    if (cacheKey.isBlank()) return@withContext
-    val mediaCache = cache ?: return@withContext
+): Boolean = withContext(Dispatchers.IO) {
+    if (cacheKey.isBlank()) return@withContext false
+    val mediaCache = cache ?: return@withContext false
     try {
         mediaCache.removeResource(cacheKey)
         NPLogger.w(
             "NERI-PlayerManager",
             "已移除异常播放缓存: key=$cacheKey, reason=$reason"
         )
+        true
     } catch (e: Exception) {
         NPLogger.w(
             "NERI-PlayerManager",
             "移除异常播放缓存失败: key=$cacheKey, reason=$reason, error=${e.message}"
         )
+        false
     }
 }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/watchdog/PlayerManagerStartupWatchdogExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/watchdog/PlayerManagerStartupWatchdogExtensions.kt
@@ -202,7 +202,12 @@ private fun PlayerManager.recoverPlaybackStartupStall(requestToken: Long) {
         return
     }
 
-    if (trySwitchToNextPlaybackCandidateForRecovery(reason = "startup_stall")) {
+    if (
+        trySwitchToNextPlaybackCandidateForRecovery(
+            reason = "startup_stall",
+            invalidateCurrentCache = false
+        )
+    ) {
         return
     }
 
@@ -288,7 +293,10 @@ private fun PlayerManager.tryRestartSystemFallbackSinkForStartupStall(requestTok
     return true
 }
 
-internal fun PlayerManager.trySwitchToNextPlaybackCandidateForRecovery(reason: String): Boolean {
+internal fun PlayerManager.trySwitchToNextPlaybackCandidateForRecovery(
+    reason: String,
+    invalidateCurrentCache: Boolean
+): Boolean {
     val nextIndex = activePlaybackUrlIndex + 1
     val candidate = activePlaybackCandidates.getOrNull(nextIndex) ?: return false
     val requestToken = playbackRequestToken
@@ -307,6 +315,7 @@ internal fun PlayerManager.trySwitchToNextPlaybackCandidateForRecovery(reason: S
             resumePositionMs = activePlaybackResumePositionMs,
             requestToken = requestToken,
             staleCacheKey = staleCacheKey,
+            invalidateCurrentCache = invalidateCurrentCache,
             recoveryReason = reason
         )
     }
@@ -318,18 +327,25 @@ private suspend fun PlayerManager.applyPlaybackCandidate(
     resumePositionMs: Long,
     requestToken: Long,
     staleCacheKey: String?,
+    invalidateCurrentCache: Boolean,
     recoveryReason: String
 ) {
     val song = _currentSongFlow.value ?: return
     if (requestToken != playbackRequestToken) return
-    staleCacheKey?.let {
+    val cacheKey = candidate.cacheKeyOverride ?: computeCacheKey(song)
+    if (
+        shouldInvalidateStalePlaybackCache(
+            invalidateCurrentCache = invalidateCurrentCache,
+            staleCacheKey = staleCacheKey,
+            nextCacheKey = cacheKey
+        )
+    ) {
         invalidateCachedResourceForPlaybackRecovery(
-            cacheKey = it,
+            cacheKey = staleCacheKey.orEmpty(),
             reason = recoveryReason
         )
     }
     if (requestToken != playbackRequestToken) return
-    val cacheKey = candidate.cacheKeyOverride ?: computeCacheKey(song)
     invalidateMismatchedCachedResource(
         cacheKey = cacheKey,
         expectedContentLength = candidate.expectedContentLength
@@ -358,6 +374,16 @@ private suspend fun PlayerManager.applyPlaybackCandidate(
     startProgressUpdates()
     scheduleStatePersist(positionMs = resumePositionMs, shouldResumePlayback = true)
     schedulePlaybackStartupWatchdog(reason = "candidate_switch")
+}
+
+internal fun shouldInvalidateStalePlaybackCache(
+    invalidateCurrentCache: Boolean,
+    staleCacheKey: String?,
+    nextCacheKey: String
+): Boolean {
+    return invalidateCurrentCache &&
+        !staleCacheKey.isNullOrBlank() &&
+        staleCacheKey != nextCacheKey
 }
 
 internal fun PlayerManager.shouldTreatReadyAtStartAsUnhealthyPrepared(): Boolean {

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerMediaCacheLifecycleTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerMediaCacheLifecycleTest.kt
@@ -1,0 +1,33 @@
+package moe.ouom.neriplayer.core.player.lifecycle
+
+import androidx.media3.datasource.cache.Cache
+import moe.ouom.neriplayer.core.player.PlayerManager
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+class PlayerManagerMediaCacheLifecycleTest {
+
+    @After
+    fun clearCacheReference() {
+        PlayerManager.cache = null
+    }
+
+    @Test
+    fun `releasing media cache clears the reference before releasing it`() {
+        val mediaCache = mock(Cache::class.java)
+        doAnswer {
+            assertFalse(PlayerManager.isCacheInitialized())
+            null
+        }.`when`(mediaCache).release()
+        PlayerManager.cache = mediaCache
+
+        PlayerManager.releaseMediaCache()
+
+        assertFalse(PlayerManager.isCacheInitialized())
+        verify(mediaCache).release()
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerMediaCacheLifecycleTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerMediaCacheLifecycleTest.kt
@@ -1,13 +1,17 @@
 package moe.ouom.neriplayer.core.player.lifecycle
 
 import androidx.media3.datasource.cache.Cache
+import androidx.media3.datasource.cache.Cache.CacheException
 import moe.ouom.neriplayer.core.player.PlayerManager
 import org.junit.After
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import java.io.File
+import java.nio.file.Files
 
 class PlayerManagerMediaCacheLifecycleTest {
 
@@ -29,5 +33,49 @@ class PlayerManagerMediaCacheLifecycleTest {
 
         assertFalse(PlayerManager.isCacheInitialized())
         verify(mediaCache).release()
+    }
+
+    @Test
+    fun `only explicit cache initialization failures can rebuild the media cache`() {
+        assertTrue(
+            shouldRebuildMediaCacheAfterInitializationFailure(
+                CacheException("broken cache index")
+            )
+        )
+        assertTrue(
+            shouldRebuildMediaCacheAfterInitializationFailure(
+                IllegalStateException("wrapped", CacheException("broken cache index"))
+            )
+        )
+        assertFalse(
+            shouldRebuildMediaCacheAfterInitializationFailure(
+                IllegalStateException("unrelated initialization failure")
+            )
+        )
+        assertFalse(
+            shouldRebuildMediaCacheAfterInitializationFailure(
+                IllegalStateException(
+                    "Another SimpleCache instance uses the folder",
+                    CacheException("broken cache index")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `cache directory is reopened only after it is empty or gone`() {
+        val parent = Files.createTempDirectory("neriplayer-media-cache-test").toFile()
+        val cacheDir = File(parent, "media_cache")
+        try {
+            assertTrue(isMediaCacheDirectorySafeToOpen(cacheDir))
+
+            assertTrue(cacheDir.mkdirs())
+            assertTrue(isMediaCacheDirectorySafeToOpen(cacheDir))
+
+            Files.createTempFile(cacheDir.toPath(), "orphan", ".exo")
+            assertFalse(isMediaCacheDirectorySafeToOpen(cacheDir))
+        } finally {
+            parent.deleteRecursively()
+        }
     }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerManagerCachePrefetchPreparationTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerManagerCachePrefetchPreparationTest.kt
@@ -1,0 +1,132 @@
+@file:androidx.annotation.OptIn(markerClass = [androidx.media3.common.util.UnstableApi::class])
+
+package moe.ouom.neriplayer.core.player.url
+
+import androidx.media3.datasource.cache.Cache
+import androidx.media3.datasource.cache.CacheSpan
+import androidx.media3.datasource.cache.ContentMetadataMutations
+import androidx.media3.datasource.cache.DefaultContentMetadata
+import java.io.File
+import java.util.TreeSet
+import kotlinx.coroutines.runBlocking
+import moe.ouom.neriplayer.core.player.PlayerManager
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class PlayerManagerCachePrefetchPreparationTest {
+
+    @After
+    fun clearCacheReference() {
+        PlayerManager.cache = null
+    }
+
+    @Test
+    fun `prefetch waits for damaged cache removal before it may write`() = runBlocking {
+        val cacheKey = "damaged-cache"
+        val damagedFile = temporaryFile(length = 3)
+        val mediaCache = cacheWithDamagedSpan(cacheKey, damagedFile)
+        PlayerManager.cache = mediaCache
+
+        try {
+            val readiness = PlayerManager.prepareExoPlayerCacheForPrefetch(cacheKey)
+
+            assertEquals(CachePrefetchReadiness.READY_FOR_PREFETCH, readiness)
+            verify(mediaCache).removeResource(cacheKey)
+        } finally {
+            damagedFile.delete()
+        }
+    }
+
+    @Test
+    fun `prefetch is skipped when damaged cache removal fails`() = runBlocking {
+        val cacheKey = "damaged-cache"
+        val damagedFile = temporaryFile(length = 3)
+        val mediaCache = cacheWithDamagedSpan(cacheKey, damagedFile)
+        doThrow(IllegalStateException("cache write failed"))
+            .`when`(mediaCache)
+            .removeResource(cacheKey)
+        PlayerManager.cache = mediaCache
+
+        try {
+            val readiness = PlayerManager.prepareExoPlayerCacheForPrefetch(cacheKey)
+
+            assertEquals(CachePrefetchReadiness.UNAVAILABLE, readiness)
+            verify(mediaCache).removeResource(cacheKey)
+        } finally {
+            damagedFile.delete()
+        }
+    }
+
+    @Test
+    fun `prefetch does not discard a mismatched resource after playback takes ownership`() = runBlocking {
+        val cacheKey = "active-playback-cache"
+        val cachedFile = temporaryFile(length = 1)
+        val mediaCache = cacheWithSpan(
+            cacheKey = cacheKey,
+            cachedFile = cachedFile,
+            spanLength = 1L,
+            contentLength = 1_000_000L
+        )
+        PlayerManager.cache = mediaCache
+
+        try {
+            PlayerManager.invalidateMismatchedCachedResource(
+                cacheKey = cacheKey,
+                expectedContentLength = 50_000_000L,
+                shouldApplyMutation = { false }
+            )
+
+            verify(mediaCache, never()).removeResource(cacheKey)
+        } finally {
+            cachedFile.delete()
+        }
+    }
+
+    private fun cacheWithDamagedSpan(cacheKey: String, damagedFile: File): Cache {
+        return cacheWithSpan(
+            cacheKey = cacheKey,
+            cachedFile = damagedFile,
+            spanLength = 4L,
+            contentLength = 4L
+        )
+    }
+
+    private fun cacheWithSpan(
+        cacheKey: String,
+        cachedFile: File,
+        spanLength: Long,
+        contentLength: Long
+    ): Cache {
+        val mediaCache = mock(Cache::class.java)
+        val spans = TreeSet<CacheSpan>().apply {
+            add(CacheSpan(cacheKey, 0L, spanLength, 0L, cachedFile))
+        }
+        `when`(mediaCache.getCachedSpans(cacheKey)).thenReturn(spans)
+        `when`(mediaCache.getContentMetadata(cacheKey)).thenReturn(
+            contentMetadata(length = contentLength)
+        )
+        return mediaCache
+    }
+
+    private fun contentMetadata(length: Long): DefaultContentMetadata {
+        val mutations = ContentMetadataMutations()
+        ContentMetadataMutations.setContentLength(mutations, length)
+        return DefaultContentMetadata.EMPTY.copyWithMutationsApplied(mutations)
+    }
+
+    private fun temporaryFile(length: Int): File {
+        return File.createTempFile("neriplayer-prefetch-cache", ".exo").also { file ->
+            file.outputStream().use { output ->
+                output.write(ByteArray(length))
+            }
+            assertTrue(file.isFile)
+        }
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerManagerYouTubePlaybackRecoveryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerManagerYouTubePlaybackRecoveryTest.kt
@@ -3,6 +3,7 @@
 package moe.ouom.neriplayer.core.player.url
 
 import androidx.media3.common.PlaybackException
+import androidx.media3.common.util.StuckPlayerException
 import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.data.model.SongItem
 import org.junit.Assert.assertEquals
@@ -228,5 +229,92 @@ class PlayerManagerYouTubePlaybackRecoveryTest {
                 error = error
             )
         )
+        assertFalse(
+            shouldInvalidateCacheAfterPlaybackFailure(
+                shouldInvalidateCache = shouldInvalidateCachedResourceForPlaybackRecovery(error),
+                isOfflineCache = false
+            )
+        )
+    }
+
+    @Test
+    fun `unrecoverable remote network failure invalidates its cache`() {
+        val error = playbackError(PlaybackException.ERROR_CODE_TIMEOUT)
+
+        assertTrue(
+            shouldInvalidateCacheAfterPlaybackFailure(
+                shouldInvalidateCache = shouldInvalidateCachedResourceForPlaybackRecovery(error),
+                isOfflineCache = false
+            )
+        )
+    }
+
+    @Test
+    fun `offline cache failure never invalidates cache in final failure path`() {
+        assertFalse(
+            shouldInvalidateCacheAfterPlaybackFailure(
+                shouldInvalidateCache = true,
+                isOfflineCache = true
+            )
+        )
+    }
+
+    @Test
+    fun `offline decoder error discards cache so recovery does not loop on damaged media`() {
+        val error = playbackError(PlaybackException.ERROR_CODE_DECODING_FORMAT_UNSUPPORTED)
+
+        assertTrue(
+            shouldInvalidateCacheForPlaybackRecovery(
+                error = error,
+                isOfflineCache = true
+            )
+        )
+    }
+
+    @Test
+    fun `remote decoder error retains cache because decoder support is not cache corruption`() {
+        val error = playbackError(PlaybackException.ERROR_CODE_DECODING_FORMAT_UNSUPPORTED)
+
+        assertFalse(
+            shouldInvalidateCacheForPlaybackRecovery(
+                error = error,
+                isOfflineCache = false
+            )
+        )
+    }
+
+    @Test
+    fun `media3 stuck timeout does not discard cache`() {
+        val error = PlaybackException(
+            "test",
+            StuckPlayerException(
+                StuckPlayerException.STUCK_PLAYING_NOT_ENDING,
+                60_000
+            ),
+            PlaybackException.ERROR_CODE_TIMEOUT
+        )
+
+        assertFalse(shouldInvalidateCachedResourceForPlaybackRecovery(error))
+        assertFalse(shouldAttemptYouTubePlaybackRecovery(error, isOfflineCache = false))
+        assertNull(resolveYouTubePlaybackRecoveryStrategy(error, isOfflineCache = false))
+        assertTrue(shouldTreatPlaybackFailureAsTrackEnd(error))
+        assertTrue(shouldAdvanceAfterStuckTrackEnd(error, playbackRequested = true))
+        assertFalse(shouldAdvanceAfterStuckTrackEnd(error, playbackRequested = false))
+    }
+
+    @Test
+    fun `other media3 stuck timeouts retain normal recovery behavior`() {
+        val error = PlaybackException(
+            "test",
+            StuckPlayerException(
+                StuckPlayerException.STUCK_BUFFERING_NO_PROGRESS,
+                60_000
+            ),
+            PlaybackException.ERROR_CODE_TIMEOUT
+        )
+
+        assertTrue(shouldInvalidateCachedResourceForPlaybackRecovery(error))
+        assertTrue(shouldAttemptYouTubePlaybackRecovery(error, isOfflineCache = false))
+        assertFalse(shouldTreatPlaybackFailureAsTrackEnd(error))
     }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerManagerYouTubePlaybackRecoveryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerManagerYouTubePlaybackRecoveryTest.kt
@@ -126,25 +126,37 @@ class PlayerManagerYouTubePlaybackRecoveryTest {
     }
 
     @Test
-    fun `offline cache playback failure always refreshes the resource`() {
+    fun `offline audio failure refreshes without deleting the cache`() {
+        val error = playbackError(PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED)
         assertTrue(
             shouldAttemptCachedPlaybackRepair(
-                error = playbackError(PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED),
+                error = error,
                 isOfflineCache = true,
                 isYouTubeTrack = false,
                 isLocalSong = false
+            )
+        )
+        assertFalse(
+            shouldInvalidateCachedResourceForPlaybackRecovery(
+                error = error
             )
         )
     }
 
     @Test
     fun `remote timeout refreshes the resource so a bad cache entry is discarded`() {
+        val error = playbackError(PlaybackException.ERROR_CODE_TIMEOUT)
         assertTrue(
             shouldAttemptCachedPlaybackRepair(
-                error = playbackError(PlaybackException.ERROR_CODE_TIMEOUT),
+                error = error,
                 isOfflineCache = false,
                 isYouTubeTrack = false,
                 isLocalSong = false
+            )
+        )
+        assertTrue(
+            shouldInvalidateCachedResourceForPlaybackRecovery(
+                error = error
             )
         )
     }
@@ -157,6 +169,63 @@ class PlayerManagerYouTubePlaybackRecoveryTest {
                 isOfflineCache = false,
                 isYouTubeTrack = false,
                 isLocalSong = true
+            )
+        )
+    }
+
+    @Test
+    fun `remote decoder failure does not trigger generic cache recovery`() {
+        val error = playbackError(PlaybackException.ERROR_CODE_DECODING_FORMAT_UNSUPPORTED)
+
+        assertFalse(
+            shouldAttemptCachedPlaybackRepair(
+                error = error,
+                isOfflineCache = false,
+                isYouTubeTrack = false,
+                isLocalSong = false
+            )
+        )
+        assertFalse(
+            shouldInvalidateCachedResourceForPlaybackRecovery(
+                error = error
+            )
+        )
+    }
+
+    @Test
+    fun `remote parsing failure does not trigger generic cache recovery`() {
+        val error = playbackError(PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED)
+
+        assertFalse(
+            shouldAttemptCachedPlaybackRepair(
+                error = error,
+                isOfflineCache = false,
+                isYouTubeTrack = false,
+                isLocalSong = false
+            )
+        )
+        assertFalse(
+            shouldInvalidateCachedResourceForPlaybackRecovery(
+                error = error
+            )
+        )
+    }
+
+    @Test
+    fun `youtube format recovery retains a remote cache entry`() {
+        val error = playbackError(PlaybackException.ERROR_CODE_DECODING_FORMAT_UNSUPPORTED)
+
+        assertTrue(
+            shouldAttemptCachedPlaybackRepair(
+                error = error,
+                isOfflineCache = false,
+                isYouTubeTrack = true,
+                isLocalSong = false
+            )
+        )
+        assertFalse(
+            shouldInvalidateCachedResourceForPlaybackRecovery(
+                error = error
             )
         )
     }

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/watchdog/PlayerManagerPlaybackCandidateRecoveryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/watchdog/PlayerManagerPlaybackCandidateRecoveryTest.kt
@@ -1,0 +1,41 @@
+package moe.ouom.neriplayer.core.player.watchdog
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PlayerManagerPlaybackCandidateRecoveryTest {
+
+    @Test
+    fun `startup stall does not invalidate the current cache`() {
+        assertFalse(
+            shouldInvalidateStalePlaybackCache(
+                invalidateCurrentCache = false,
+                staleCacheKey = "current-cache",
+                nextCacheKey = "fallback-cache"
+            )
+        )
+    }
+
+    @Test
+    fun `candidate recovery keeps a cache key that the next candidate reuses`() {
+        assertFalse(
+            shouldInvalidateStalePlaybackCache(
+                invalidateCurrentCache = true,
+                staleCacheKey = "shared-cache",
+                nextCacheKey = "shared-cache"
+            )
+        )
+    }
+
+    @Test
+    fun `cache recovery removes a stale cache key before a different candidate starts`() {
+        assertTrue(
+            shouldInvalidateStalePlaybackCache(
+                invalidateCurrentCache = true,
+                staleCacheKey = "stale-cache",
+                nextCacheKey = "fallback-cache"
+            )
+        )
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 改进媒体缓存生命周期。释放播放器时先清除缓存引用，再释放缓存实例。
- 播放恢复按错误类型处理缓存。网络、HTTP、范围和超时错误会失效相关缓存；解码和容器解析错误不会触发通用缓存恢复。
- 启动卡顿恢复仅在候选项变化、缓存键不同且明确要求时失效旧缓存。
- 增加媒体缓存释放、缓存完整性、预取准备、播放恢复和候选项切换测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->