### PR TITLE
feat: implement playback progress prediction for WaveformSlider

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/ui/component/playback/WaveformSlider.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/component/playback/WaveformSlider.kt
@@ -61,6 +61,7 @@ import kotlin.math.sin
 private const val WAVE_AMPLITUDE = 6f   // 波浪的振幅
 private const val WAVE_FREQUENCY = 0.08f // 波浪的频率
 private const val WAVE_ANIMATION_DURATION_NS = 2_000_000_000L
+private const val NANOS_PER_MILLISECOND = 1_000_000L
 private const val WAVE_SAMPLE_SPACING_PX = 6f
 private const val MIN_WAVE_SEGMENTS = 48
 private const val MAX_WAVE_SEGMENTS = 180
@@ -88,8 +89,14 @@ fun WaveformSlider(
     onValueChangeCanceled: () -> Unit = {},
     enabled: Boolean = true,
     isPlaybackWaiting: Boolean = false,
-    activeTint: Color = MaterialTheme.colorScheme.primary
+    isProgressStalled: Boolean = false,
+    isProgressPreviewing: Boolean = false,
+    activeTint: Color = MaterialTheme.colorScheme.primary,
+    durationMs: Long = 0L,
+    playbackSpeed: Float = 1f,
+    playbackSessionKey: String? = null
 ) {
+    val clampedValue = normalizeWaveProgress(value)
     val activeColor = activeTint.copy(alpha = if (enabled) 1f else 0.55f)
     val inactiveColor = MaterialTheme.colorScheme.onSurface.copy(alpha = if (enabled) 0.3f else 0.18f)
     val thumbColor = activeTint.copy(alpha = if (enabled) 1f else 0.55f)
@@ -117,9 +124,36 @@ fun WaveformSlider(
     val isWaitingPulseAnimating = animationsEnabled && isPlaybackWaiting && !isDragging
     val isWaveAnimating =
         animationsEnabled && enabled && isPlaying && !isPlaybackWaiting && !isDragging
-    LaunchedEffect(lifecycleOwner, isWaitingPulseAnimating, isWaveAnimating) {
+    val isProgressPredicting = shouldPredictWaveProgress(
+        isWaveAnimating = isWaveAnimating,
+        isProgressStalled = isProgressStalled,
+        isProgressPreviewing = isProgressPreviewing
+    )
+    val waveProgress = remember(playbackSessionKey) { WaveProgressPredictor(clampedValue) }
+    LaunchedEffect(
+        playbackSessionKey,
+        clampedValue,
+        durationMs,
+        playbackSpeed,
+        isProgressPredicting
+    ) {
+        waveProgress.updateTarget(
+            targetValue = clampedValue,
+            durationMs = durationMs,
+            playbackSpeed = playbackSpeed,
+            animate = isProgressPredicting
+        )
+    }
+    LaunchedEffect(
+        lifecycleOwner,
+        waveProgress,
+        isWaitingPulseAnimating,
+        isWaveAnimating,
+        isProgressPredicting
+    ) {
         if (!isWaitingPulseAnimating && !isWaveAnimating) return@LaunchedEffect
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            waveProgress.resetFrameAnchor()
             val anchorPhase = phase
             var anchorFrameNs = 0L
             while (isActive) {
@@ -128,6 +162,9 @@ fun WaveformSlider(
                     anchorFrameNs = frameNs
                 }
                 val elapsedNs = frameNs - anchorFrameNs
+                if (isProgressPredicting) {
+                    waveProgress.onFrame(frameNs)
+                }
                 phase = if (isWaitingPulseAnimating) {
                     resolveWaitingPulsePhase(anchorPhase, elapsedNs)
                 } else {
@@ -182,7 +219,12 @@ fun WaveformSlider(
             .then(dragModifier)
     ) {
         val centerY = size.height / 2
-        val progressPx = value * size.width
+        val progressValue = if (isProgressPredicting) {
+            waveProgress.currentValue
+        } else {
+            clampedValue
+        }
+        val progressPx = progressValue * size.width
         val currentPhase = phase
 
         if (isPlaybackWaiting && !isDragging) {
@@ -273,6 +315,29 @@ internal fun resolveWavePhase(anchorPhase: Float, elapsedNs: Long): Float {
     return resolveAnimationPhase(anchorPhase, elapsedNs, WAVE_ANIMATION_DURATION_NS)
 }
 
+internal fun resolveWaveProgress(
+    anchorValue: Float,
+    durationMs: Long,
+    playbackSpeed: Float,
+    elapsedNs: Long
+): Float {
+    val anchor = normalizeWaveProgress(anchorValue)
+    if (durationMs <= 0L) return anchor
+    val speed = normalizeWavePlaybackSpeed(playbackSpeed)
+    if (speed <= 0f) return anchor
+    val elapsedMs = elapsedNs.coerceAtLeast(0L).toDouble() / NANOS_PER_MILLISECOND
+    val progressAdvance = elapsedMs / durationMs.toDouble() * speed
+    return (anchor + progressAdvance.toFloat()).coerceIn(0f, 1f)
+}
+
+internal fun shouldPredictWaveProgress(
+    isWaveAnimating: Boolean,
+    isProgressStalled: Boolean,
+    isProgressPreviewing: Boolean
+): Boolean {
+    return isWaveAnimating && !isProgressStalled && !isProgressPreviewing
+}
+
 internal fun resolveWaitingPulsePhase(anchorPhase: Float, elapsedNs: Long): Float {
     return resolveAnimationPhase(
         anchorPhase = anchorPhase,
@@ -314,6 +379,72 @@ private fun resolveAnimationPhase(
     val elapsedInCycle = elapsedNs.floorMod(durationNs)
     val cycleFraction = elapsedInCycle.toFloat() / durationNs.toFloat()
     return (anchorPhase + TWO_PI * cycleFraction).floorMod(TWO_PI)
+}
+
+private fun normalizeWaveProgress(value: Float): Float {
+    return value.takeIf { it.isFinite() }?.coerceIn(0f, 1f) ?: 0f
+}
+
+private fun normalizeWavePlaybackSpeed(value: Float): Float {
+    return value.takeIf { it.isFinite() && it > 0f } ?: 0f
+}
+
+internal class WaveProgressPredictor(initialValue: Float) {
+    private var anchorValue = normalizeWaveProgress(initialValue)
+    private var targetValue = anchorValue
+    private var durationMs = 0L
+    private var playbackSpeed = 0f
+    private var anchorFrameNs = 0L
+    private var hasPendingAnchor = true
+    private var wasAnimating = false
+
+    var currentValue = anchorValue
+        private set
+
+    fun updateTarget(
+        targetValue: Float,
+        durationMs: Long,
+        playbackSpeed: Float,
+        animate: Boolean
+    ) {
+        val normalizedTarget = normalizeWaveProgress(targetValue)
+        val normalizedDurationMs = durationMs.coerceAtLeast(0L)
+        val normalizedPlaybackSpeed = normalizeWavePlaybackSpeed(playbackSpeed)
+        val inputChanged = normalizedTarget != this.targetValue ||
+            normalizedDurationMs != this.durationMs ||
+            normalizedPlaybackSpeed != this.playbackSpeed
+        if (inputChanged || !animate || !wasAnimating) {
+            anchorValue = normalizedTarget
+            currentValue = normalizedTarget
+            hasPendingAnchor = true
+        }
+        this.targetValue = normalizedTarget
+        this.durationMs = normalizedDurationMs
+        this.playbackSpeed = normalizedPlaybackSpeed
+        wasAnimating = animate
+    }
+
+    fun onFrame(frameNs: Long) {
+        if (frameNs <= 0L) return
+        if (hasPendingAnchor || anchorFrameNs == 0L || frameNs < anchorFrameNs) {
+            anchorFrameNs = frameNs
+            currentValue = anchorValue
+            hasPendingAnchor = false
+            return
+        }
+        currentValue = resolveWaveProgress(
+            anchorValue = anchorValue,
+            durationMs = durationMs,
+            playbackSpeed = playbackSpeed,
+            elapsedNs = frameNs - anchorFrameNs
+        )
+    }
+
+    fun resetFrameAnchor() {
+        anchorValue = currentValue
+        anchorFrameNs = 0L
+        hasPendingAnchor = true
+    }
 }
 
 private fun Long.floorMod(other: Long): Long {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/LyricsScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/LyricsScreen.kt
@@ -676,6 +676,7 @@ fun LyricsScreen(
                 lyricOffsetMs = lyricOffsetMs,
                 isPlaying = isPlaying,
                 isPlaybackWaiting = isPlaybackWaiting,
+                playbackSpeed = lyricsPlaybackSoundState.speed,
                 onSeekTo = onSeekTo,
                 seekEnabled = progressSeekEnabled,
                 onPreviewPositionChange = { previewPositionOverrideMs = it },
@@ -1206,6 +1207,7 @@ private fun LyricsProgressSection(
     lyricOffsetMs: Long,
     isPlaying: Boolean,
     isPlaybackWaiting: Boolean,
+    playbackSpeed: Float,
     onSeekTo: (Long) -> Unit,
     seekEnabled: Boolean,
     onPreviewPositionChange: (Long?) -> Unit,
@@ -1313,7 +1315,13 @@ private fun LyricsProgressSection(
             },
             isPlaying = isPlaying,
             enabled = seekEnabled,
-            isPlaybackWaiting = delayedPlaybackWaiting
+            isPlaybackWaiting = delayedPlaybackWaiting,
+            isProgressStalled = isPlaybackWaiting,
+            isProgressPreviewing = isUserDraggingSlider ||
+                pendingSeekPreviewPositionMs != null,
+            durationMs = durationMs,
+            playbackSpeed = playbackSpeed,
+            playbackSessionKey = songKey
         )
 
         Text(

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
@@ -2569,6 +2569,7 @@ fun NowPlayingScreen(
                         lyricOffsetMs = totalOffset,
                         isPlaying = isPlaying,
                         isPlaybackWaiting = isPlaybackWaiting,
+                        playbackSpeed = playbackSoundState.speed,
                         progressInfoSegments = progressInfoSegments,
                         seekEnabled = playbackProgressSeekEnabled,
                         activeContentColor = targetNowPlayingActiveIconColor,
@@ -5092,6 +5093,7 @@ private fun NowPlayingProgressSection(
     lyricOffsetMs: Long,
     isPlaying: Boolean,
     isPlaybackWaiting: Boolean,
+    playbackSpeed: Float,
     progressInfoSegments: List<NowPlayingProgressInfoSegment>,
     seekEnabled: Boolean,
     activeContentColor: Color,
@@ -5208,7 +5210,13 @@ private fun NowPlayingProgressSection(
                 isPlaying = isPlaying,
                 enabled = seekEnabled,
                 isPlaybackWaiting = delayedPlaybackWaiting,
-                activeTint = activeContentColor
+                isProgressStalled = isPlaybackWaiting,
+                isProgressPreviewing = isUserDraggingSlider ||
+                    pendingSeekPreviewPositionMs != null,
+                activeTint = activeContentColor,
+                durationMs = durationMs,
+                playbackSpeed = playbackSpeed,
+                playbackSessionKey = songKey
             )
 
             Text(

--- a/app/src/test/java/moe/ouom/neriplayer/ui/component/playback/WaveformSliderTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/component/playback/WaveformSliderTest.kt
@@ -29,6 +29,190 @@ class WaveformSliderTest {
     }
 
     @Test
+    fun `short track progress advances at the rendered frame cadence`() {
+        assertEquals(
+            0.225f,
+            resolveWaveProgress(
+                anchorValue = 0.20f,
+                durationMs = 5_000L,
+                playbackSpeed = 1f,
+                elapsedNs = 125_000_000L
+            ),
+            0.0001f
+        )
+        assertEquals(
+            0.25f,
+            resolveWaveProgress(
+                anchorValue = 0.20f,
+                durationMs = 5_000L,
+                playbackSpeed = 1f,
+                elapsedNs = 250_000_000L
+            ),
+            0.0001f
+        )
+    }
+
+    @Test
+    fun `wave progress prediction clamps values and ignores invalid inputs`() {
+        assertEquals(
+            0f,
+            resolveWaveProgress(
+                anchorValue = -0.2f,
+                durationMs = 5_000L,
+                playbackSpeed = 1f,
+                elapsedNs = -1L
+            ),
+            0.0001f
+        )
+        assertEquals(
+            1f,
+            resolveWaveProgress(
+                anchorValue = 0.8f,
+                durationMs = 5_000L,
+                playbackSpeed = 1f,
+                elapsedNs = 5_000_000_000L
+            ),
+            0.0001f
+        )
+        assertEquals(
+            0.8f,
+            resolveWaveProgress(
+                anchorValue = 0.8f,
+                durationMs = 0L,
+                playbackSpeed = 1f,
+                elapsedNs = 250_000_000L
+            ),
+            0.0001f
+        )
+        assertEquals(
+            0.8f,
+            resolveWaveProgress(
+                anchorValue = 0.8f,
+                durationMs = 5_000L,
+                playbackSpeed = Float.NaN,
+                elapsedNs = 250_000_000L
+            ),
+            0.0001f
+        )
+    }
+
+    @Test
+    fun `wave progress prediction stops for waiting and seek previews`() {
+        assertTrue(
+            shouldPredictWaveProgress(
+                isWaveAnimating = true,
+                isProgressStalled = false,
+                isProgressPreviewing = false
+            )
+        )
+        assertEquals(
+            false,
+            shouldPredictWaveProgress(
+                isWaveAnimating = true,
+                isProgressStalled = true,
+                isProgressPreviewing = false
+            )
+        )
+        assertEquals(
+            false,
+            shouldPredictWaveProgress(
+                isWaveAnimating = true,
+                isProgressStalled = false,
+                isProgressPreviewing = true
+            )
+        )
+        assertEquals(
+            false,
+            shouldPredictWaveProgress(
+                isWaveAnimating = false,
+                isProgressStalled = false,
+                isProgressPreviewing = false
+            )
+        )
+    }
+
+    @Test
+    fun `predictor reanchors each real progress update without sampler lag`() {
+        val predictor = WaveProgressPredictor(0.20f)
+
+        predictor.updateTarget(
+            targetValue = 0.20f,
+            durationMs = 5_000L,
+            playbackSpeed = 1f,
+            animate = true
+        )
+        predictor.onFrame(1_000_000_000L)
+        predictor.onFrame(1_125_000_000L)
+        assertEquals(0.225f, predictor.currentValue, 0.0001f)
+
+        predictor.updateTarget(
+            targetValue = 0.25f,
+            durationMs = 5_000L,
+            playbackSpeed = 1f,
+            animate = true
+        )
+        predictor.onFrame(1_250_000_000L)
+        assertEquals(0.25f, predictor.currentValue, 0.0001f)
+        predictor.onFrame(1_375_000_000L)
+        assertEquals(0.275f, predictor.currentValue, 0.0001f)
+    }
+
+    @Test
+    fun `predictor immediately aligns after pause and seek`() {
+        val predictor = WaveProgressPredictor(0.40f)
+
+        predictor.updateTarget(
+            targetValue = 0.40f,
+            durationMs = 10_000L,
+            playbackSpeed = 1.5f,
+            animate = true
+        )
+        predictor.onFrame(1_000_000_000L)
+        predictor.onFrame(1_200_000_000L)
+        assertEquals(0.43f, predictor.currentValue, 0.0001f)
+
+        predictor.updateTarget(
+            targetValue = 0.15f,
+            durationMs = 10_000L,
+            playbackSpeed = 1.5f,
+            animate = false
+        )
+        assertEquals(0.15f, predictor.currentValue, 0.0001f)
+
+        predictor.updateTarget(
+            targetValue = 0.15f,
+            durationMs = 10_000L,
+            playbackSpeed = 1.5f,
+            animate = true
+        )
+        predictor.onFrame(2_000_000_000L)
+        assertEquals(0.15f, predictor.currentValue, 0.0001f)
+        predictor.onFrame(2_200_000_000L)
+        assertEquals(0.18f, predictor.currentValue, 0.0001f)
+    }
+
+    @Test
+    fun `predictor resets its frame anchor when animation resumes`() {
+        val predictor = WaveProgressPredictor(0.40f)
+
+        predictor.updateTarget(
+            targetValue = 0.40f,
+            durationMs = 10_000L,
+            playbackSpeed = 1f,
+            animate = true
+        )
+        predictor.onFrame(1_000_000_000L)
+        predictor.onFrame(1_200_000_000L)
+        assertEquals(0.42f, predictor.currentValue, 0.0001f)
+
+        predictor.resetFrameAnchor()
+        predictor.onFrame(10_000_000_000L)
+        assertEquals(0.42f, predictor.currentValue, 0.0001f)
+        predictor.onFrame(10_200_000_000L)
+        assertEquals(0.44f, predictor.currentValue, 0.0001f)
+    }
+
+    @Test
     fun `waiting pulse segment count stays dense but bounded`() {
         assertEquals(1, resolveWaitingPulseSegmentCount(0f, 24f))
         assertEquals(1, resolveWaitingPulseSegmentCount(12f, 24f))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 用户可见变化
- 播放波形进度会按播放时长和播放速度预测，并在短音频上保持平滑推进。
- 播放等待、停滞或拖动预览时，进度预测会暂停并显示对应进度。
- 播放暂停、跳转、恢复播放或会话变化后，进度预测会重新对齐实际进度。
- 无效或越界进度会被限制在有效范围内。

## 兼容性影响
- `WaveformSlider` 新增进度停滞、预览、时长、播放速度和会话标识参数。现有调用方需要更新参数。

## 测试
- 新增短音频逐帧推进测试。
- 新增进度钳制、等待和预览状态测试。
- 新增实时更新、暂停、跳转及动画恢复后的重新对齐测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->