### PR TITLE
feat: enhance storage usage analysis and add downloaded covers support

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/storage/StorageUsageResourceTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/storage/StorageUsageResourceTest.kt
@@ -1,0 +1,52 @@
+package moe.ouom.neriplayer.data.storage
+
+import android.content.res.Configuration
+import android.content.res.Resources
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.util.Locale
+import moe.ouom.neriplayer.data.local.database.store.DownloadIndexStorageStats
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StorageUsageResourceTest {
+    @Test
+    fun downloadIndexRecordsWithoutLegacyFilesRenderCountArguments() {
+        assertEquals(
+            "索引记录 118 条",
+            downloadIndexCountDescription(
+                localizedResources(Locale.SIMPLIFIED_CHINESE),
+                downloadIndexUsageStats(
+                    fileStats = FileStats.Empty,
+                    roomStats = DownloadIndexStorageStats(
+                        databaseRecordCount = 118,
+                        allocatedPageBytes = 0L
+                    )
+                )
+            )
+        )
+        assertEquals(
+            "1 index record",
+            downloadIndexCountDescription(
+                localizedResources(Locale.US),
+                downloadIndexUsageStats(
+                    fileStats = FileStats.Empty,
+                    roomStats = DownloadIndexStorageStats(
+                        databaseRecordCount = 1,
+                        allocatedPageBytes = 0L
+                    )
+                )
+            )
+        )
+    }
+
+    private fun localizedResources(locale: Locale): Resources {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val configuration = Configuration(context.resources.configuration).apply {
+            setLocale(locale)
+        }
+        return context.createConfigurationContext(configuration).resources
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/DownloadIndexRoomStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/store/DownloadIndexRoomStore.kt
@@ -1,0 +1,134 @@
+package moe.ouom.neriplayer.data.local.database.store
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+
+internal data class DownloadIndexStorageStats(
+    val databaseRecordCount: Int,
+    val allocatedPageBytes: Long
+) {
+    companion object {
+        val Empty = DownloadIndexStorageStats(
+            databaseRecordCount = 0,
+            allocatedPageBytes = 0L
+        )
+    }
+}
+
+internal class DownloadIndexRoomStore(
+    private val database: NeriUserDataDatabase
+) {
+    fun storageStats(): DownloadIndexStorageStats {
+        val sqliteDatabase = database.openHelper.readableDatabase
+        val tableStats = DOWNLOAD_INDEX_TABLES.map { tableName ->
+            readTableStats(sqliteDatabase, tableName)
+        }
+        val recordCount = tableStats.sumOf(DownloadIndexTableStats::recordCount)
+        if (recordCount <= 0L) return DownloadIndexStorageStats.Empty
+
+        val payloadBytes = tableStats.sumOf(DownloadIndexTableStats::payloadBytes)
+        val allocatedPageBytes = downloadIndexPageBytes(sqliteDatabase)
+            ?.takeIf { bytes -> bytes > 0L }
+            ?: estimatedDownloadIndexPageBytes(sqliteDatabase, payloadBytes)
+        return DownloadIndexStorageStats(
+            databaseRecordCount = recordCount.coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
+            allocatedPageBytes = allocatedPageBytes
+        )
+    }
+}
+
+private data class DownloadIndexTableStats(
+    val recordCount: Long,
+    val payloadBytes: Long
+) {
+    companion object {
+        val Empty = DownloadIndexTableStats(recordCount = 0L, payloadBytes = 0L)
+    }
+}
+
+private fun readTableStats(
+    database: SupportSQLiteDatabase,
+    tableName: String
+): DownloadIndexTableStats {
+    val columns = database.tableColumns(tableName)
+    if (columns.isEmpty()) return DownloadIndexTableStats.Empty
+
+    val payloadExpression = columns.joinToString(" + ") { columnName ->
+        "COALESCE(length(CAST(${quoteIdentifier(columnName)} AS TEXT)), 0)"
+    }
+    return database.query(
+        "SELECT COUNT(*), COALESCE(SUM($DOWNLOAD_INDEX_ROW_OVERHEAD_BYTES + " +
+            "$payloadExpression), 0) FROM ${quoteIdentifier(tableName)}"
+    ).use { cursor ->
+        check(cursor.moveToFirst())
+        DownloadIndexTableStats(
+            recordCount = cursor.getLong(0),
+            payloadBytes = cursor.getLong(1)
+        )
+    }
+}
+
+private fun SupportSQLiteDatabase.tableColumns(tableName: String): List<String> {
+    return query("PRAGMA table_info(${quoteString(tableName)})").use { cursor ->
+        val nameIndex = cursor.getColumnIndexOrThrow("name")
+        buildList {
+            while (cursor.moveToNext()) {
+                add(cursor.getString(nameIndex))
+            }
+        }
+    }
+}
+
+private fun downloadIndexPageBytes(database: SupportSQLiteDatabase): Long? {
+    return runCatching {
+        database.query(
+            "SELECT COALESCE(SUM(pgsize), 0) FROM dbstat " +
+                "WHERE name IN (" +
+                "SELECT name FROM sqlite_master " +
+                "WHERE type IN ('table', 'index') AND tbl_name IN (" +
+                DOWNLOAD_INDEX_TABLES.joinToString(",") { tableName ->
+                    quoteString(tableName)
+                } +
+                ")" +
+                ")"
+        ).use { cursor ->
+            check(cursor.moveToFirst())
+            cursor.getLong(0)
+        }
+    }.getOrNull()
+}
+
+private fun estimatedDownloadIndexPageBytes(
+    database: SupportSQLiteDatabase,
+    payloadBytes: Long
+): Long {
+    if (payloadBytes <= 0L) return 0L
+    val pageSize = database.pragmaLong("page_size").coerceAtLeast(1L)
+    val roundedPayloadBytes = ((payloadBytes + pageSize - 1L) / pageSize) * pageSize
+    return roundedPayloadBytes.coerceAtLeast(pageSize)
+}
+
+private fun SupportSQLiteDatabase.pragmaLong(name: String): Long {
+    return query("PRAGMA $name").use { cursor ->
+        check(cursor.moveToFirst())
+        cursor.getLong(0)
+    }
+}
+
+private fun quoteIdentifier(value: String): String {
+    return "\"${value.replace("\"", "\"\"")}\""
+}
+
+private fun quoteString(value: String): String {
+    return "'${value.replace("'", "''")}'"
+}
+
+private const val DOWNLOAD_INDEX_ROW_OVERHEAD_BYTES = 24L
+
+private val DOWNLOAD_INDEX_TABLES = listOf(
+    "downloaded_song_catalog",
+    "download_snapshot_entry",
+    "download_snapshot_metadata",
+    "download_pending_queue",
+    "download_cancelled_key"
+)

--- a/app/src/main/java/moe/ouom/neriplayer/data/storage/StorageUsageAnalyzer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/storage/StorageUsageAnalyzer.kt
@@ -32,8 +32,11 @@ import kotlinx.coroutines.withContext
 import moe.ouom.neriplayer.R
 import moe.ouom.neriplayer.core.crash.ExceptionHandler
 import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
+import moe.ouom.neriplayer.core.download.storage.NO_MEDIA_FILE_NAME
 import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
+import moe.ouom.neriplayer.data.local.database.store.DownloadIndexRoomStore
+import moe.ouom.neriplayer.data.local.database.store.DownloadIndexStorageStats
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheRoomStore
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheStorageStats
 
@@ -62,6 +65,7 @@ enum class StorageUsageItemKind {
     OtherCache,
     DownloadedMusic,
     DownloadedLyrics,
+    DownloadedCovers,
     DownloadIndex,
     LogFiles,
     CrashLogs,
@@ -108,6 +112,7 @@ data class StorageUsageItem(
     val fileCount: Int,
     val kind: StorageUsageItemKind,
     val databaseRecordCount: Int? = null,
+    val countDescription: String? = null,
     val cacheKind: StorageCacheKind? = null
 )
 
@@ -147,6 +152,13 @@ data class ExtraCacheClearResult(
     val deletedFiles: Int
 )
 
+private data class StorageUsageScanInputs(
+    val downloadLibraryUsage: ManagedDownloadLibraryUsage,
+    val platformCacheStats: Map<String, PlatformPlaylistCacheStorageStats>,
+    val downloadIndexStorageStats: DownloadIndexStorageStats,
+    val databaseFileStats: FileStats
+)
+
 suspend fun analyzeStorageUsage(context: Context): StorageUsageSummary = withContext(Dispatchers.IO) {
     val appContext = context.applicationContext
     val filesDir = appContext.filesDir
@@ -166,13 +178,16 @@ suspend fun analyzeStorageUsage(context: Context): StorageUsageSummary = withCon
     val logDir = File(diagnosticsBaseDir, DIR_LOGS)
     val crashDir = File(diagnosticsBaseDir, DIR_CRASHES)
 
-    val (downloadableAudio, rawPlatformCacheStats, databaseFileStats) = coroutineScope {
-        val downloadableAudio = async {
+    val scanInputs = coroutineScope {
+        val downloadLibraryUsage = async {
             runCatching {
-                ManagedDownloadStorage.listDownloadedAudio(appContext)
-            }.getOrDefault(emptyList())
+                ManagedDownloadStorage.buildDownloadLibrarySnapshot(
+                    context = appContext,
+                    forceRefresh = true
+                ).toManagedDownloadLibraryUsage()
+            }.getOrDefault(ManagedDownloadLibraryUsage.Empty)
         }
-        val rawPlatformCacheStats = async {
+        val platformCacheStats = async {
             runCatching {
                 val roomStore = PlatformPlaylistCacheRoomStore(
                     NeriUserDataDatabase.getInstance(appContext)
@@ -180,26 +195,43 @@ suspend fun analyzeStorageUsage(context: Context): StorageUsageSummary = withCon
                 roomStore.storageStats(PLATFORM_CACHE_PLATFORMS)
             }.getOrDefault(emptyMap())
         }
+        val downloadIndexStorageStats = async {
+            runCatching {
+                DownloadIndexRoomStore(
+                    NeriUserDataDatabase.getInstance(appContext)
+                ).storageStats()
+            }.getOrDefault(DownloadIndexStorageStats.Empty)
+        }
         val databaseFileStats = async {
             databaseFiles.fold(FileStats.Empty) { acc, file ->
                 acc + statsOf(file)
             }
         }
-        Triple(
-            downloadableAudio.await(),
-            rawPlatformCacheStats.await(),
-            databaseFileStats.await()
+        StorageUsageScanInputs(
+            downloadLibraryUsage = downloadLibraryUsage.await(),
+            platformCacheStats = platformCacheStats.await(),
+            downloadIndexStorageStats = downloadIndexStorageStats.await(),
+            databaseFileStats = databaseFileStats.await()
         )
     }
-    val platformCacheStats = normalizePlatformCacheStats(
-        stats = rawPlatformCacheStats,
-        databaseBytes = databaseFileStats.sizeBytes
+    val databaseAttribution = normalizeDatabaseStorageAttribution(
+        platformCacheStats = scanInputs.platformCacheStats,
+        downloadIndexStorageStats = scanInputs.downloadIndexStorageStats,
+        databaseBytes = scanInputs.databaseFileStats.sizeBytes
     )
-    val platformCachePageBytes = platformCacheStats.values.sumOf { it.allocatedPageBytes }
+    val platformCacheStats = databaseAttribution.platformCacheStats
+    val downloadIndexStorageStats = databaseAttribution.downloadIndexStorageStats
+    val attributedDatabaseBytes = platformCacheStats.values.sumOf {
+        it.allocatedPageBytes
+    } + downloadIndexStorageStats.allocatedPageBytes
     val databaseUsageStats = databaseUsageStats(
-        databaseStats = databaseFileStats,
-        roomCachePageBytes = platformCachePageBytes
+        databaseStats = scanInputs.databaseFileStats,
+        attributedDatabaseBytes = attributedDatabaseBytes
     )
+    val downloadIndexFileStats = scanInputs.downloadLibraryUsage.metadataFiles +
+        downloadMetadataFiles.fold(FileStats.Empty) { acc, file ->
+            acc + statsOf(file)
+        }
 
     val cacheKnownRoots = listOf(
         mediaCacheDir,
@@ -214,7 +246,8 @@ suspend fun analyzeStorageUsage(context: Context): StorageUsageSummary = withCon
         downloadMetadataFiles = downloadMetadataFiles,
         playlistDataFiles = playlistDataFiles,
         logDir = logDir,
-        crashDir = crashDir
+        crashDir = crashDir,
+        downloadedStorageFiles = scanInputs.downloadLibraryUsage.localFiles
     )
 
     StorageUsageSummary(
@@ -335,17 +368,28 @@ suspend fun analyzeStorageUsage(context: Context): StorageUsageSummary = withCon
                         title = appContext.getString(R.string.storage_type_downloaded_music),
                         description = appContext.getString(R.string.storage_desc_downloaded_music),
                         path = null,
-                        sizeBytes = downloadableAudio.sumOf { it.sizeBytes },
-                        fileCount = downloadableAudio.size,
+                        sizeBytes = scanInputs.downloadLibraryUsage.audioFiles.sizeBytes,
+                        fileCount = scanInputs.downloadLibraryUsage.audioFiles.fileCount,
                         kind = StorageUsageItemKind.DownloadedMusic
                     ),
-                    downloadedLyricUsageItem(appContext),
-                    aggregateUsageItem(
+                    downloadedLibraryUsageItem(
                         context = appContext,
-                        titleRes = R.string.storage_type_download_index,
-                        descriptionRes = R.string.storage_desc_download_index,
-                        files = downloadMetadataFiles,
-                        kind = StorageUsageItemKind.DownloadIndex
+                        titleRes = R.string.storage_type_downloaded_lyrics,
+                        descriptionRes = R.string.storage_desc_downloaded_lyrics,
+                        stats = scanInputs.downloadLibraryUsage.lyricFiles,
+                        kind = StorageUsageItemKind.DownloadedLyrics
+                    ),
+                    downloadedLibraryUsageItem(
+                        context = appContext,
+                        titleRes = R.string.storage_type_downloaded_covers,
+                        descriptionRes = R.string.storage_desc_downloaded_covers,
+                        stats = scanInputs.downloadLibraryUsage.coverFiles,
+                        kind = StorageUsageItemKind.DownloadedCovers
+                    ),
+                    downloadIndexUsageItem(
+                        context = appContext,
+                        fileStats = downloadIndexFileStats,
+                        roomStats = downloadIndexStorageStats
                     )
                 )
             ),
@@ -393,19 +437,58 @@ suspend fun analyzeStorageUsage(context: Context): StorageUsageSummary = withCon
     )
 }
 
-private fun downloadedLyricUsageItem(
-    context: Context
+private fun downloadedLibraryUsageItem(
+    context: Context,
+    titleRes: Int,
+    descriptionRes: Int,
+    stats: FileStats,
+    kind: StorageUsageItemKind
 ): StorageUsageItem {
-    val lyricsDir = defaultDownloadLyricsDir(context)
-    val stats = statsOf(lyricsDir)
     return StorageUsageItem(
-        title = context.getString(R.string.storage_type_downloaded_lyrics),
-        description = context.getString(R.string.storage_desc_downloaded_lyrics),
-        path = lyricsDir.absolutePath,
+        title = context.getString(titleRes),
+        description = context.getString(descriptionRes),
+        path = null,
         sizeBytes = stats.sizeBytes,
         fileCount = stats.fileCount,
-        kind = StorageUsageItemKind.DownloadedLyrics
+        kind = kind
     )
+}
+
+private fun downloadIndexUsageItem(
+    context: Context,
+    fileStats: FileStats,
+    roomStats: DownloadIndexStorageStats
+): StorageUsageItem {
+    val stats = downloadIndexUsageStats(fileStats, roomStats)
+    return StorageUsageItem(
+        title = context.getString(R.string.storage_type_download_index),
+        description = context.getString(R.string.storage_desc_download_index),
+        path = null,
+        sizeBytes = stats.sizeBytes,
+        fileCount = stats.fileCount,
+        kind = StorageUsageItemKind.DownloadIndex,
+        countDescription = downloadIndexCountDescription(context, stats)
+    )
+}
+
+private fun downloadIndexCountDescription(
+    context: Context,
+    stats: DownloadIndexUsageStats
+): String? {
+    if (stats.databaseRecordCount <= 0) return null
+    return if (stats.fileCount > 0) {
+        context.resources.getQuantityString(
+            R.plurals.storage_details_download_index_record_and_file_count,
+            stats.databaseRecordCount,
+            stats.databaseRecordCount,
+            stats.fileCount
+        )
+    } else {
+        context.resources.getQuantityString(
+            R.plurals.storage_details_download_index_record_count,
+            stats.databaseRecordCount
+        )
+    }
 }
 
 suspend fun clearExtraStorageCaches(
@@ -576,27 +659,156 @@ internal data class FileStats(
     }
 }
 
-private fun normalizePlatformCacheStats(
-    stats: Map<String, PlatformPlaylistCacheStorageStats>,
-    databaseBytes: Long
-): Map<String, PlatformPlaylistCacheStorageStats> {
-    val totalAllocatedBytes = stats.values.sumOf { it.allocatedPageBytes }
-    if (totalAllocatedBytes <= 0L || databaseBytes <= 0L || totalAllocatedBytes <= databaseBytes) {
-        return stats
-    }
-    return stats.mapValues { (_, value) ->
-        value.copy(
-            allocatedPageBytes = (value.allocatedPageBytes.toDouble() * databaseBytes /
-                totalAllocatedBytes).toLong()
+internal data class ManagedDownloadLibraryUsage(
+    val audioFiles: FileStats,
+    val lyricFiles: FileStats,
+    val coverFiles: FileStats,
+    val metadataFiles: FileStats,
+    val localFiles: List<File>
+) {
+    companion object {
+        val Empty = ManagedDownloadLibraryUsage(
+            audioFiles = FileStats.Empty,
+            lyricFiles = FileStats.Empty,
+            coverFiles = FileStats.Empty,
+            metadataFiles = FileStats.Empty,
+            localFiles = emptyList()
         )
     }
 }
 
-private fun databaseUsageStats(
-    databaseStats: FileStats,
-    roomCachePageBytes: Long
+internal data class DownloadIndexUsageStats(
+    val sizeBytes: Long,
+    val fileCount: Int,
+    val databaseRecordCount: Int
+)
+
+internal fun ManagedDownloadStorage.DownloadLibrarySnapshot.toManagedDownloadLibraryUsage():
+    ManagedDownloadLibraryUsage {
+    return managedDownloadLibraryUsage(
+        audioEntries = audioEntries,
+        lyricEntries = lyricEntriesByName.values,
+        coverEntries = coverEntriesByName.values,
+        metadataEntries = metadataEntriesByAudioName.values
+    )
+}
+
+internal fun managedDownloadLibraryUsage(
+    audioEntries: Collection<ManagedDownloadStorage.StoredEntry>,
+    lyricEntries: Collection<ManagedDownloadStorage.StoredEntry>,
+    coverEntries: Collection<ManagedDownloadStorage.StoredEntry>,
+    metadataEntries: Collection<ManagedDownloadStorage.StoredEntry>
+): ManagedDownloadLibraryUsage {
+    val allEntries = audioEntries + lyricEntries + coverEntries + metadataEntries
+    return ManagedDownloadLibraryUsage(
+        audioFiles = storedEntryStats(audioEntries),
+        lyricFiles = storedEntryStats(lyricEntries),
+        coverFiles = storedEntryStats(coverEntries),
+        metadataFiles = storedEntryStats(metadataEntries),
+        localFiles = managedStoredEntries(allEntries)
+            .mapNotNull(ManagedDownloadStorage.StoredEntry::localFilePath)
+            .map(::File)
+            .distinctBy { file -> file.absolutePath }
+    )
+}
+
+internal fun downloadIndexUsageStats(
+    fileStats: FileStats,
+    roomStats: DownloadIndexStorageStats
+): DownloadIndexUsageStats {
+    return DownloadIndexUsageStats(
+        sizeBytes = fileStats.sizeBytes + roomStats.allocatedPageBytes,
+        fileCount = fileStats.fileCount,
+        databaseRecordCount = roomStats.databaseRecordCount
+    )
+}
+
+private fun storedEntryStats(
+    entries: Collection<ManagedDownloadStorage.StoredEntry>
 ): FileStats {
-    val attributedBytes = roomCachePageBytes.coerceIn(0L, databaseStats.sizeBytes)
+    return managedStoredEntries(entries).fold(FileStats.Empty) { stats, entry ->
+        stats + FileStats(entry.sizeBytes.coerceAtLeast(0L), 1)
+    }
+}
+
+private fun managedStoredEntries(
+    entries: Collection<ManagedDownloadStorage.StoredEntry>
+): List<ManagedDownloadStorage.StoredEntry> {
+    return entries
+        .asSequence()
+        .filterNot { entry -> entry.isDirectory || entry.name == NO_MEDIA_FILE_NAME }
+        .distinctBy(ManagedDownloadStorage.StoredEntry::usageIdentity)
+        .toList()
+}
+
+private fun ManagedDownloadStorage.StoredEntry.usageIdentity(): String {
+    return reference.takeIf(String::isNotBlank)
+        ?: mediaUri.takeIf(String::isNotBlank)
+        ?: name
+}
+
+internal data class DatabaseStorageAttribution(
+    val platformCacheStats: Map<String, PlatformPlaylistCacheStorageStats>,
+    val downloadIndexStorageStats: DownloadIndexStorageStats
+)
+
+internal fun normalizeDatabaseStorageAttribution(
+    platformCacheStats: Map<String, PlatformPlaylistCacheStorageStats>,
+    downloadIndexStorageStats: DownloadIndexStorageStats,
+    databaseBytes: Long
+): DatabaseStorageAttribution {
+    val allocations = buildMap {
+        platformCacheStats
+            .filterValues { it.allocatedPageBytes > 0L }
+            .toSortedMap()
+            .forEach { (platform, stats) ->
+                put("platform:$platform", stats.allocatedPageBytes)
+            }
+        if (downloadIndexStorageStats.allocatedPageBytes > 0L) {
+            put("download_index", downloadIndexStorageStats.allocatedPageBytes)
+        }
+    }
+    val totalAllocatedBytes = allocations.values.sum()
+    if (totalAllocatedBytes <= 0L || databaseBytes <= 0L || totalAllocatedBytes <= databaseBytes) {
+        return DatabaseStorageAttribution(
+            platformCacheStats = platformCacheStats,
+            downloadIndexStorageStats = downloadIndexStorageStats
+        )
+    }
+
+    var remainingBytes = databaseBytes
+    var remainingAllocatedBytes = totalAllocatedBytes
+    val normalizedBytes = buildMap {
+        allocations.entries.forEachIndexed { index, (key, allocatedBytes) ->
+            val normalized = if (index == allocations.size - 1) {
+                remainingBytes
+            } else {
+                (remainingBytes.toDouble() * allocatedBytes / remainingAllocatedBytes)
+                    .toLong()
+                    .coerceIn(0L, remainingBytes)
+            }
+            put(key, normalized)
+            remainingBytes -= normalized
+            remainingAllocatedBytes -= allocatedBytes
+        }
+    }
+    return DatabaseStorageAttribution(
+        platformCacheStats = platformCacheStats.mapValues { (platform, stats) ->
+            stats.copy(
+                allocatedPageBytes = normalizedBytes["platform:$platform"] ?: 0L
+            )
+        },
+        downloadIndexStorageStats = downloadIndexStorageStats.copy(
+            allocatedPageBytes = normalizedBytes["download_index"] ?: 0L
+        )
+    )
+}
+
+internal fun databaseUsageStats(
+    databaseStats: FileStats,
+    attributedDatabaseBytes: Long
+): FileStats {
+    val attributedBytes = attributedDatabaseBytes.coerceIn(0L, databaseStats.sizeBytes)
     return FileStats(
         sizeBytes = databaseStats.sizeBytes - attributedBytes,
         fileCount = databaseStats.fileCount
@@ -611,7 +823,8 @@ internal fun knownAppDataRoots(
     downloadMetadataFiles: List<File>,
     playlistDataFiles: List<File>,
     logDir: File,
-    crashDir: File
+    crashDir: File,
+    downloadedStorageFiles: List<File> = emptyList()
 ): List<File> {
     return platformCacheDirs +
         downloadStagingDirs +
@@ -620,7 +833,8 @@ internal fun knownAppDataRoots(
         downloadMetadataFiles +
         playlistDataFiles +
         logDir +
-        crashDir
+        crashDir +
+        downloadedStorageFiles
 }
 
 internal fun statsOf(file: File?, excludedRoots: List<File> = emptyList()): FileStats {
@@ -634,7 +848,9 @@ internal fun statsOf(file: File?, excludedRoots: List<File> = emptyList()): File
                 .onEnter { directory ->
                     excludedRootPaths.none { directory.isUnder(it) }
                 }
-                .filter { entry -> entry.isFile }
+                .filter { entry ->
+                    entry.isFile && excludedRootPaths.none { entry.isUnder(it) }
+                }
                 .fold(FileStats.Empty) { acc, entry ->
                     acc + FileStats(entry.length(), 1)
                 }
@@ -677,7 +893,8 @@ private fun downloadMetadataFiles(filesDir: File): List<File> {
         File(filesDir, FILE_MANAGED_DOWNLOAD_SNAPSHOT),
         File(filesDir, FILE_PENDING_DOWNLOAD_QUEUE),
         File(filesDir, FILE_CANCELLED_DOWNLOAD_KEYS),
-        File(filesDir, FILE_DOWNLOADED_SONG_CATALOG)
+        File(filesDir, FILE_DOWNLOADED_SONG_CATALOG_V3),
+        File(filesDir, FILE_DOWNLOADED_SONG_CATALOG_V4)
     )
 }
 
@@ -689,18 +906,10 @@ private fun playlistDataFiles(filesDir: File): List<File> {
     )
 }
 
-private fun defaultDownloadLyricsDir(context: Context): File {
-    val baseDir = context.getExternalFilesDir(android.os.Environment.DIRECTORY_MUSIC)
-        ?: context.filesDir
-    return File(File(baseDir, DIR_DOWNLOAD_ROOT), DIR_DOWNLOAD_LYRICS)
-}
-
 private const val DIR_MEDIA_CACHE = "media_cache"
 private const val DIR_IMAGE_CACHE = "image_cache"
 private const val DIR_DOWNLOAD_STAGING = "download_staging"
 private const val DIR_SHARED_MEDIA_EXPORTS = "shared_media_exports"
-private const val DIR_DOWNLOAD_ROOT = "NeriPlayer"
-private const val DIR_DOWNLOAD_LYRICS = "Lyrics"
 private const val DIR_BILI_FAVORITE_CACHE = "bili_favorite_cache"
 private const val DIR_BILI_ARCHIVE_CACHE = "bili_archive_cache"
 private const val DIR_NETEASE_PLAYLIST_CACHE = "netease_playlist_cache"
@@ -712,7 +921,8 @@ private const val DIR_CRASHES = "crashes"
 private const val FILE_MANAGED_DOWNLOAD_SNAPSHOT = "managed_download_snapshot_v1.json"
 private const val FILE_PENDING_DOWNLOAD_QUEUE = "pending_download_queue_v1.json"
 private const val FILE_CANCELLED_DOWNLOAD_KEYS = "cancelled_download_keys_v1.json"
-private const val FILE_DOWNLOADED_SONG_CATALOG = "downloaded_song_catalog_v3.json"
+private const val FILE_DOWNLOADED_SONG_CATALOG_V3 = "downloaded_song_catalog_v3.json"
+private const val FILE_DOWNLOADED_SONG_CATALOG_V4 = "downloaded_song_catalog_v4.json"
 private const val FILE_LOCAL_PLAYLISTS = "local_playlists.json"
 private const val FILE_FAVORITE_PLAYLISTS = "favorite_playlists.json"
 private const val FILE_PLAYLIST_USAGE = "playlist_usage.json"

--- a/app/src/main/java/moe/ouom/neriplayer/data/storage/StorageUsageAnalyzer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/storage/StorageUsageAnalyzer.kt
@@ -24,7 +24,9 @@ package moe.ouom.neriplayer.data.storage
  */
 
 import android.content.Context
+import android.content.res.Resources
 import java.io.File
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -159,6 +161,19 @@ private data class StorageUsageScanInputs(
     val databaseFileStats: FileStats
 )
 
+internal suspend fun <T> storageScanOrDefault(
+    fallback: T,
+    scan: suspend () -> T
+): T {
+    return try {
+        scan()
+    } catch (error: CancellationException) {
+        throw error
+    } catch (_: Throwable) {
+        fallback
+    }
+}
+
 suspend fun analyzeStorageUsage(context: Context): StorageUsageSummary = withContext(Dispatchers.IO) {
     val appContext = context.applicationContext
     val filesDir = appContext.filesDir
@@ -180,27 +195,27 @@ suspend fun analyzeStorageUsage(context: Context): StorageUsageSummary = withCon
 
     val scanInputs = coroutineScope {
         val downloadLibraryUsage = async {
-            runCatching {
+            storageScanOrDefault(ManagedDownloadLibraryUsage.Empty) {
                 ManagedDownloadStorage.buildDownloadLibrarySnapshot(
                     context = appContext,
                     forceRefresh = true
                 ).toManagedDownloadLibraryUsage()
-            }.getOrDefault(ManagedDownloadLibraryUsage.Empty)
+            }
         }
         val platformCacheStats = async {
-            runCatching {
+            storageScanOrDefault(emptyMap()) {
                 val roomStore = PlatformPlaylistCacheRoomStore(
                     NeriUserDataDatabase.getInstance(appContext)
                 )
                 roomStore.storageStats(PLATFORM_CACHE_PLATFORMS)
-            }.getOrDefault(emptyMap())
+            }
         }
         val downloadIndexStorageStats = async {
-            runCatching {
+            storageScanOrDefault(DownloadIndexStorageStats.Empty) {
                 DownloadIndexRoomStore(
                     NeriUserDataDatabase.getInstance(appContext)
                 ).storageStats()
-            }.getOrDefault(DownloadIndexStorageStats.Empty)
+            }
         }
         val databaseFileStats = async {
             databaseFiles.fold(FileStats.Empty) { acc, file ->
@@ -467,25 +482,26 @@ private fun downloadIndexUsageItem(
         sizeBytes = stats.sizeBytes,
         fileCount = stats.fileCount,
         kind = StorageUsageItemKind.DownloadIndex,
-        countDescription = downloadIndexCountDescription(context, stats)
+        countDescription = downloadIndexCountDescription(context.resources, stats)
     )
 }
 
-private fun downloadIndexCountDescription(
-    context: Context,
+internal fun downloadIndexCountDescription(
+    resources: Resources,
     stats: DownloadIndexUsageStats
 ): String? {
     if (stats.databaseRecordCount <= 0) return null
     return if (stats.fileCount > 0) {
-        context.resources.getQuantityString(
+        resources.getQuantityString(
             R.plurals.storage_details_download_index_record_and_file_count,
             stats.databaseRecordCount,
             stats.databaseRecordCount,
             stats.fileCount
         )
     } else {
-        context.resources.getQuantityString(
+        resources.getQuantityString(
             R.plurals.storage_details_download_index_record_count,
+            stats.databaseRecordCount,
             stats.databaseRecordCount
         )
     }

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/StorageCacheDetailsContent.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/StorageCacheDetailsContent.kt
@@ -534,7 +534,7 @@ private fun StorageUsageItemRow(item: StorageUsageItem) {
                 fontWeight = FontWeight.SemiBold
             )
             Text(
-                text = item.databaseRecordCount?.let { recordCount ->
+                text = item.countDescription ?: item.databaseRecordCount?.let { recordCount ->
                     stringResource(R.string.storage_details_cache_record_count, recordCount)
                 } ?: pluralStringResource(
                     R.plurals.storage_details_file_count,
@@ -561,6 +561,7 @@ private fun StorageUsageItemKind.toStorageIcon(): ImageVector {
         StorageUsageItemKind.OtherCache -> Icons.Outlined.Layers
         StorageUsageItemKind.DownloadedMusic -> Icons.Outlined.DownloadDone
         StorageUsageItemKind.DownloadedLyrics -> Icons.Outlined.Subtitles
+        StorageUsageItemKind.DownloadedCovers -> Icons.Outlined.PictureInPictureAlt
         StorageUsageItemKind.DownloadIndex -> Icons.Outlined.Tab
         StorageUsageItemKind.LogFiles -> Icons.Outlined.Description
         StorageUsageItemKind.CrashLogs -> Icons.Outlined.BugReport

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1649,6 +1649,7 @@
     <string name="storage_type_youtube_playlist_cache">YouTube Music Playlist Cache</string>
     <string name="storage_type_downloaded_music">Downloaded Music</string>
     <string name="storage_type_downloaded_lyrics">Downloaded Lyrics</string>
+    <string name="storage_type_downloaded_covers">Downloaded Cover Art</string>
     <string name="storage_type_download_index">Download Index</string>
     <string name="storage_type_log_files">Log Files</string>
     <string name="storage_type_crash_logs">Crash Logs</string>
@@ -1670,6 +1671,7 @@
     <string name="storage_desc_other_cache">Files in the cache directory not covered above</string>
     <string name="storage_desc_downloaded_music">Songs saved by the user. These are not removed by clearing cache</string>
     <string name="storage_desc_downloaded_lyrics">Original and translated lyric sidecar files for downloads. These are not removed by clearing cache</string>
+    <string name="storage_desc_downloaded_covers">Cover art sidecar files for downloads. These are not removed by clearing cache</string>
     <string name="storage_desc_download_index">Download catalog, pending queue, and cancellation records</string>
     <string name="storage_desc_log_files">Debug logs and long-running log files</string>
     <string name="storage_desc_crash_logs">Crash, ANR, and native crash reports</string>
@@ -1696,6 +1698,14 @@
     <string name="storage_cleanable_total">Cleanable cache</string>
     <string name="storage_details_files_summary">%1$s · %2$d files</string>
     <string name="storage_details_cache_record_count">%1$d Room cache entries</string>
+    <plurals name="storage_details_download_index_record_count">
+        <item quantity="one">%1$d index record</item>
+        <item quantity="other">%1$d index records</item>
+    </plurals>
+    <plurals name="storage_details_download_index_record_and_file_count">
+        <item quantity="one">%1$d index record · index files: %2$d</item>
+        <item quantity="other">%1$d index records · index files: %2$d</item>
+    </plurals>
     <string name="storage_details_empty">No measurable files found yet</string>
 
     <!-- Sync & Backup -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1649,6 +1649,7 @@
     <string name="storage_type_youtube_playlist_cache">YouTube Music 歌单缓存</string>
     <string name="storage_type_downloaded_music">下载的音乐</string>
     <string name="storage_type_downloaded_lyrics">下载歌词文件</string>
+    <string name="storage_type_downloaded_covers">下载封面文件</string>
     <string name="storage_type_download_index">下载索引</string>
     <string name="storage_type_log_files">日志文件</string>
     <string name="storage_type_crash_logs">崩溃日志</string>
@@ -1670,6 +1671,7 @@
     <string name="storage_desc_other_cache">缓存目录内未归入上述类型的文件</string>
     <string name="storage_desc_downloaded_music">用户主动下载保存的歌曲，不会通过清缓存删除</string>
     <string name="storage_desc_downloaded_lyrics">下载歌曲附带的原文和翻译歌词文件，不会通过清缓存删除</string>
+    <string name="storage_desc_downloaded_covers">下载歌曲附带的封面文件，不会通过清缓存删除</string>
     <string name="storage_desc_download_index">下载目录索引、待下载队列和取消记录</string>
     <string name="storage_desc_log_files">调试日志和长期记录日志</string>
     <string name="storage_desc_crash_logs">崩溃、ANR 和原生崩溃报告</string>
@@ -1696,6 +1698,14 @@
     <string name="storage_cleanable_total">可清理缓存</string>
     <string name="storage_details_files_summary">%1$s · %2$d 个文件</string>
     <string name="storage_details_cache_record_count">Room 缓存 %1$d 条</string>
+    <plurals name="storage_details_download_index_record_count">
+        <item quantity="one">索引记录 %1$d 条</item>
+        <item quantity="other">索引记录 %1$d 条</item>
+    </plurals>
+    <plurals name="storage_details_download_index_record_and_file_count">
+        <item quantity="one">索引记录 %1$d 条 · 索引文件：%2$d 个</item>
+        <item quantity="other">索引记录 %1$d 条 · 索引文件：%2$d 个</item>
+    </plurals>
     <string name="storage_details_empty">暂未发现可计量文件</string>
 
     <!-- Sync & Backup -->

--- a/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorageSnapshotCacheTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorageSnapshotCacheTest.kt
@@ -194,19 +194,22 @@ class ManagedDownloadStorageSnapshotCacheTest {
         val snapshot = emptySnapshot()
         val persistenceStore = BlockingSnapshotPersistenceStore("root" to snapshot)
         val cacheStore = ManagedDownloadSnapshotCacheStore(
-            scope = CoroutineScope(Dispatchers.IO),
+            scope = CoroutineScope(Dispatchers.Unconfined),
             cacheKeyProvider = { "root" },
             persistenceStoreProvider = { persistenceStore }
         )
-        val executor = Executors.newSingleThreadExecutor()
+        val restoreExecutor = Executors.newSingleThreadExecutor()
+        val invalidationExecutor = Executors.newSingleThreadExecutor()
 
         try {
-            val restoreFuture = executor.submit<ManagedDownloadStorage.DownloadLibrarySnapshot?> {
+            val restoreFuture = restoreExecutor.submit<ManagedDownloadStorage.DownloadLibrarySnapshot?> {
                 cacheStore.restorePersisted(context, expectedKey = "root")
             }
             assertTrue(persistenceStore.restoreStarted.await(5, TimeUnit.SECONDS))
 
-            cacheStore.invalidate(context)
+            val invalidationFuture = invalidationExecutor.submit {
+                cacheStore.invalidate(context)
+            }
 
             assertTrue(persistenceStore.clearStarted.await(5, TimeUnit.SECONDS))
             persistenceStore.releaseRestore.countDown()
@@ -216,9 +219,11 @@ class ManagedDownloadStorageSnapshotCacheTest {
 
             persistenceStore.releaseClear.countDown()
             assertTrue(persistenceStore.clearFinished.await(5, TimeUnit.SECONDS))
+            invalidationFuture.get(5, TimeUnit.SECONDS)
             assertEquals(snapshot, cacheStore.restorePersisted(context, expectedKey = "root"))
         } finally {
-            executor.shutdownNow()
+            restoreExecutor.shutdownNow()
+            invalidationExecutor.shutdownNow()
             persistenceStore.releaseRestore.countDown()
             persistenceStore.releaseClear.countDown()
         }

--- a/app/src/test/java/moe/ouom/neriplayer/data/storage/StorageUsageSummaryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/storage/StorageUsageSummaryTest.kt
@@ -2,11 +2,15 @@ package moe.ouom.neriplayer.data.storage
 
 import java.io.File
 import java.nio.file.Files
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
 import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
 import moe.ouom.neriplayer.data.local.database.store.DownloadIndexStorageStats
 import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheStorageStats
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -154,6 +158,31 @@ class StorageUsageSummaryTest {
                 attributedDatabaseBytes = attributedBytes
             ).sizeBytes
         )
+    }
+
+    @Test
+    fun storageScanFallsBackForNonCancellationFailure() = runBlocking {
+        assertEquals(
+            "fallback",
+            storageScanOrDefault("fallback") {
+                throw IllegalStateException("storage read failed")
+            }
+        )
+    }
+
+    @Test
+    fun storageScanRethrowsCancellation() {
+        val cancellation = CancellationException("storage scan cancelled")
+
+        val thrown = assertThrows(CancellationException::class.java) {
+            runBlocking {
+                storageScanOrDefault("fallback") {
+                    throw cancellation
+                }
+            }
+        }
+
+        assertSame(cancellation, thrown)
     }
 
     private fun storedEntry(

--- a/app/src/test/java/moe/ouom/neriplayer/data/storage/StorageUsageSummaryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/storage/StorageUsageSummaryTest.kt
@@ -2,6 +2,9 @@ package moe.ouom.neriplayer.data.storage
 
 import java.io.File
 import java.nio.file.Files
+import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
+import moe.ouom.neriplayer.data.local.database.store.DownloadIndexStorageStats
+import moe.ouom.neriplayer.data.local.database.store.PlatformPlaylistCacheStorageStats
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -83,6 +86,88 @@ class StorageUsageSummaryTest {
         } finally {
             root.deleteRecursively()
         }
+    }
+
+    @Test
+    fun downloadLibraryUsageCountsLyricSidecarsFromDocumentTreeSnapshot() {
+        val usage = managedDownloadLibraryUsage(
+            audioEntries = listOf(storedEntry("song.m4a", 3_000L)),
+            lyricEntries = listOf(
+                storedEntry(".nomedia", 0L),
+                storedEntry("song.lrc", 120L),
+                storedEntry("song_trans.lrc", 80L)
+            ),
+            coverEntries = listOf(storedEntry("song.jpg", 300L)),
+            metadataEntries = listOf(storedEntry("song.m4a.meta.json", 40L))
+        )
+
+        assertEquals(3_000L, usage.audioFiles.sizeBytes)
+        assertEquals(1, usage.audioFiles.fileCount)
+        assertEquals(200L, usage.lyricFiles.sizeBytes)
+        assertEquals(2, usage.lyricFiles.fileCount)
+        assertEquals(300L, usage.coverFiles.sizeBytes)
+        assertEquals(1, usage.coverFiles.fileCount)
+        assertEquals(40L, usage.metadataFiles.sizeBytes)
+        assertEquals(1, usage.metadataFiles.fileCount)
+        assertTrue(usage.localFiles.isEmpty())
+    }
+
+    @Test
+    fun downloadIndexUsageKeepsRoomRecordsSeparateFromLegacyFiles() {
+        val usage = downloadIndexUsageStats(
+            fileStats = FileStats(sizeBytes = 32L, fileCount = 1),
+            roomStats = DownloadIndexStorageStats(
+                databaseRecordCount = 118,
+                allocatedPageBytes = 8_192L
+            )
+        )
+
+        assertEquals(8_224L, usage.sizeBytes)
+        assertEquals(1, usage.fileCount)
+        assertEquals(118, usage.databaseRecordCount)
+    }
+
+    @Test
+    fun databaseAttributionDoesNotDoubleCountDownloadIndexPages() {
+        val attribution = normalizeDatabaseStorageAttribution(
+            platformCacheStats = mapOf(
+                "netease" to PlatformPlaylistCacheStorageStats(
+                    cacheRecordCount = 2,
+                    allocatedPageBytes = 700L
+                )
+            ),
+            downloadIndexStorageStats = DownloadIndexStorageStats(
+                databaseRecordCount = 118,
+                allocatedPageBytes = 800L
+            ),
+            databaseBytes = 1_000L
+        )
+        val attributedBytes = attribution.platformCacheStats.values.sumOf {
+            it.allocatedPageBytes
+        } + attribution.downloadIndexStorageStats.allocatedPageBytes
+
+        assertEquals(1_000L, attributedBytes)
+        assertEquals(
+            0L,
+            databaseUsageStats(
+                databaseStats = FileStats(sizeBytes = 1_000L, fileCount = 1),
+                attributedDatabaseBytes = attributedBytes
+            ).sizeBytes
+        )
+    }
+
+    private fun storedEntry(
+        name: String,
+        sizeBytes: Long
+    ): ManagedDownloadStorage.StoredEntry {
+        return ManagedDownloadStorage.StoredEntry(
+            name = name,
+            reference = "content://downloads/$name",
+            mediaUri = "content://downloads/$name",
+            localFilePath = null,
+            sizeBytes = sizeBytes,
+            lastModifiedMs = 0L
+        )
     }
 
     private fun usageItem(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 用户可见变化

- 存储分析现在分别统计下载音乐、歌词、封面和下载索引。
- 下载封面会作为独立的存储类型显示。
- 下载索引会显示记录数和索引文件数。
- 数据库空间会统一归因，避免重复计算。
- 扫描应用数据时会排除托管下载文件，避免重复统计。

## 测试

- 新增存储统计测试。
- 覆盖下载音频、歌词、封面、元数据、下载索引和数据库空间归因。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->