### PR TITLE
feat(netease): fetch and apply personalized metadata for radar playlists

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/auth/netease/NeteaseCookieRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/auth/netease/NeteaseCookieRepositoryAndroidTest.kt
@@ -9,10 +9,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import moe.ouom.neriplayer.core.api.netease.NeteaseClient
 import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthState
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -98,6 +100,45 @@ class NeteaseCookieRepositoryAndroidTest {
 
         val recreatedRepository = NeteaseCookieRepository(context)
         assertEquals("legacy-cookie", recreatedRepository.getCookiesOnce()["MUSIC_U"])
+    }
+
+    @Test
+    fun saveCookiesIfCurrent_rejectsAnObsoleteAccountSnapshot() {
+        val repository = NeteaseCookieRepository(context)
+        assertTrue(repository.saveCookies(mapOf("MUSIC_U" to "account-a")))
+        val accountASnapshot = repository.getCookiesOnce()
+
+        assertTrue(repository.saveCookies(mapOf("MUSIC_U" to "account-b")))
+        assertFalse(
+            repository.saveCookiesIfCurrent(
+                expectedCookies = accountASnapshot,
+                cookies = accountASnapshot + ("__csrf" to "old-session")
+            )
+        )
+        assertEquals("account-b", repository.getCookiesOnce()["MUSIC_U"])
+        assertNull(repository.getCookiesOnce()["__csrf"])
+    }
+
+    @Test
+    fun withCurrentCookiesIfMatches_doesNotReactivateAnObsoleteClientSession() {
+        val repository = NeteaseCookieRepository(context)
+        val client = NeteaseClient()
+        assertTrue(repository.saveCookies(mapOf("MUSIC_U" to "account-a")))
+        val accountA = repository.getCookiesOnce()
+
+        assertTrue(repository.saveCookies(mapOf("MUSIC_U" to "account-b")))
+        assertTrue(
+            repository.withCurrentCookiesIfMatches(repository.getCookiesOnce()) { cookies ->
+                client.setPersistedCookies(cookies)
+            }
+        )
+        assertFalse(
+            repository.withCurrentCookiesIfMatches(accountA) { cookies ->
+                client.setPersistedCookies(cookies)
+            }
+        )
+
+        assertEquals("account-b", client.getNeteaseRequestCookies()["MUSIC_U"])
     }
 
     private fun clearStorage() {

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/platform/PlatformPlaylistCacheRoomMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/platform/PlatformPlaylistCacheRoomMigrationTest.kt
@@ -25,6 +25,7 @@ import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistDetail
 import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistHeader
 import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistTrack
 import moe.ouom.neriplayer.data.platform.netease.NeteasePlaylistCacheRepository
+import moe.ouom.neriplayer.data.platform.netease.neteaseRadarPlaylistCacheKey
 import moe.ouom.neriplayer.data.platform.youtube.CachedYouTubeMusicPlaylistDetail
 import moe.ouom.neriplayer.data.platform.youtube.CachedYouTubeMusicPlaylistTrack
 import moe.ouom.neriplayer.data.platform.youtube.YouTubeMusicPlaylistCacheRepository
@@ -39,6 +40,10 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class PlatformPlaylistCacheRoomMigrationTest {
     private val gson = Gson()
+
+    private companion object {
+        const val RADAR_PLAYLIST_ID = 5_320_167_908L
+    }
 
     @Test
     fun roomStoreRoundTripsHeaderTracksAndArtists() = runTest {
@@ -142,7 +147,10 @@ class PlatformPlaylistCacheRoomMigrationTest {
             val biliArchiveDir = File(root, "bili_archive_cache").apply { mkdirs() }
             val youtubeDir = File(root, "youtube_music_playlist_cache").apply { mkdirs() }
 
-            val neteaseCache = neteaseCache()
+            val neteaseCache = neteaseCache(
+                playlistId = RADAR_PLAYLIST_ID,
+                radarCacheContext = "radar-account-fingerprint"
+            )
             val biliFavoriteCache = biliFavoriteCache()
             val biliArchiveCache = biliArchiveCache()
             val youtubeCache = youtubeCache()
@@ -178,21 +186,34 @@ class PlatformPlaylistCacheRoomMigrationTest {
             assertFalse(biliFavoriteFile.exists())
             assertFalse(biliArchiveFile.exists())
             assertFalse(youtubeFile.exists())
-            assertEquals(neteaseCache, neteaseRepo.read(neteaseCache.playlistId))
+            assertEquals(
+                neteaseCache,
+                neteaseRepo.read(neteaseCache.playlistId, neteaseCache.radarCacheContext)
+            )
             assertEquals(biliFavoriteCache, biliFavoriteRepo.read(biliFavoriteCache.mediaId))
             assertEquals(
                 biliArchiveCache,
                 biliArchiveRepo.read(biliArchiveCache.mediaId, biliArchiveCache.kind)
             )
             assertEquals(youtubeCache, youtubeRepo.read(youtubeCache.browseId))
-            assertNotNull(database.platformPlaylistCacheDao().getCache("netease", "42"))
+            val neteaseRecord = database.platformPlaylistCacheDao().getCache(
+                "netease",
+                neteaseRadarPlaylistCacheKey(
+                    neteaseCache.playlistId,
+                    neteaseCache.radarCacheContext
+                )
+            )
+            assertNotNull(neteaseRecord)
+            assertEquals("radar-account-fingerprint", neteaseRecord?.signatureSecondary)
 
-            neteaseRepo.clear(neteaseCache.playlistId)
+            neteaseRepo.clear(neteaseCache.playlistId, neteaseCache.radarCacheContext)
             biliFavoriteRepo.clear(biliFavoriteCache.mediaId)
             biliArchiveRepo.clear(biliArchiveCache.mediaId, biliArchiveCache.kind)
             youtubeRepo.clear(youtubeCache.browseId)
 
-            assertNull(neteaseRepo.read(neteaseCache.playlistId))
+            assertNull(
+                neteaseRepo.read(neteaseCache.playlistId, neteaseCache.radarCacheContext)
+            )
             assertNull(biliFavoriteRepo.read(biliFavoriteCache.mediaId))
             assertNull(biliArchiveRepo.read(biliArchiveCache.mediaId, biliArchiveCache.kind))
             assertNull(youtubeRepo.read(youtubeCache.browseId))
@@ -234,6 +255,70 @@ class PlatformPlaylistCacheRoomMigrationTest {
         }
     }
 
+    @Test
+    fun neteaseRepositoryDoesNotReplaceNewerRoomCache() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = inMemoryDatabase(context)
+        val root = File(context.cacheDir, "platform-cache-current-${System.nanoTime()}")
+        try {
+            val repo = NeteasePlaylistCacheRepository(context, database, root)
+            val newerCache = neteaseCache(
+                playlistName = "new room cache",
+                savedAtMs = 500L
+            )
+            val staleCache = neteaseCache(
+                playlistName = "stale response cache",
+                savedAtMs = 100L
+            )
+
+            repo.save(newerCache)
+            repo.saveIfNewer(staleCache)
+
+            assertEquals(newerCache, repo.read(newerCache.playlistId))
+        } finally {
+            database.close()
+            root.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun neteaseRepositorySeparatesRadarCachesByAccountContext() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val database = inMemoryDatabase(context)
+        val root = File(context.cacheDir, "platform-cache-radar-${System.nanoTime()}")
+        try {
+            val repo = NeteasePlaylistCacheRepository(context, database, root)
+            val accountACache = neteaseCache(
+                playlistId = RADAR_PLAYLIST_ID,
+                playlistName = "account A radar",
+                radarCacheContext = "account-a-context",
+                savedAtMs = 200L
+            )
+            val accountBCache = neteaseCache(
+                playlistId = RADAR_PLAYLIST_ID,
+                playlistName = "account B radar",
+                radarCacheContext = "account-b-context",
+                savedAtMs = 100L
+            )
+
+            repo.saveIfNewer(accountBCache)
+            repo.saveIfNewer(accountACache)
+
+            assertEquals(
+                accountACache,
+                repo.read(RADAR_PLAYLIST_ID, accountACache.radarCacheContext)
+            )
+            assertEquals(
+                accountBCache,
+                repo.read(RADAR_PLAYLIST_ID, accountBCache.radarCacheContext)
+            )
+            assertNull(repo.read(RADAR_PLAYLIST_ID, "account-c-context"))
+        } finally {
+            database.close()
+            root.deleteRecursively()
+        }
+    }
+
     private fun inMemoryDatabase(context: Context): NeriUserDataDatabase {
         return Room.inMemoryDatabaseBuilder(
             context,
@@ -263,13 +348,15 @@ class PlatformPlaylistCacheRoomMigrationTest {
     }
 
     private fun neteaseCache(
+        playlistId: Long = 42L,
         playlistName: String = "NetEase Mix",
+        radarCacheContext: String? = null,
         savedAtMs: Long = 100L
     ): CachedNeteasePlaylistDetail {
         return CachedNeteasePlaylistDetail(
-            playlistId = 42L,
+            playlistId = playlistId,
             header = CachedNeteasePlaylistHeader(
-                id = 42L,
+                id = playlistId,
                 name = playlistName,
                 coverUrl = "https://img.example/netease.jpg",
                 playCount = 88L,
@@ -290,6 +377,7 @@ class PlatformPlaylistCacheRoomMigrationTest {
                     addedAt = 11L
                 )
             ),
+            radarCacheContext = radarCacheContext,
             savedAtMs = savedAtMs
         )
     }

--- a/app/src/main/java/moe/ouom/neriplayer/core/api/netease/NeteaseClient.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/api/netease/NeteaseClient.kt
@@ -108,100 +108,107 @@ internal fun buildNeteaseRadarPlaylistMetadataParams(playlistId: Long): Map<Stri
     )
 }
 
-class NeteaseClient {
-    private companion object {
-        const val MAX_RESPONSE_BYTES = 4L * 1024L * 1024L
-        const val NETEASE_MAIN_HOST = "music.163.com"
+private const val NETEASE_MAIN_HOST = "music.163.com"
+private const val NETEASE_REQUEST_OS = "pc"
+private const val NETEASE_REQUEST_APP_VERSION = "8.10.35"
 
-        fun newSessionCookieValue(): String {
-            val bytes = ByteArray(16)
-            SecureRandom().nextBytes(bytes)
-            val hex = "0123456789abcdef"
-            return buildString(bytes.size * 2) {
-                bytes.forEach { byte ->
-                    val value = byte.toInt() and 0xff
-                    append(hex[value ushr 4])
-                    append(hex[value and 0x0f])
+private fun newNeteaseSessionCookieValue(): String {
+    val bytes = ByteArray(16)
+    SecureRandom().nextBytes(bytes)
+    val hex = "0123456789abcdef"
+    return buildString(bytes.size * 2) {
+        bytes.forEach { byte ->
+            val value = byte.toInt() and 0xff
+            append(hex[value ushr 4])
+            append(hex[value and 0x0f])
+        }
+    }
+}
+
+private fun normalizeNeteasePersistedCookies(cookies: Map<String, String>): Map<String, String> {
+    return cookies.toMutableMap().apply {
+        putIfAbsent("os", NETEASE_REQUEST_OS)
+        putIfAbsent("appver", NETEASE_REQUEST_APP_VERSION)
+    }.toMap()
+}
+
+private fun neteaseAuthCookieFingerprint(cookies: Map<String, String>): String {
+    return cookies
+        .filterKeys { key ->
+            key !in setOf("NMTID", "__csrf", "_ntes_nuid", "__remember_me", "os", "appver")
+        }
+        .entries
+        .sortedBy { entry -> entry.key }
+        .joinToString("\u0000") { entry -> "${entry.key}=${entry.value}" }
+}
+
+internal class NeteaseRequestSession(
+    initialPersistedCookies: Map<String, String>
+) {
+    private val cookieStore: MutableMap<String, MutableList<Cookie>> = mutableMapOf()
+    private val cookieLock = Any()
+    private var persistedCookies = initialPersistedCookies
+    private val requestContextCookies = mapOf(
+        "__remember_me" to "true",
+        "_ntes_nuid" to newNeteaseSessionCookieValue(),
+        "NMTID" to newNeteaseSessionCookieValue()
+    )
+    internal val personalizedSessionLock = Any()
+    private var preheatedAuthCookieFingerprint: String? = null
+
+    internal val cookieJar = object : CookieJar {
+        override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+            saveResponseCookies(cookies)
+        }
+
+        override fun loadForRequest(url: HttpUrl): List<Cookie> {
+            return requestCookiesForUrl(url)
+                .map { (name, value) ->
+                    Cookie.Builder()
+                        .name(name)
+                        .value(value)
+                        .hostOnlyDomain(url.host)
+                        .path("/")
+                        .build()
                 }
-            }
         }
     }
 
-    private val okHttpClient: OkHttpClient
-    private val http1RetryClient: OkHttpClient
-    private val cookieStore: MutableMap<String, MutableList<Cookie>> = mutableMapOf()
-    private val cookieLock = Any()
-    private val neteaseMainUrl = "https://$NETEASE_MAIN_HOST/".toHttpUrl()
+    internal val okHttpClient: OkHttpClient = OkHttpClient.Builder()
+        .cookieJar(cookieJar)
+        // use a dynamic ProxySelector so bypass can be toggled at runtime
+        .proxySelector(DynamicProxySelector)
+        .build()
+    internal val http1RetryClient: OkHttpClient = okHttpClient.newBuilder()
+        .protocols(listOf(Protocol.HTTP_1_1))
+        .build()
 
-    @Volatile
-    private var persistedCookies: Map<String, String> = emptyMap()
-    private val requestContextCookies = mapOf(
-        "__remember_me" to "true",
-        "_ntes_nuid" to newSessionCookieValue(),
-        "NMTID" to newSessionCookieValue()
-    )
-    private val personalizedSessionLock = Any()
-    private var preheatedAuthCookieFingerprint: String? = null
-
-    init {
-        okHttpClient = OkHttpClient.Builder()
-            .cookieJar(object : CookieJar {
-                override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
-                    synchronized(cookieLock) {
-                        cookies.forEach { fresh ->
-                            removeStoredCookie(fresh)
-                            if (fresh.isUsableCookie()) {
-                                cookieStore.getOrPut(fresh.domain) { mutableListOf() }.add(fresh)
-                            }
-                        }
-                    }
-                }
-
-                override fun loadForRequest(url: HttpUrl): List<Cookie> {
-                    return synchronized(cookieLock) {
-                        requestCookiesForUrlLocked(url)
-                            .map { (name, value) ->
-                                Cookie.Builder()
-                                    .name(name)
-                                    .value(value)
-                                    .hostOnlyDomain(url.host)
-                                    .path("/")
-                                    .build()
-                            }
-                    }
-                }
-            })
-            // use a dynamic ProxySelector so bypass can be toggled at runtime
-            .proxySelector(DynamicProxySelector)
-            .build()
-        http1RetryClient = okHttpClient.newBuilder()
-            .protocols(listOf(Protocol.HTTP_1_1))
-            .build()
+    fun hasLogin(): Boolean = synchronized(cookieLock) {
+        !persistedCookies["MUSIC_U"].isNullOrBlank()
     }
 
-    fun evictConnections() {
-        okHttpClient.connectionPool.evictAll()
+    fun persistedCookiesSnapshot(): Map<String, String> = synchronized(cookieLock) {
+        persistedCookies
     }
 
-    /** 是否已登录 */
-    fun hasLogin(): Boolean = !persistedCookies["MUSIC_U"].isNullOrBlank()
+    fun authCookieFingerprint(): String = synchronized(cookieLock) {
+        neteaseAuthCookieFingerprint(persistedCookies)
+    }
 
-    /** 设置/更新持久化 Cookie, 并把它们注入到本实例的 CookieJar */
-    fun setPersistedCookies(cookies: Map<String, String>) {
-        val m = cookies.toMutableMap()
-        m.putIfAbsent("os", "pc")
-        m.putIfAbsent("appver", "8.10.35")
-        val snapshot = m.toMap()
+    fun replacePersistedCookies(snapshot: Map<String, String>) {
         synchronized(cookieLock) {
-            if (persistedCookies == snapshot) return
-
-            if (authCookieFingerprint(persistedCookies) != authCookieFingerprint(snapshot)) {
-                preheatedAuthCookieFingerprint = null
-            }
             persistedCookies = snapshot
             cookieStore.clear()
             seedCookieJarFromPersistedLocked("music.163.com", snapshot)
             seedCookieJarFromPersistedLocked("interface.music.163.com", snapshot)
+            preheatedAuthCookieFingerprint = null
+        }
+    }
+
+    init {
+        synchronized(cookieLock) {
+            seedCookieJarFromPersistedLocked("music.163.com", persistedCookies)
+            seedCookieJarFromPersistedLocked("interface.music.163.com", persistedCookies)
         }
     }
 
@@ -222,11 +229,7 @@ class NeteaseClient {
         }
     }
 
-    /**
-     * Returns a snapshot of all cookies currently in memory, flattened by name.
-     * Later occurrences override earlier ones.
-     */
-    fun getCookies(): Map<String, String> {
+    fun cookiesSnapshot(): Map<String, String> {
         return synchronized(cookieLock) {
             evictExpiredCookiesLocked()
             val result = LinkedHashMap<String, String>()
@@ -235,54 +238,60 @@ class NeteaseClient {
         }
     }
 
-    /** Returns the exact Cookie context used for music.163.com requests. */
-    internal fun getNeteaseRequestCookies(): Map<String, String> {
+    fun requestCookiesForUrl(requestUrl: HttpUrl): Map<String, String> {
         return synchronized(cookieLock) {
-            requestCookiesForUrlLocked("https://$NETEASE_MAIN_HOST/".toHttpUrl())
+            requestCookiesForUrlLocked(requestUrl)
         }
     }
 
-    fun logout() {
+    fun hasPreheatedPersonalizedSession(
+        fingerprint: String,
+        requestUrl: HttpUrl
+    ): Boolean {
         synchronized(cookieLock) {
-            cookieStore.clear()
-            persistedCookies = emptyMap()
-            preheatedAuthCookieFingerprint = null
+            return preheatedAuthCookieFingerprint == fingerprint &&
+                !requestCookiesForUrlLocked(requestUrl)["__csrf"].isNullOrBlank()
         }
     }
 
-    /** Preheats the personalized session once for the current login identity. */
-    @Throws(IOException::class)
-    fun ensurePersonalizedSession() {
-        val fingerprint = synchronized(cookieLock) {
-            if (persistedCookies["MUSIC_U"].isNullOrBlank()) {
-                return
+    fun markPersonalizedSessionPreheated(
+        fingerprint: String,
+        requestUrl: HttpUrl
+    ) {
+        synchronized(cookieLock) {
+            preheatedAuthCookieFingerprint = if (
+                neteaseAuthCookieFingerprint(persistedCookies) == fingerprint &&
+                !requestCookiesForUrlLocked(requestUrl)["__csrf"].isNullOrBlank()
+            ) {
+                fingerprint
+            } else {
+                null
             }
-            authCookieFingerprint(persistedCookies)
         }
-        synchronized(personalizedSessionLock) {
-            val alreadyPreheated = synchronized(cookieLock) {
-                preheatedAuthCookieFingerprint == fingerprint &&
-                    !requestCookiesForUrlLocked(neteaseMainUrl)["__csrf"].isNullOrBlank()
-            }
-            if (alreadyPreheated) return
+    }
 
-            ensureWeapiSession()
+    fun needsWeapiSessionPreheat(
+        requestUrl: HttpUrl,
+        usePersistedCookies: Boolean
+    ): Boolean {
+        return synchronized(cookieLock) {
+            shouldPreheatNeteaseWeapiSession(
+                persistedCookies = persistedCookies,
+                requestCookies = requestCookiesForUrlLocked(requestUrl),
+                usePersistedCookies = usePersistedCookies
+            )
+        }
+    }
 
-            synchronized(cookieLock) {
-                if (
-                    authCookieFingerprint(persistedCookies) == fingerprint &&
-                    !requestCookiesForUrlLocked(neteaseMainUrl)["__csrf"].isNullOrBlank()
-                ) {
-                    preheatedAuthCookieFingerprint = fingerprint
-                } else {
-                    preheatedAuthCookieFingerprint = null
+    private fun saveResponseCookies(cookies: List<Cookie>) {
+        synchronized(cookieLock) {
+            cookies.forEach { fresh ->
+                removeStoredCookie(fresh)
+                if (fresh.isUsableCookie()) {
+                    cookieStore.getOrPut(fresh.domain) { mutableListOf() }.add(fresh)
                 }
             }
         }
-    }
-
-    private fun getCsrfCookie(requestUrl: HttpUrl): String? = synchronized(cookieLock) {
-        requestCookiesForUrlLocked(requestUrl)["__csrf"]
     }
 
     private fun removeStoredCookie(cookie: Cookie) {
@@ -325,21 +334,102 @@ class NeteaseClient {
             cookies.removeAll { it.expiresAt <= now }
         }
     }
+}
 
-    private fun authCookieFingerprint(cookies: Map<String, String>): String {
-        return cookies
-            .filterKeys { key ->
-                key !in setOf("NMTID", "__csrf", "_ntes_nuid", "__remember_me", "os", "appver")
+internal class NeteaseRequestSessionStore {
+    private val sessionLock = Any()
+
+    @Volatile
+    private var activeSession = NeteaseRequestSession(emptyMap())
+
+    fun currentSession(): NeteaseRequestSession = activeSession
+
+    fun setPersistedCookies(cookies: Map<String, String>): NeteaseRequestSession {
+        val snapshot = normalizeNeteasePersistedCookies(cookies)
+        return synchronized(sessionLock) {
+            val current = activeSession
+            if (current.persistedCookiesSnapshot() == snapshot) {
+                return@synchronized current
             }
-            .entries
-            .sortedBy { entry -> entry.key }
-            .joinToString("\u0000") { entry -> "${entry.key}=${entry.value}" }
+            if (current.authCookieFingerprint() != neteaseAuthCookieFingerprint(snapshot)) {
+                NeteaseRequestSession(snapshot).also { replacement ->
+                    activeSession = replacement
+                }
+            } else {
+                current.replacePersistedCookies(snapshot)
+                current
+            }
+        }
+    }
+
+    fun logout() {
+        synchronized(sessionLock) {
+            activeSession = NeteaseRequestSession(emptyMap())
+        }
+    }
+}
+
+class NeteaseClient {
+    private companion object {
+        const val MAX_RESPONSE_BYTES = 4L * 1024L * 1024L
+    }
+
+    private val sessionStore = NeteaseRequestSessionStore()
+    private val neteaseMainUrl = "https://$NETEASE_MAIN_HOST/".toHttpUrl()
+
+    fun evictConnections() {
+        sessionStore.currentSession().okHttpClient.connectionPool.evictAll()
+    }
+
+    /** 是否已登录 */
+    fun hasLogin(): Boolean = sessionStore.currentSession().hasLogin()
+
+    /** 设置/更新持久化 Cookie, 并把它们注入到本实例的 CookieJar */
+    fun setPersistedCookies(cookies: Map<String, String>) {
+        sessionStore.setPersistedCookies(cookies)
+    }
+
+    /**
+     * Returns a snapshot of all cookies currently in memory, flattened by name.
+     * Later occurrences override earlier ones.
+     */
+    fun getCookies(): Map<String, String> = sessionStore.currentSession().cookiesSnapshot()
+
+    /** Returns the exact Cookie context used for music.163.com requests. */
+    internal fun getNeteaseRequestCookies(): Map<String, String> {
+        return sessionStore.currentSession().requestCookiesForUrl(neteaseMainUrl)
+    }
+
+    fun logout() {
+        sessionStore.logout()
+    }
+
+    /** Preheats the personalized session once for the current login identity. */
+    @Throws(IOException::class)
+    fun ensurePersonalizedSession() {
+        ensurePersonalizedSession(sessionStore.currentSession())
+    }
+
+    private fun ensurePersonalizedSession(session: NeteaseRequestSession) {
+        if (!session.hasLogin()) return
+        val fingerprint = session.authCookieFingerprint()
+        synchronized(session.personalizedSessionLock) {
+            if (session.hasPreheatedPersonalizedSession(fingerprint, neteaseMainUrl)) return
+
+            ensureWeapiSession(session)
+            session.markPersonalizedSessionPreheated(fingerprint, neteaseMainUrl)
+        }
     }
 
     /** 访问一次站点首页, 通常会下发 __csrf 等 Cookie */
     @Throws(IOException::class)
     fun ensureWeapiSession() {
-        request(
+        ensureWeapiSession(sessionStore.currentSession())
+    }
+
+    private fun ensureWeapiSession(session: NeteaseRequestSession) {
+        requestForSession(
+            session = session,
             url = "https://music.163.com/",
             params = emptyMap(),
             mode = CryptoMode.API,
@@ -357,23 +447,45 @@ class NeteaseClient {
         usePersistedCookies: Boolean = true,
         retryHttp1OnStreamReset: Boolean = false
     ): String {
-        ensureWeapiSessionIfNeeded(mode, usePersistedCookies)
+        return requestForSession(
+            session = sessionStore.currentSession(),
+            url = url,
+            params = params,
+            mode = mode,
+            method = method,
+            usePersistedCookies = usePersistedCookies,
+            retryHttp1OnStreamReset = retryHttp1OnStreamReset
+        )
+    }
+
+    @Throws(IOException::class)
+    private fun requestForSession(
+        session: NeteaseRequestSession,
+        url: String,
+        params: Map<String, Any>,
+        mode: CryptoMode,
+        method: String,
+        usePersistedCookies: Boolean,
+        retryHttp1OnStreamReset: Boolean = false
+    ): String {
+        ensureWeapiSessionIfNeeded(session, mode, usePersistedCookies)
         val request = buildRequest(
             url = url,
             params = params,
             mode = mode,
             method = method,
-            usePersistedCookies = usePersistedCookies
+            usePersistedCookies = usePersistedCookies,
+            session = session
         )
         return try {
-            executeRequest(okHttpClient, request)
+            executeRequest(session.okHttpClient, request)
         } catch (error: IOException) {
             if (!retryHttp1OnStreamReset || !error.isTransientHttp2StreamReset()) throw error
             NPLogger.w(
                 "NERI-NeteaseClient",
                 "HTTP/2 stream reset for $url, retrying with HTTP/1.1: ${error.message.orEmpty()}"
             )
-            executeRequest(http1RetryClient, request)
+            executeRequest(session.http1RetryClient, request)
         }
     }
 
@@ -385,9 +497,10 @@ class NeteaseClient {
         usePersistedCookies: Boolean = true,
         retryHttp1OnStreamReset: Boolean = false
     ): String {
+        val session = sessionStore.currentSession()
         if (mode == CryptoMode.WEAPI) {
             withContext(Dispatchers.IO) {
-                ensureWeapiSessionIfNeeded(mode, usePersistedCookies)
+                ensureWeapiSessionIfNeeded(session, mode, usePersistedCookies)
             }
         }
         val request = buildRequest(
@@ -395,44 +508,40 @@ class NeteaseClient {
             params = params,
             mode = mode,
             method = method,
-            usePersistedCookies = usePersistedCookies
+            usePersistedCookies = usePersistedCookies,
+            session = session
         )
         return try {
-            executeRequestCancellable(okHttpClient, request)
+            executeRequestCancellable(session.okHttpClient, request)
         } catch (error: IOException) {
             if (!retryHttp1OnStreamReset || !error.isTransientHttp2StreamReset()) throw error
             NPLogger.w(
                 "NERI-NeteaseClient",
                 "HTTP/2 stream reset for $url, retrying with HTTP/1.1: ${error.message.orEmpty()}"
             )
-            executeRequestCancellable(http1RetryClient, request)
+            executeRequestCancellable(session.http1RetryClient, request)
         }
     }
 
     @Throws(IOException::class)
     private fun ensureWeapiSessionIfNeeded(
+        session: NeteaseRequestSession,
         mode: CryptoMode,
         usePersistedCookies: Boolean
     ) {
         if (mode != CryptoMode.WEAPI) return
-        val needsPreheat = synchronized(cookieLock) {
-            shouldPreheatNeteaseWeapiSession(
-                persistedCookies = persistedCookies,
-                requestCookies = requestCookiesForUrlLocked(neteaseMainUrl),
-                usePersistedCookies = usePersistedCookies
-            )
-        }
+        val needsPreheat = session.needsWeapiSessionPreheat(
+            requestUrl = neteaseMainUrl,
+            usePersistedCookies = usePersistedCookies
+        )
         if (!needsPreheat) return
 
-        ensurePersonalizedSession()
+        ensurePersonalizedSession(session)
 
-        val stillMissingCsrf = synchronized(cookieLock) {
-            shouldPreheatNeteaseWeapiSession(
-                persistedCookies = persistedCookies,
-                requestCookies = requestCookiesForUrlLocked(neteaseMainUrl),
-                usePersistedCookies = usePersistedCookies
-            )
-        }
+        val stillMissingCsrf = session.needsWeapiSessionPreheat(
+            requestUrl = neteaseMainUrl,
+            usePersistedCookies = usePersistedCookies
+        )
         if (stillMissingCsrf) {
             throw IOException("NetEase session preheat did not provide __csrf")
         }
@@ -443,7 +552,8 @@ class NeteaseClient {
         params: Map<String, Any>,
         mode: CryptoMode,
         method: String,
-        usePersistedCookies: Boolean
+        usePersistedCookies: Boolean,
+        session: NeteaseRequestSession
     ): Request {
         val requestUrl = url.toHttpUrl()
 
@@ -466,7 +576,11 @@ class NeteaseClient {
 
         // WEAPI 的 csrf_token 优先用持久化 Cookie, 再回退本地 CookieJar
         if (mode == CryptoMode.WEAPI) {
-            val csrf = if (usePersistedCookies) getCsrfCookie(requestUrl).orEmpty() else ""
+            val csrf = if (usePersistedCookies) {
+                session.requestCookiesForUrl(requestUrl)["__csrf"].orEmpty()
+            } else {
+                ""
+            }
             reqUrl = requestUrl.newBuilder()
                 .setQueryParameter("csrf_token", csrf)
                 .build()

--- a/app/src/main/java/moe/ouom/neriplayer/core/api/netease/NeteaseClient.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/api/netease/NeteaseClient.kt
@@ -98,6 +98,16 @@ internal fun shouldPreheatNeteaseWeapiSession(
         requestCookies["__csrf"].isNullOrBlank()
 }
 
+internal fun buildNeteaseRadarPlaylistMetadataParams(playlistId: Long): Map<String, Any> {
+    require(playlistId > 0L) { "playlistId must be positive" }
+    return linkedMapOf(
+        "id" to playlistId.toString(),
+        "n" to "1",
+        "s" to "0",
+        "uiPlaylistType" to "MGC"
+    )
+}
+
 class NeteaseClient {
     private companion object {
         const val MAX_RESPONSE_BYTES = 4L * 1024L * 1024L
@@ -892,6 +902,13 @@ class NeteaseClient {
             "n" to n.toString(),
             "s" to s.toString()
         )
+        return requestCancellable(url, params, CryptoMode.API, "POST", usePersistedCookies = true)
+    }
+
+    /** 雷达普通详情接口返回当前推荐周期的标题和封面，曲目仍由 v6 接口加载 */
+    internal suspend fun getRadarPlaylistMetadataCancellable(playlistId: Long): String {
+        val url = "https://music.163.com/api/playlist/detail"
+        val params = buildNeteaseRadarPlaylistMetadataParams(playlistId)
         return requestCancellable(url, params, CryptoMode.API, "POST", usePersistedCookies = true)
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/di/AppContainer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/di/AppContainer.kt
@@ -343,9 +343,9 @@ object AppContainer {
     // 网络客户端
     val neteaseClient by lazy {
         NeteaseClient().also { client ->
-            val cookies = neteaseCookieRepo.cookieFlow.value.toMutableMap()
-            cookies.putIfAbsent("os", "pc")
-            client.setPersistedCookies(cookies)
+            neteaseCookieRepo.withCurrentCookies { cookies ->
+                client.setPersistedCookies(cookies)
+            }
         }
     }
 
@@ -502,10 +502,9 @@ object AppContainer {
     private fun startCookieObserver() {
         neteaseCookieRepo.cookieFlow
             .onEach { cookies ->
-                val mutableCookies = cookies.toMutableMap()
-                mutableCookies.putIfAbsent("os", "pc")
-
-                neteaseClient.setPersistedCookies(mutableCookies)
+                neteaseCookieRepo.withCurrentCookiesIfMatches(cookies) { currentCookies ->
+                    neteaseClient.setPersistedCookies(currentCookies)
+                }
             }
             .launchIn(scope)
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/auth/netease/NeteaseCookieRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/auth/netease/NeteaseCookieRepository.kt
@@ -183,6 +183,7 @@ internal fun evaluateNeteaseAuthHealth(
 }
 
 class NeteaseCookieRepository(private val context: Context) {
+    private val mutationLock = Any()
     private var encryptedPrefs: SharedPreferences
     private val _authFlow: MutableStateFlow<NeteaseAuthBundle>
     private val _cookieFlow: MutableStateFlow<Map<String, String>>
@@ -206,6 +207,23 @@ class NeteaseCookieRepository(private val context: Context) {
 
     fun getCookiesOnce(): Map<String, String> = _cookieFlow.value
 
+    fun <T> withCurrentCookies(action: (Map<String, String>) -> T): T {
+        return synchronized(mutationLock) {
+            action(_cookieFlow.value)
+        }
+    }
+
+    fun withCurrentCookiesIfMatches(
+        expectedCookies: Map<String, String>,
+        action: (Map<String, String>) -> Unit
+    ): Boolean {
+        return synchronized(mutationLock) {
+            if (_cookieFlow.value != expectedCookies) return@synchronized false
+            action(_cookieFlow.value)
+            true
+        }
+    }
+
     fun getAuthHealthOnce(): SavedCookieAuthHealth = _authHealthFlow.value
 
     fun getAuthHealth(
@@ -219,6 +237,27 @@ class NeteaseCookieRepository(private val context: Context) {
     fun saveCookies(
         cookies: Map<String, String>,
         savedAt: Long = System.currentTimeMillis()
+    ): Boolean {
+        return synchronized(mutationLock) {
+            saveCookiesLocked(cookies, savedAt)
+        }
+    }
+
+    /** only applies a session update when the account snapshot is still current */
+    fun saveCookiesIfCurrent(
+        expectedCookies: Map<String, String>,
+        cookies: Map<String, String>,
+        savedAt: Long = System.currentTimeMillis()
+    ): Boolean {
+        return synchronized(mutationLock) {
+            if (_cookieFlow.value != expectedCookies) return@synchronized false
+            saveCookiesLocked(cookies, savedAt)
+        }
+    }
+
+    private fun saveCookiesLocked(
+        cookies: Map<String, String>,
+        savedAt: Long
     ): Boolean {
         val validation = validateCookies(cookies)
         if (!validation.isAccepted) {
@@ -246,14 +285,16 @@ class NeteaseCookieRepository(private val context: Context) {
     }
 
     fun clear() {
-        encryptedPrefs.edit {
-            remove(KEY_NETEASE_AUTH_BUNDLE)
+        synchronized(mutationLock) {
+            encryptedPrefs.edit {
+                remove(KEY_NETEASE_AUTH_BUNDLE)
+            }
+            val cleared = NeteaseAuthBundle()
+            _authFlow.value = cleared
+            _cookieFlow.value = cleared.cookies
+            _authHealthFlow.value = evaluateNeteaseAuthHealth(cleared)
+            NPLogger.d("NERI-CookieRepo", "Cleared all saved cookies.")
         }
-        val cleared = NeteaseAuthBundle()
-        _authFlow.value = cleared
-        _cookieFlow.value = cleared.cookies
-        _authHealthFlow.value = evaluateNeteaseAuthHealth(cleared)
-        NPLogger.d("NERI-CookieRepo", "Cleared all saved cookies.")
     }
 
     fun refreshHealth(now: Long = System.currentTimeMillis()) {

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/netease/NeteasePlaylistCacheRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/netease/NeteasePlaylistCacheRepository.kt
@@ -66,6 +66,7 @@ data class CachedNeteasePlaylistDetail(
     val header: CachedNeteasePlaylistHeader,
     val recentTrackSignature: String,
     val tracks: List<CachedNeteasePlaylistTrack>,
+    val radarCacheContext: String? = null,
     val savedAtMs: Long = System.currentTimeMillis()
 )
 
@@ -91,13 +92,23 @@ class NeteasePlaylistCacheRepository private constructor(
         cacheDir = cacheDir
     )
 
-    fun read(playlistId: Long): CachedNeteasePlaylistDetail? {
-        val cacheKey = playlistId.toString()
+    fun read(
+        playlistId: Long,
+        radarCacheContext: String? = null
+    ): CachedNeteasePlaylistDetail? {
+        val cacheKey = neteaseRadarPlaylistCacheKey(playlistId, radarCacheContext)
         readRoom(cacheKey)?.toNeteasePlaylistDetail()?.let { return it }
         val file = cacheFile(playlistId)
         if (!file.exists()) return null
         return runCatching {
-            readLegacyFile(file, playlistId)?.also(::saveRoomAndDeleteLegacy)
+            readLegacyFile(file, playlistId)
+                ?.takeIf { cache ->
+                    neteaseRadarPlaylistCacheKey(
+                        playlistId = cache.playlistId,
+                        radarCacheContext = cache.radarCacheContext
+                    ) == cacheKey
+                }
+                ?.also(::saveRoomAndDeleteLegacy)
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to read NetEase playlist cache: playlistId=$playlistId", error)
         }.getOrNull()
@@ -112,10 +123,24 @@ class NeteasePlaylistCacheRepository private constructor(
         }
     }
 
-    fun clear(playlistId: Long) {
+    fun saveIfNewer(cache: CachedNeteasePlaylistDetail) {
         runCatching {
-            clearRoom(playlistId.toString())
-            cacheFile(playlistId).delete()
+            saveRoomIfNewer(cache)
+            deleteLegacyFile(cacheFile(cache.playlistId))
+        }.onFailure { error ->
+            NPLogger.w(TAG, "Failed to update NetEase playlist cache: playlistId=${cache.playlistId}", error)
+        }
+    }
+
+    fun clear(
+        playlistId: Long,
+        radarCacheContext: String? = null
+    ) {
+        runCatching {
+            clearRoom(neteaseRadarPlaylistCacheKey(playlistId, radarCacheContext))
+            if (radarCacheContext.isNullOrBlank()) {
+                cacheFile(playlistId).delete()
+            }
         }.onFailure { error ->
             NPLogger.w(TAG, "Failed to clear NetEase playlist cache: playlistId=$playlistId", error)
         }
@@ -200,7 +225,7 @@ class NeteasePlaylistCacheRepository private constructor(
     private fun CachedNeteasePlaylistDetail.toRecord(): PlatformPlaylistCacheRecord {
         return PlatformPlaylistCacheRecord(
             platform = PLATFORM,
-            cacheKey = playlistId.toString(),
+            cacheKey = neteaseRadarPlaylistCacheKey(playlistId, radarCacheContext),
             sourceId = playlistId,
             title = header.name,
             coverUrl = header.coverUrl,
@@ -208,6 +233,7 @@ class NeteasePlaylistCacheRepository private constructor(
             trackCount = header.trackCount,
             totalCount = tracks.size,
             signaturePrimary = recentTrackSignature,
+            signatureSecondary = radarCacheContext,
             savedAtMs = savedAtMs,
             tracks = tracks.map { track ->
                 PlatformPlaylistCacheTrackRecord(
@@ -243,6 +269,7 @@ class NeteasePlaylistCacheRepository private constructor(
                 trackCount = trackCount
             ),
             recentTrackSignature = signaturePrimary.orEmpty(),
+            radarCacheContext = signatureSecondary,
             tracks = tracks.map { track ->
                 CachedNeteasePlaylistTrack(
                     id = track.itemId ?: 0L,

--- a/app/src/main/java/moe/ouom/neriplayer/data/platform/netease/NeteaseRadarCacheContext.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/platform/netease/NeteaseRadarCacheContext.kt
@@ -1,0 +1,30 @@
+package moe.ouom.neriplayer.data.platform.netease
+
+import java.security.MessageDigest
+
+private const val NETEASE_RADAR_PUBLIC_CACHE_CONTEXT = "public-v1"
+private const val NETEASE_RADAR_ACCOUNT_CACHE_CONTEXT_PREFIX = "account-sha256-v1:"
+private const val NETEASE_RADAR_CACHE_CONTEXT_DOMAIN = "neriplayer-radar-cache-v1:"
+private const val NETEASE_RADAR_PLAYLIST_CACHE_KEY_PREFIX = "radar-v1/"
+
+internal fun neteaseRadarCacheContext(cookies: Map<String, String>): String {
+    val musicU = cookies["MUSIC_U"]?.trim().orEmpty()
+    if (musicU.isEmpty()) return NETEASE_RADAR_PUBLIC_CACHE_CONTEXT
+
+    val fingerprint = MessageDigest.getInstance("SHA-256")
+        .digest(
+            "$NETEASE_RADAR_CACHE_CONTEXT_DOMAIN$musicU"
+                .toByteArray(Charsets.UTF_8)
+        )
+        .joinToString(separator = "") { byte -> "%02x".format(byte) }
+    return "$NETEASE_RADAR_ACCOUNT_CACHE_CONTEXT_PREFIX$fingerprint"
+}
+
+internal fun neteaseRadarPlaylistCacheKey(
+    playlistId: Long,
+    radarCacheContext: String?
+): String {
+    val context = radarCacheContext?.trim().orEmpty()
+    if (context.isEmpty()) return playlistId.toString()
+    return "$NETEASE_RADAR_PLAYLIST_CACHE_KEY_PREFIX$playlistId/$context"
+}

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/playlist/NeteaseCollectionDetailViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/playlist/NeteaseCollectionDetailViewModel.kt
@@ -46,7 +46,6 @@ import moe.ouom.neriplayer.data.model.NeteaseArtistSummary
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.ui.viewmodel.artist.parseNeteaseArtistSummaries
 import moe.ouom.neriplayer.ui.viewmodel.tab.AlbumSummary
-import moe.ouom.neriplayer.ui.viewmodel.tab.NETEASE_FAN_RADAR_PLAYLIST_ID
 import moe.ouom.neriplayer.ui.viewmodel.tab.PlaylistSummary
 import moe.ouom.neriplayer.ui.viewmodel.tab.isNeteaseRadarPlaylist
 import moe.ouom.neriplayer.ui.viewmodel.tab.parseNeteasePlaylistDetailSummary
@@ -162,7 +161,7 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
                 }
                 detailRequest.await() to radarHeaderRequest.await()
             }
-            if (playlist.id == NETEASE_FAN_RADAR_PLAYLIST_ID) {
+            if (isNeteaseRadarPlaylist(playlist.id)) {
                 withContext(Dispatchers.IO) {
                     persistNeteaseSessionCookies()
                 }
@@ -177,7 +176,7 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
             )
             if (!forceRefresh && cached != null && shouldReuseCachedPlaylist(cached, parsed)) {
                 val reusableCache = if (isNeteaseRadarPlaylist(playlist.id)) {
-                    refreshNeteasePlaylistCachedHeader(cached, parsed.header)
+                    refreshNeteasePlaylistCachedHeader(cached, parsedWithRadarHeader.header)
                 } else {
                     cached
                 }
@@ -206,7 +205,7 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
                 if (client.hasLogin()) {
                     persistNeteaseSessionCookies()
                 }
-                playlistCacheRepo.save(parsed.toCache(tracks))
+                playlistCacheRepo.save(parsedWithRadarHeader.toCache(tracks))
             }
         } catch (e: CancellationException) {
             throw e
@@ -242,7 +241,7 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
             val cookies = cookieRepo.getCookiesOnce()
             client.setPersistedCookies(cookies)
             if (
-                playlistId != NETEASE_FAN_RADAR_PLAYLIST_ID ||
+                !isNeteaseRadarPlaylist(playlistId) ||
                 cookies["MUSIC_U"].isNullOrBlank()
             ) {
                 return@withContext

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/playlist/NeteaseCollectionDetailViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/playlist/NeteaseCollectionDetailViewModel.kt
@@ -48,6 +48,8 @@ import moe.ouom.neriplayer.ui.viewmodel.artist.parseNeteaseArtistSummaries
 import moe.ouom.neriplayer.ui.viewmodel.tab.AlbumSummary
 import moe.ouom.neriplayer.ui.viewmodel.tab.NETEASE_FAN_RADAR_PLAYLIST_ID
 import moe.ouom.neriplayer.ui.viewmodel.tab.PlaylistSummary
+import moe.ouom.neriplayer.ui.viewmodel.tab.isNeteaseRadarPlaylist
+import moe.ouom.neriplayer.ui.viewmodel.tab.parseNeteasePlaylistDetailSummary
 import moe.ouom.neriplayer.core.logging.NPLogger
 import org.json.JSONObject
 import java.io.IOException
@@ -82,6 +84,24 @@ internal fun refreshNeteasePlaylistCachedHeader(
             playCount = fresh.playCount.takeIf { it > 0L } ?: previous.playCount,
             trackCount = fresh.trackCount.takeIf { it > 0 } ?: previous.trackCount
         )
+    )
+}
+
+internal fun applyNeteaseRadarPlaylistHeader(
+    playlist: PlaylistSummary,
+    detailHeader: NeteaseCollectionHeader
+): NeteaseCollectionHeader {
+    if (!isNeteaseRadarPlaylist(playlist.id)) {
+        return detailHeader
+    }
+    return detailHeader.copy(
+        name = playlist.name.ifBlank { detailHeader.name },
+        coverUrl = resolveNeteaseCollectionCoverUrl(
+            primary = playlist.picUrl,
+            fallback = detailHeader.coverUrl
+        ),
+        playCount = playlist.playCount.takeIf { it > 0L } ?: detailHeader.playCount,
+        trackCount = playlist.trackCount.takeIf { it > 0 } ?: detailHeader.trackCount
     )
 }
 
@@ -133,7 +153,15 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
 
         try {
             preparePlaylistRequest(playlist.id)
-            val raw = client.getPlaylistDetailCancellable(playlist.id)
+            val (raw, radarHeader) = coroutineScope {
+                val detailRequest = async {
+                    client.getPlaylistDetailCancellable(playlist.id)
+                }
+                val radarHeaderRequest = async {
+                    loadRadarPlaylistHeader(playlist)
+                }
+                detailRequest.await() to radarHeaderRequest.await()
+            }
             if (playlist.id == NETEASE_FAN_RADAR_PLAYLIST_ID) {
                 withContext(Dispatchers.IO) {
                     persistNeteaseSessionCookies()
@@ -142,13 +170,19 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
             NPLogger.d(TAG_PD, "detail head=${raw.take(500)}")
 
             val parsed = parseDetailFromPlaylist(raw)
+            val parsedWithRadarHeader = parsed.copy(
+                header = radarHeader?.let { header ->
+                    applyNeteaseRadarPlaylistHeader(header, parsed.header)
+                } ?: applyNeteaseRadarPlaylistHeader(playlist, parsed.header)
+            )
             if (!forceRefresh && cached != null && shouldReuseCachedPlaylist(cached, parsed)) {
-                val reusableCache = if (playlist.id == NETEASE_FAN_RADAR_PLAYLIST_ID) {
+                val reusableCache = if (isNeteaseRadarPlaylist(playlist.id)) {
                     refreshNeteasePlaylistCachedHeader(cached, parsed.header)
                 } else {
                     cached
                 }
-                publishCachedPlaylist(reusableCache, playlist)
+                val headerFallback = radarHeader ?: playlist
+                publishCachedPlaylist(reusableCache, headerFallback)
                 if (reusableCache != cached) {
                     withContext(Dispatchers.IO) {
                         playlistCacheRepo.save(reusableCache)
@@ -165,7 +199,7 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
             _uiState.value = NeteaseCollectionDetailUiState(
                 loading = false,
                 error = null,
-                header = parsed.header,
+                header = parsedWithRadarHeader.header,
                 tracks = tracks
             )
             withContext(Dispatchers.IO) {
@@ -220,6 +254,19 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
             } catch (error: Exception) {
                 NPLogger.w(TAG_PD, "radar session preheat failed: ${error.message}")
             }
+        }
+    }
+
+    private suspend fun loadRadarPlaylistHeader(playlist: PlaylistSummary): PlaylistSummary? {
+        if (!isNeteaseRadarPlaylist(playlist.id)) return null
+        return try {
+            val raw = client.getRadarPlaylistMetadataCancellable(playlist.id)
+            parseNeteasePlaylistDetailSummary(raw, playlist)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            NPLogger.w(TAG_PD, "radar metadata failed: playlistId=${playlist.id}, error=${error.message}")
+            null
         }
     }
 
@@ -301,7 +348,7 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
     }
 
     private fun CachedNeteasePlaylistHeader.toHeader(fallback: PlaylistSummary): NeteaseCollectionHeader {
-        return NeteaseCollectionHeader(
+        val cachedHeader = NeteaseCollectionHeader(
             id = id,
             isAlbum = false,
             name = name.ifBlank { fallback.name },
@@ -309,6 +356,7 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
             playCount = playCount.takeIf { it > 0L } ?: fallback.playCount,
             trackCount = trackCount.takeIf { it > 0 } ?: fallback.trackCount
         )
+        return applyNeteaseRadarPlaylistHeader(fallback, cachedHeader)
     }
 
     private fun NeteaseCollectionHeader.toCachedHeader(): CachedNeteasePlaylistHeader {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/playlist/NeteaseCollectionDetailViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/playlist/NeteaseCollectionDetailViewModel.kt
@@ -28,11 +28,14 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.ouom.neriplayer.R
@@ -42,13 +45,16 @@ import moe.ouom.neriplayer.data.platform.netease.CachedNeteaseArtist
 import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistDetail
 import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistHeader
 import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistTrack
+import moe.ouom.neriplayer.data.platform.netease.neteaseRadarCacheContext
 import moe.ouom.neriplayer.data.model.NeteaseArtistSummary
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.ui.viewmodel.artist.parseNeteaseArtistSummaries
 import moe.ouom.neriplayer.ui.viewmodel.tab.AlbumSummary
+import moe.ouom.neriplayer.ui.viewmodel.tab.NeteaseRadarPlaylistDefinitions
 import moe.ouom.neriplayer.ui.viewmodel.tab.PlaylistSummary
 import moe.ouom.neriplayer.ui.viewmodel.tab.isNeteaseRadarPlaylist
-import moe.ouom.neriplayer.ui.viewmodel.tab.parseNeteasePlaylistDetailSummary
+import moe.ouom.neriplayer.ui.viewmodel.tab.parseNeteasePlaylistDetailSummaryOrNull
+import moe.ouom.neriplayer.ui.viewmodel.tab.toPlaylistSummary
 import moe.ouom.neriplayer.core.logging.NPLogger
 import org.json.JSONObject
 import java.io.IOException
@@ -72,8 +78,9 @@ private fun normalizeNeteaseCollectionCoverUrl(url: String?): String? {
 
 internal fun refreshNeteasePlaylistCachedHeader(
     cached: CachedNeteasePlaylistDetail,
-    fresh: NeteaseCollectionHeader
+    fresh: NeteaseCollectionHeader?
 ): CachedNeteasePlaylistDetail {
+    fresh ?: return cached
     val previous = cached.header
     return cached.copy(
         header = CachedNeteasePlaylistHeader(
@@ -84,6 +91,87 @@ internal fun refreshNeteasePlaylistCachedHeader(
             trackCount = fresh.trackCount.takeIf { it > 0 } ?: previous.trackCount
         )
     )
+}
+
+internal fun shouldReuseNeteasePlaylistCache(
+    cached: CachedNeteasePlaylistDetail,
+    expectedTrackCount: Int,
+    recentTrackSignature: String,
+    requireHeaderTrackCountMatch: Boolean
+): Boolean {
+    if (requireHeaderTrackCountMatch) {
+        val cachedTrackCount = cached.header.trackCount.takeIf { it > 0 }
+            ?: cached.tracks.size
+        if (expectedTrackCount > 0 && cachedTrackCount != expectedTrackCount) return false
+    }
+    if (expectedTrackCount > 0 && cached.tracks.size < expectedTrackCount) return false
+    return cached.recentTrackSignature == recentTrackSignature
+}
+
+internal fun isNeteasePlaylistCacheCompatible(
+    cached: CachedNeteasePlaylistDetail,
+    requestedPlaylistId: Long,
+    expectedRadarCacheContext: String
+): Boolean {
+    if (cached.playlistId != requestedPlaylistId) return false
+    if (!isNeteaseRadarPlaylist(requestedPlaylistId)) return true
+    return cached.radarCacheContext == expectedRadarCacheContext
+}
+
+internal fun shouldAcceptNeteasePlaylistLoadResult(
+    requestedPlaylistId: Long,
+    activePlaylistId: Long,
+    requestRadarCacheContext: String,
+    currentRadarCacheContext: String
+): Boolean {
+    if (requestedPlaylistId != activePlaylistId) return false
+    if (!isNeteaseRadarPlaylist(requestedPlaylistId)) return true
+    return requestRadarCacheContext == currentRadarCacheContext
+}
+
+internal fun shouldAcceptNeteaseCollectionLoadResult(
+    requestedCollectionId: Long,
+    activeCollectionId: Long,
+    requestGeneration: Long,
+    activeGeneration: Long
+): Boolean {
+    return requestedCollectionId == activeCollectionId &&
+        requestGeneration == activeGeneration
+}
+
+internal fun shouldHandleInitialNeteaseRadarContextEmission(
+    isFirstEmission: Boolean,
+    initialRadarCacheContext: String,
+    emittedRadarCacheContext: String
+): Boolean = !isFirstEmission || initialRadarCacheContext != emittedRadarCacheContext
+
+internal fun resetNeteaseRadarPlaylistSummaryForContextChange(
+    playlist: PlaylistSummary
+): PlaylistSummary {
+    if (!isNeteaseRadarPlaylist(playlist.id)) return playlist
+    return NeteaseRadarPlaylistDefinitions
+        .firstOrNull { definition -> definition.id == playlist.id }
+        ?.toPlaylistSummary()
+        ?: playlist.copy(
+            name = playlist.name,
+            picUrl = "",
+            playCount = 0L,
+            trackCount = 0
+        )
+}
+
+internal fun prepareNeteasePlaylistEntryForContext(
+    playlist: PlaylistSummary,
+    knownCacheContext: String?,
+    currentCacheContext: String
+): PlaylistSummary {
+    if (
+        !isNeteaseRadarPlaylist(playlist.id) ||
+        knownCacheContext != null && knownCacheContext == currentCacheContext
+    ) {
+        return playlist
+    }
+    return resetNeteaseRadarPlaylistSummaryForContextChange(playlist)
 }
 
 internal fun applyNeteaseRadarPlaylistHeader(
@@ -104,6 +192,48 @@ internal fun applyNeteaseRadarPlaylistHeader(
     )
 }
 
+internal fun CachedNeteasePlaylistHeader.toNeteaseCollectionHeader(
+    fallback: PlaylistSummary
+): NeteaseCollectionHeader {
+    return NeteaseCollectionHeader(
+        id = id,
+        isAlbum = false,
+        name = name.ifBlank { fallback.name },
+        coverUrl = coverUrl.ifBlank {
+            normalizeNeteaseCollectionCoverUrl(fallback.picUrl) ?: ""
+        },
+        playCount = playCount.takeIf { it > 0L } ?: fallback.playCount,
+        trackCount = trackCount.takeIf { it > 0 } ?: fallback.trackCount
+    )
+}
+
+internal fun resolveNeteasePlaylistDisplayHeader(
+    playlist: PlaylistSummary,
+    detailHeader: NeteaseCollectionHeader,
+    freshRadarHeader: PlaylistSummary?,
+    cachedRadarHeader: CachedNeteasePlaylistHeader?
+): NeteaseCollectionHeader {
+    if (!isNeteaseRadarPlaylist(playlist.id)) return detailHeader
+    val fallbackHeader = cachedRadarHeader?.toNeteaseCollectionHeader(playlist)
+        ?: applyNeteaseRadarPlaylistHeader(playlist, detailHeader)
+    return freshRadarHeader?.let { header ->
+        applyNeteaseRadarPlaylistHeader(header, fallbackHeader)
+    } ?: fallbackHeader
+}
+
+internal fun matchingNeteaseRadarCacheHeader(
+    cached: CachedNeteasePlaylistDetail?,
+    playlistId: Long,
+    expectedRadarCacheContext: String
+): CachedNeteasePlaylistHeader? {
+    return cached
+        ?.takeIf { cache ->
+            !isNeteaseRadarPlaylist(playlistId) ||
+                cache.radarCacheContext == expectedRadarCacheContext
+        }
+        ?.header
+}
+
 class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewModel(application) {
     private val client = AppContainer.neteaseClient
     private val cookieRepo = AppContainer.neteaseCookieRepo
@@ -114,44 +244,105 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
 
     private var playlistId: Long = 0L
     private var currentPlaylist: PlaylistSummary? = null
+    private var visibleRadarCacheContext: String? = null
+    private var playlistLoadJob: Job? = null
+    private var playlistLoadGeneration: Long = 0L
+    private val initialRadarCacheContext = neteaseRadarCacheContext(cookieRepo.getCookiesOnce())
+
+    init {
+        viewModelScope.launch {
+            var isFirstRadarContextEmission = true
+            cookieRepo.cookieFlow
+                .map(::neteaseRadarCacheContext)
+                .distinctUntilChanged()
+                .collect { radarCacheContext ->
+                    val shouldHandleEmission = shouldHandleInitialNeteaseRadarContextEmission(
+                        isFirstEmission = isFirstRadarContextEmission,
+                        initialRadarCacheContext = initialRadarCacheContext,
+                        emittedRadarCacheContext = radarCacheContext
+                    )
+                    isFirstRadarContextEmission = false
+                    if (!shouldHandleEmission) return@collect
+                    val playlist = currentPlaylist
+                        ?.takeIf { isNeteaseRadarPlaylist(it.id) }
+                        ?: return@collect
+                    if (visibleRadarCacheContext == radarCacheContext) return@collect
+                    startPlaylist(
+                        playlist = resetNeteaseRadarPlaylistSummaryForContextChange(playlist),
+                        forceRefresh = true
+                    )
+                }
+        }
+    }
 
     fun startPlaylist(playlist: PlaylistSummary, forceRefresh: Boolean = false) {
-        currentPlaylist = playlist
-        playlistId = playlist.id
+        playlistLoadJob?.cancel()
+        playlistLoadGeneration += 1L
+        val loadGeneration = playlistLoadGeneration
+        val radarCacheContext = neteaseRadarCacheContext(cookieRepo.getCookiesOnce())
+        val entryPlaylist = prepareNeteasePlaylistEntryForContext(
+            playlist = playlist,
+            knownCacheContext = visibleRadarCacheContext,
+            currentCacheContext = radarCacheContext
+        )
+        currentPlaylist = entryPlaylist
+        playlistId = entryPlaylist.id
+        val isRadarPlaylist = isNeteaseRadarPlaylist(entryPlaylist.id)
         val previous = _uiState.value.takeIf {
             val header = it.header
-            forceRefresh && header?.id == playlist.id && header.isAlbum == false
+            forceRefresh &&
+                header?.id == entryPlaylist.id &&
+                header.isAlbum == false &&
+                (!isRadarPlaylist || visibleRadarCacheContext == radarCacheContext)
         }
+        visibleRadarCacheContext = radarCacheContext.takeIf { isRadarPlaylist }
 
         // 用入口数据把 header 预填
         _uiState.value = NeteaseCollectionDetailUiState(
             loading = true,
             header = previous?.header ?: NeteaseCollectionHeader(
-                id = playlist.id,
+                id = entryPlaylist.id,
                 isAlbum = false,
-                name = playlist.name,
-                coverUrl = toHttps(playlist.picUrl) ?: "",
-                playCount = playlist.playCount,
-                trackCount = playlist.trackCount
+                name = entryPlaylist.name,
+                coverUrl = toHttps(entryPlaylist.picUrl) ?: "",
+                playCount = entryPlaylist.playCount,
+                trackCount = entryPlaylist.trackCount
             ),
             tracks = previous?.tracks.orEmpty()
         )
 
-        viewModelScope.launch {
-            loadPlaylist(playlist, forceRefresh)
+        playlistLoadJob = viewModelScope.launch {
+            loadPlaylist(
+                playlist = entryPlaylist,
+                forceRefresh = forceRefresh,
+                loadGeneration = loadGeneration
+            )
         }
     }
 
-    private suspend fun loadPlaylist(playlist: PlaylistSummary, forceRefresh: Boolean) {
-        val cached = withContext(Dispatchers.IO) {
-            if (forceRefresh) null else playlistCacheRepo.read(playlist.id)
-        }
-        if (cached != null) {
+    private suspend fun loadPlaylist(
+        playlist: PlaylistSummary,
+        forceRefresh: Boolean,
+        loadGeneration: Long
+    ) {
+        var radarCacheContext = neteaseRadarCacheContext(cookieRepo.getCookiesOnce())
+        val requestStartedAtMs = System.currentTimeMillis()
+        val cached = readCompatiblePlaylistCache(playlist.id)
+        if (
+            !forceRefresh &&
+            cached != null &&
+            isCurrentPlaylistLoad(
+                playlist = playlist,
+                loadGeneration = loadGeneration,
+                radarCacheContext = cached.radarCacheContext ?: radarCacheContext
+            )
+        ) {
             publishCachedPlaylist(cached, playlist, loading = true)
         }
 
         try {
-            preparePlaylistRequest(playlist.id)
+            radarCacheContext = preparePlaylistRequest(playlist.id)
+            if (!isCurrentPlaylistLoad(playlist, loadGeneration, radarCacheContext)) return
             val (raw, radarHeader) = coroutineScope {
                 val detailRequest = async {
                     client.getPlaylistDetailCancellable(playlist.id)
@@ -161,22 +352,38 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
                 }
                 detailRequest.await() to radarHeaderRequest.await()
             }
+            if (!isCurrentPlaylistLoad(playlist, loadGeneration, radarCacheContext)) return
             if (isNeteaseRadarPlaylist(playlist.id)) {
                 withContext(Dispatchers.IO) {
-                    persistNeteaseSessionCookies()
+                    persistNeteaseSessionCookies(radarCacheContext)
                 }
             }
             NPLogger.d(TAG_PD, "detail head=${raw.take(500)}")
 
             val parsed = parseDetailFromPlaylist(raw)
-            val parsedWithRadarHeader = parsed.copy(
-                header = radarHeader?.let { header ->
-                    applyNeteaseRadarPlaylistHeader(header, parsed.header)
-                } ?: applyNeteaseRadarPlaylistHeader(playlist, parsed.header)
+            val displayHeader = resolveNeteasePlaylistDisplayHeader(
+                playlist = playlist,
+                detailHeader = parsed.header,
+                freshRadarHeader = radarHeader,
+                cachedRadarHeader = matchingNeteaseRadarCacheHeader(
+                    cached = cached,
+                    playlistId = playlist.id,
+                    expectedRadarCacheContext = radarCacheContext
+                )
             )
-            if (!forceRefresh && cached != null && shouldReuseCachedPlaylist(cached, parsed)) {
+            if (
+                !forceRefresh &&
+                cached != null &&
+                isNeteasePlaylistCacheCompatible(
+                    cached = cached,
+                    requestedPlaylistId = playlist.id,
+                    expectedRadarCacheContext = radarCacheContext
+                ) &&
+                shouldReuseCachedPlaylist(cached, parsed)
+            ) {
+                if (!isCurrentPlaylistLoad(playlist, loadGeneration, radarCacheContext)) return
                 val reusableCache = if (isNeteaseRadarPlaylist(playlist.id)) {
-                    refreshNeteasePlaylistCachedHeader(cached, parsedWithRadarHeader.header)
+                    refreshNeteasePlaylistCachedHeader(cached, displayHeader)
                 } else {
                     cached
                 }
@@ -184,7 +391,9 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
                 publishCachedPlaylist(reusableCache, headerFallback)
                 if (reusableCache != cached) {
                     withContext(Dispatchers.IO) {
-                        playlistCacheRepo.save(reusableCache)
+                        if (isCurrentPlaylistLoad(playlist, loadGeneration, radarCacheContext)) {
+                            playlistCacheRepo.saveIfNewer(reusableCache)
+                        }
                     }
                 }
                 NPLogger.d(
@@ -195,23 +404,42 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
             }
 
             val tracks = resolvePlaylistTracks(parsed)
+            if (!isCurrentPlaylistLoad(playlist, loadGeneration, radarCacheContext)) return
+            visibleRadarCacheContext = radarCacheContext.takeIf {
+                isNeteaseRadarPlaylist(playlist.id)
+            }
             _uiState.value = NeteaseCollectionDetailUiState(
                 loading = false,
                 error = null,
-                header = parsedWithRadarHeader.header,
+                header = displayHeader,
                 tracks = tracks
             )
             withContext(Dispatchers.IO) {
-                if (client.hasLogin()) {
-                    persistNeteaseSessionCookies()
+                if (!isCurrentPlaylistLoad(playlist, loadGeneration, radarCacheContext)) {
+                    return@withContext
                 }
-                playlistCacheRepo.save(parsedWithRadarHeader.toCache(tracks))
+                if (client.hasLogin()) {
+                    persistNeteaseSessionCookies(radarCacheContext)
+                }
+                if (!isCurrentPlaylistLoad(playlist, loadGeneration, radarCacheContext)) {
+                    return@withContext
+                }
+                playlistCacheRepo.saveIfNewer(
+                    parsed.toCache(
+                        tracks = tracks,
+                        displayHeader = displayHeader,
+                        radarCacheContext = radarCacheContext,
+                        savedAtMs = requestStartedAtMs
+                    )
+                )
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: IOException) {
-            val fallback = cached ?: withContext(Dispatchers.IO) { playlistCacheRepo.read(playlist.id) }
+            if (!isCurrentPlaylistLoad(playlist, loadGeneration, radarCacheContext)) return
+            val fallback = readCompatiblePlaylistCache(playlist.id)
             if (fallback != null) {
+                if (!isCurrentPlaylistLoad(playlist, loadGeneration, radarCacheContext)) return
                 NPLogger.w(TAG_PD, "NetEase playlist detail failed, fallback to cache: playlistId=${playlist.id}", e)
                 publishCachedPlaylist(fallback, playlist)
                 return
@@ -222,8 +450,10 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
                 error = "Network or server error: ${e.message ?: e.javaClass.simpleName}"  // Localized in UI
             )
         } catch (e: Exception) {
-            val fallback = cached ?: withContext(Dispatchers.IO) { playlistCacheRepo.read(playlist.id) }
+            if (!isCurrentPlaylistLoad(playlist, loadGeneration, radarCacheContext)) return
+            val fallback = readCompatiblePlaylistCache(playlist.id)
             if (fallback != null) {
+                if (!isCurrentPlaylistLoad(playlist, loadGeneration, radarCacheContext)) return
                 NPLogger.w(TAG_PD, "NetEase playlist detail parse failed, fallback to cache: playlistId=${playlist.id}", e)
                 publishCachedPlaylist(fallback, playlist)
                 return
@@ -236,15 +466,38 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
         }
     }
 
-    private suspend fun preparePlaylistRequest(playlistId: Long) {
-        withContext(Dispatchers.IO) {
-            val cookies = cookieRepo.getCookiesOnce()
-            client.setPersistedCookies(cookies)
+    private fun isCurrentPlaylistLoad(
+        playlist: PlaylistSummary,
+        loadGeneration: Long,
+        radarCacheContext: String
+    ): Boolean {
+        if (
+            !shouldAcceptNeteaseCollectionLoadResult(
+                requestedCollectionId = playlist.id,
+                activeCollectionId = playlistId,
+                requestGeneration = loadGeneration,
+                activeGeneration = playlistLoadGeneration
+            )
+        ) {
+            return false
+        }
+        return shouldAcceptNeteasePlaylistLoadResult(
+            requestedPlaylistId = playlist.id,
+            activePlaylistId = playlistId,
+            requestRadarCacheContext = radarCacheContext,
+            currentRadarCacheContext = neteaseRadarCacheContext(cookieRepo.getCookiesOnce())
+        )
+    }
+
+    private suspend fun preparePlaylistRequest(playlistId: Long): String {
+        return withContext(Dispatchers.IO) {
+            val cookies = syncNeteaseClientCookies()
+            val radarCacheContext = neteaseRadarCacheContext(cookies)
             if (
                 !isNeteaseRadarPlaylist(playlistId) ||
                 cookies["MUSIC_U"].isNullOrBlank()
             ) {
-                return@withContext
+                return@withContext radarCacheContext
             }
             try {
                 client.ensurePersonalizedSession()
@@ -253,6 +506,32 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
             } catch (error: Exception) {
                 NPLogger.w(TAG_PD, "radar session preheat failed: ${error.message}")
             }
+            radarCacheContext
+        }
+    }
+
+    private fun syncNeteaseClientCookies(): Map<String, String> {
+        return cookieRepo.withCurrentCookies { cookies ->
+            client.setPersistedCookies(cookies)
+            cookies
+        }
+    }
+
+    private suspend fun readCompatiblePlaylistCache(
+        playlistId: Long
+    ): CachedNeteasePlaylistDetail? {
+        return withContext(Dispatchers.IO) {
+            val radarCacheContext = neteaseRadarCacheContext(cookieRepo.getCookiesOnce())
+            val requestedRadarCacheContext = radarCacheContext.takeIf {
+                isNeteaseRadarPlaylist(playlistId)
+            }
+            playlistCacheRepo.read(playlistId, requestedRadarCacheContext)?.takeIf { cached ->
+                isNeteasePlaylistCacheCompatible(
+                    cached = cached,
+                    requestedPlaylistId = playlistId,
+                    expectedRadarCacheContext = radarCacheContext
+                )
+            }
         }
     }
 
@@ -260,7 +539,9 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
         if (!isNeteaseRadarPlaylist(playlist.id)) return null
         return try {
             val raw = client.getRadarPlaylistMetadataCancellable(playlist.id)
-            parseNeteasePlaylistDetailSummary(raw, playlist)
+            parseNeteasePlaylistDetailSummaryOrNull(raw)?.takeIf { header ->
+                header.id == playlist.id
+            }
         } catch (error: CancellationException) {
             throw error
         } catch (error: Exception) {
@@ -269,14 +550,23 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
         }
     }
 
-    private fun persistNeteaseSessionCookies() {
+    private fun persistNeteaseSessionCookies(expectedRadarCacheContext: String? = null) {
         val persisted = cookieRepo.getCookiesOnce()
+        if (
+            expectedRadarCacheContext != null &&
+            neteaseRadarCacheContext(persisted) != expectedRadarCacheContext
+        ) {
+            return
+        }
         val updated = mergeNeteaseSessionCookies(
             persistedCookies = persisted,
             runtimeCookies = client.getNeteaseRequestCookies()
         )
         if (updated != persisted) {
-            cookieRepo.saveCookies(updated)
+            cookieRepo.saveCookiesIfCurrent(
+                expectedCookies = persisted,
+                cookies = updated
+            )
         }
     }
 
@@ -285,11 +575,14 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
         fallback: PlaylistSummary,
         loading: Boolean = false
     ) {
+        visibleRadarCacheContext = cached.radarCacheContext.takeIf {
+            isNeteaseRadarPlaylist(cached.playlistId)
+        }
         _uiState.value = withContext(Dispatchers.Default) {
             NeteaseCollectionDetailUiState(
                 loading = loading,
                 error = null,
-                header = cached.header.toHeader(fallback),
+                header = cached.header.toNeteaseCollectionHeader(fallback),
                 tracks = cached.tracks.map { it.toSongItem() }
             )
         }
@@ -299,11 +592,12 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
         cached: CachedNeteasePlaylistDetail,
         parsed: ParsedDetail
     ): Boolean {
-        val expectedTrackCount = parsed.expectedTrackCount()
-        val cachedTrackCount = cached.header.trackCount.takeIf { it > 0 } ?: cached.tracks.size
-        if (expectedTrackCount > 0 && cachedTrackCount != expectedTrackCount) return false
-        if (expectedTrackCount > 0 && cached.tracks.size < expectedTrackCount) return false
-        return cached.recentTrackSignature == parsed.recentTrackSignature()
+        return shouldReuseNeteasePlaylistCache(
+            cached = cached,
+            expectedTrackCount = parsed.expectedTrackCount(),
+            recentTrackSignature = parsed.recentTrackSignature(),
+            requireHeaderTrackCountMatch = !isNeteaseRadarPlaylist(parsed.header.id)
+        )
     }
 
     private suspend fun resolvePlaylistTracks(parsed: ParsedDetail): List<SongItem> {
@@ -337,25 +631,22 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
         }
     }
 
-    private fun ParsedDetail.toCache(tracks: List<SongItem>): CachedNeteasePlaylistDetail {
+    private fun ParsedDetail.toCache(
+        tracks: List<SongItem>,
+        displayHeader: NeteaseCollectionHeader = header,
+        radarCacheContext: String,
+        savedAtMs: Long = System.currentTimeMillis()
+    ): CachedNeteasePlaylistDetail {
         return CachedNeteasePlaylistDetail(
             playlistId = header.id,
-            header = header.toCachedHeader(),
+            header = displayHeader.toCachedHeader(),
             recentTrackSignature = recentTrackSignature(),
-            tracks = tracks.map { it.toCachedTrack() }
+            tracks = tracks.map { it.toCachedTrack() },
+            radarCacheContext = radarCacheContext.takeIf {
+                isNeteaseRadarPlaylist(header.id)
+            },
+            savedAtMs = savedAtMs
         )
-    }
-
-    private fun CachedNeteasePlaylistHeader.toHeader(fallback: PlaylistSummary): NeteaseCollectionHeader {
-        val cachedHeader = NeteaseCollectionHeader(
-            id = id,
-            isAlbum = false,
-            name = name.ifBlank { fallback.name },
-            coverUrl = coverUrl.ifBlank { toHttps(fallback.picUrl) ?: "" },
-            playCount = playCount.takeIf { it > 0L } ?: fallback.playCount,
-            trackCount = trackCount.takeIf { it > 0 } ?: fallback.trackCount
-        )
-        return applyNeteaseRadarPlaylistHeader(fallback, cachedHeader)
     }
 
     private fun NeteaseCollectionHeader.toCachedHeader(): CachedNeteasePlaylistHeader {
@@ -406,8 +697,13 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
 
     fun startAlbum(album: AlbumSummary) {
         // 专辑依然每次刷新，避免和歌单缓存混用
+        playlistLoadJob?.cancel()
+        playlistLoadGeneration += 1L
+        val loadGeneration = playlistLoadGeneration
+        val albumId = album.id
         currentPlaylist = null
-        playlistId = album.id
+        playlistId = albumId
+        visibleRadarCacheContext = null
 
         // 用入口数据把 header 预填
         _uiState.value = NeteaseCollectionDetailUiState(
@@ -423,19 +719,20 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
             tracks = emptyList()
         )
 
-        viewModelScope.launch {
+        playlistLoadJob = viewModelScope.launch {
             try {
-                // 再读一次当前持久化 Cookie，并注入
-                val cookies = withContext(Dispatchers.IO) { cookieRepo.getCookiesOnce() }.toMutableMap()
-                cookies.putIfAbsent("os", "pc")
-
-                val raw = withContext(Dispatchers.IO) { client.getAlbumDetail(playlistId) }
+                val raw = withContext(Dispatchers.IO) {
+                    syncNeteaseClientCookies()
+                    client.getAlbumDetail(albumId)
+                }
+                if (!isCurrentCollectionLoad(albumId, loadGeneration)) return@launch
                 NPLogger.d(TAG_PD, "detail head=${raw.take(500)}")
 
                 val (header, tracks) = parseDetailFromAlbum(
                     raw = raw,
                     coverFallback = album.picUrl
                 )
+                if (!isCurrentCollectionLoad(albumId, loadGeneration)) return@launch
 
                 _uiState.value = NeteaseCollectionDetailUiState(
                     loading = false,
@@ -443,13 +740,17 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
                     header = header,
                     tracks = tracks
                 )
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: IOException) {
+                if (!isCurrentCollectionLoad(albumId, loadGeneration)) return@launch
                 NPLogger.e(TAG_PD, "Network/Server error", e)
                 _uiState.value = _uiState.value.copy(
                     loading = false,
                     error = "Network or server error: ${e.message ?: e.javaClass.simpleName}"  // Localized in UI
                 )
             } catch (e: Exception) {
+                if (!isCurrentCollectionLoad(albumId, loadGeneration)) return@launch
                 NPLogger.e(TAG_PD, "Unexpected error", e)
                 _uiState.value = _uiState.value.copy(
                     loading = false,
@@ -457,6 +758,18 @@ class NeteaseCollectionDetailViewModel(application: Application) : AndroidViewMo
                 )
             }
         }
+    }
+
+    private fun isCurrentCollectionLoad(
+        collectionId: Long,
+        loadGeneration: Long
+    ): Boolean {
+        return shouldAcceptNeteaseCollectionLoadResult(
+            requestedCollectionId = collectionId,
+            activeCollectionId = playlistId,
+            requestGeneration = loadGeneration,
+            activeGeneration = playlistLoadGeneration
+        )
     }
 
     fun retry() {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/HomeViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/HomeViewModel.kt
@@ -882,16 +882,13 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
     private suspend fun loadRadarPlaylistSummaries(): List<PlaylistSummary> {
         val hasLogin = hasRecommendLogin
-        val fanRadarSummary = if (hasLogin) {
-            loadLoggedInFanRadarSummary()
-        } else {
-            null
+        if (hasLogin) {
+            prepareNeteaseRadarSession()
         }
         val summaries = loadNeteaseRadarPlaylistSummaries(
             definitions = NeteaseRadarPlaylistDefinitions,
-            fanRadarSummary = fanRadarSummary,
-            loadDetail = { playlistId, n, s ->
-                client.getPlaylistDetailCancellable(playlistId, n, s)
+            loadMetadata = { playlistId ->
+                client.getRadarPlaylistMetadataCancellable(playlistId)
             },
             onLoadFailure = { definition, error ->
                 NPLogger.w(TAG, "radar metadata failed: playlistId=${definition.id}, error=${error.message}")
@@ -903,7 +900,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         return summaries
     }
 
-    private suspend fun loadLoggedInFanRadarSummary(): PlaylistSummary? {
+    private suspend fun prepareNeteaseRadarSession() {
         try {
             withContext(Dispatchers.IO) {
                 client.ensurePersonalizedSession()
@@ -912,24 +909,6 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             throw error
         } catch (error: Exception) {
             NPLogger.w(TAG, "radar session preheat failed: ${error.message}")
-        }
-        val fallback = NeteaseRadarPlaylistDefinitions.first { definition ->
-            definition.id == NETEASE_FAN_RADAR_PLAYLIST_ID
-        }
-        return try {
-            parseNeteasePlaylistDetailSummary(
-                raw = client.getPlaylistDetailCancellable(
-                    NETEASE_FAN_RADAR_PLAYLIST_ID,
-                    n = 1,
-                    s = 0
-                ),
-                fallback = fallback
-            )
-        } catch (error: CancellationException) {
-            throw error
-        } catch (error: Exception) {
-            NPLogger.w(TAG, "fan radar metadata preheat failed: ${error.message}")
-            null
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/HomeViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/HomeViewModel.kt
@@ -44,6 +44,7 @@ import moe.ouom.neriplayer.core.di.AppContainer
 import moe.ouom.neriplayer.data.auth.youtube.YouTubeAuthBundle
 import moe.ouom.neriplayer.data.auth.youtube.buildRefreshObserverFingerprint
 import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.platform.netease.neteaseRadarCacheContext
 import moe.ouom.neriplayer.util.platform.LanguageManager
 import moe.ouom.neriplayer.core.logging.NPLogger
 import java.io.IOException
@@ -68,8 +69,25 @@ internal fun homeSongFetchAttemptCount(source: NeteaseHomeSongSource): Int {
 
 internal fun shouldRefreshNeteaseHome(
     loginChanged: Boolean,
-    recommendationsBootstrapped: Boolean
-): Boolean = loginChanged || !recommendationsBootstrapped
+    recommendationsBootstrapped: Boolean,
+    accountContextChanged: Boolean = false
+): Boolean = loginChanged || accountContextChanged || !recommendationsBootstrapped
+
+internal fun shouldAcceptNeteaseRadarPlaylistLoadResult(
+    requestGeneration: Long,
+    activeGeneration: Long,
+    requestRadarCacheContext: String,
+    activeRadarCacheContext: String
+): Boolean {
+    return requestGeneration == activeGeneration &&
+        requestRadarCacheContext == activeRadarCacheContext
+}
+
+internal fun shouldHandleInitialNeteaseHomeCookieEmission(
+    isFirstEmission: Boolean,
+    initialCookies: Map<String, String>,
+    emittedCookies: Map<String, String>
+): Boolean = !isFirstEmission || initialCookies != emittedCookies
 
 data class HomeSectionState<T>(
     val items: List<T> = emptyList(),
@@ -104,8 +122,9 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     private val client = AppContainer.neteaseClient
     private val youtubeAuthRepo = AppContainer.youtubeAuthRepo
 
-    private val initialRecommendCookies = repo.getCookiesOnce().toMutableMap().apply {
-        putIfAbsent("os", "pc")
+    private val initialRecommendCookies = repo.withCurrentCookies { cookies ->
+        client.setPersistedCookies(cookies)
+        cookies
     }
     private var hasRecommendLogin = !initialRecommendCookies["MUSIC_U"].isNullOrBlank()
     private val _uiState = MutableStateFlow(createHomeUiState(hasRecommendLogin, loading = true))
@@ -121,6 +140,8 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     private var ytMusicHomeFeedRefreshPending = false
     private var homeRecommendationsBootstrapped = false
     private var lastYouTubeAuthFingerprint: String? = null
+    private var lastNeteaseRadarCacheContext = neteaseRadarCacheContext(repo.getCookiesOnce())
+    private var radarPlaylistLoadGeneration: Long = 0L
     private var offlineMode = false
 
     private fun localizedAppContext() = LanguageManager.applyLanguage(getApplication())
@@ -228,7 +249,6 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     init {
-        client.setPersistedCookies(initialRecommendCookies)
         lastYouTubeAuthFingerprint = buildYouTubeAuthFingerprint(youtubeAuthRepo.getAuthOnce())
 
         // 观察国际化设置变化, 切换推荐源
@@ -289,18 +309,44 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
         // 登录后自动刷新首页推荐歌单
         viewModelScope.launch {
-            repo.cookieFlow.drop(1).collect { raw ->
-                val cookies = raw.toMutableMap()
-                if (!cookies.containsKey("os")) cookies["os"] = "pc"
-                NPLogger.d(TAG, "cookieFlow updated: keys=${cookies.keys.joinToString()}")
-                client.setPersistedCookies(cookies)
-                val nextHasLogin = !cookies["MUSIC_U"].isNullOrBlank()
+            var isFirstCookieEmission = true
+            repo.cookieFlow.collect { raw ->
+                if (!repo.withCurrentCookiesIfMatches(raw) { currentCookies ->
+                        client.setPersistedCookies(currentCookies)
+                    }
+                ) {
+                    return@collect
+                }
+                val shouldHandleEmission = shouldHandleInitialNeteaseHomeCookieEmission(
+                    isFirstEmission = isFirstCookieEmission,
+                    initialCookies = initialRecommendCookies,
+                    emittedCookies = raw
+                )
+                isFirstCookieEmission = false
+                if (!shouldHandleEmission) return@collect
+                NPLogger.d(TAG, "cookieFlow updated: keys=${raw.keys.joinToString()}")
+                val nextHasLogin = !raw["MUSIC_U"].isNullOrBlank()
+                val nextRadarCacheContext = neteaseRadarCacheContext(raw)
+                val accountContextChanged =
+                    lastNeteaseRadarCacheContext != nextRadarCacheContext
+                lastNeteaseRadarCacheContext = nextRadarCacheContext
                 val loginChanged = hasRecommendLogin != nextHasLogin
                 hasRecommendLogin = nextHasLogin
                 if (loginChanged) {
                     _uiState.value = _uiState.value.copy(hasLogin = nextHasLogin)
                 }
-                if (shouldRefreshNeteaseHome(loginChanged, homeRecommendationsBootstrapped)) {
+                if (accountContextChanged) {
+                    _uiState.update { state ->
+                        state.copy(radarPlaylists = HomeSectionState())
+                    }
+                }
+                if (
+                    shouldRefreshNeteaseHome(
+                        loginChanged = loginChanged,
+                        recommendationsBootstrapped = homeRecommendationsBootstrapped,
+                        accountContextChanged = accountContextChanged
+                    )
+                ) {
                     homeRecommendationsBootstrapped = true
                     refreshNeteaseHome()
                 }
@@ -493,21 +539,30 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
 
         NPLogger.d(TAG, "refreshRadarPlaylists start")
         radarPlaylistsJob?.cancel()
+        radarPlaylistLoadGeneration += 1L
+        val loadGeneration = radarPlaylistLoadGeneration
+        val requestRadarCacheContext = lastNeteaseRadarCacheContext
         val previous = _uiState.value.radarPlaylists
         _uiState.value = _uiState.value.copy(
             radarPlaylists = previous.copy(loading = true, error = null)
         )
         radarPlaylistsJob = viewModelScope.launch {
             when (val result = fetchWithRetry("refreshRadarPlaylists") {
-                loadRadarPlaylistSummaries()
+                loadRadarPlaylistSummaries(requestRadarCacheContext)
             }) {
                 is RetryLoadResult.Success -> {
+                    if (!isCurrentRadarPlaylistLoad(loadGeneration, requestRadarCacheContext)) {
+                        return@launch
+                    }
                     NPLogger.d(TAG, "refreshRadarPlaylists success: count=${result.items.size}")
                     _uiState.value = _uiState.value.copy(
                         radarPlaylists = HomeSectionState(items = result.items)
                     )
                 }
                 is RetryLoadResult.Failure -> {
+                    if (!isCurrentRadarPlaylistLoad(loadGeneration, requestRadarCacheContext)) {
+                        return@launch
+                    }
                     NPLogger.e(TAG, "refreshRadarPlaylists failed", result.throwable)
                     _uiState.value = _uiState.value.copy(
                         radarPlaylists = HomeSectionState(
@@ -517,6 +572,18 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
                 }
             }
         }
+    }
+
+    private fun isCurrentRadarPlaylistLoad(
+        loadGeneration: Long,
+        requestRadarCacheContext: String
+    ): Boolean {
+        return shouldAcceptNeteaseRadarPlaylistLoadResult(
+            requestGeneration = loadGeneration,
+            activeGeneration = radarPlaylistLoadGeneration,
+            requestRadarCacheContext = requestRadarCacheContext,
+            activeRadarCacheContext = neteaseRadarCacheContext(repo.getCookiesOnce())
+        )
     }
 
     /** 拉取 YouTube Music 歌单 */
@@ -880,7 +947,9 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         return parseRecommendOnWorker(raw)
     }
 
-    private suspend fun loadRadarPlaylistSummaries(): List<PlaylistSummary> {
+    private suspend fun loadRadarPlaylistSummaries(
+        expectedRadarCacheContext: String
+    ): List<PlaylistSummary> {
         val hasLogin = hasRecommendLogin
         if (hasLogin) {
             prepareNeteaseRadarSession()
@@ -895,7 +964,7 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
             }
         )
         if (hasLogin) {
-            persistNeteaseRadarSessionCookies()
+            persistNeteaseRadarSessionCookies(expectedRadarCacheContext)
         }
         return summaries
     }
@@ -912,13 +981,20 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    private fun persistNeteaseRadarSessionCookies() {
+    private fun persistNeteaseRadarSessionCookies(expectedRadarCacheContext: String) {
         val persisted = repo.getCookiesOnce()
+        if (neteaseRadarCacheContext(persisted) != expectedRadarCacheContext) return
         val updated = mergeNeteaseSessionCookies(
             persistedCookies = persisted,
             runtimeCookies = client.getNeteaseRequestCookies()
         )
-        if (updated != persisted && repo.saveCookies(updated)) {
+        if (
+            updated != persisted &&
+                repo.saveCookiesIfCurrent(
+                    expectedCookies = persisted,
+                    cookies = updated
+                )
+        ) {
             NPLogger.d(TAG, "persisted NetEase radar session context")
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/NeteaseHomeRecommendations.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/NeteaseHomeRecommendations.kt
@@ -54,6 +54,12 @@ internal val NeteaseRadarPlaylistDefinitions = listOf(
     NeteaseRadarPlaylistDefinition(id = 5_341_776_086L, name = "神秘雷达")
 )
 
+internal fun isNeteaseRadarPlaylist(playlistId: Long): Boolean {
+    return NeteaseRadarPlaylistDefinitions.any { definition ->
+        definition.id == playlistId
+    }
+}
+
 internal val NeteaseHomeTrendingSongSources = listOf(
     NeteaseHomeSongSource.TOP_SOARING,
     NeteaseHomeSongSource.PERSONALIZED_NEW_SONGS,
@@ -150,33 +156,32 @@ internal fun parseNeteaseHomePlaylists(
 internal fun parseNeteasePlaylistDetailSummary(
     raw: String,
     fallback: NeteaseRadarPlaylistDefinition
+): PlaylistSummary = parseNeteasePlaylistDetailSummary(raw, fallback.toPlaylistSummary())
+
+internal fun parseNeteasePlaylistDetailSummary(
+    raw: String,
+    fallback: PlaylistSummary
 ): PlaylistSummary {
     val root = JSONObject(raw)
     val code = root.optInt("code", 200)
     if (code != 200) {
         throw ApiCodeException(code)
     }
-    val playlist = root.optJSONObject("playlist")
+    val playlist = root.optJSONObject("playlist") ?: root.optJSONObject("result")
     return playlist?.let(::parseNeteasePlaylistSummary)
-        ?: fallback.toPlaylistSummary()
+        ?: fallback
 }
 
 internal suspend fun loadNeteaseRadarPlaylistSummaries(
     definitions: List<NeteaseRadarPlaylistDefinition>,
-    fanRadarSummary: PlaylistSummary?,
-    loadDetail: suspend (playlistId: Long, n: Int, s: Int) -> String,
+    loadMetadata: suspend (playlistId: Long) -> String,
     onLoadFailure: (NeteaseRadarPlaylistDefinition, Throwable) -> Unit = { _, _ -> }
 ): List<PlaylistSummary> {
     return buildList(definitions.size) {
         definitions.forEach { definition ->
             currentCoroutineContext().ensureActive()
-            if (definition.id == NETEASE_FAN_RADAR_PLAYLIST_ID && fanRadarSummary != null) {
-                add(fanRadarSummary)
-                return@forEach
-            }
-
             val summary = try {
-                val raw = loadDetail(definition.id, 1, 0)
+                val raw = loadMetadata(definition.id)
                 currentCoroutineContext().ensureActive()
                 parseNeteasePlaylistDetailSummary(raw, definition)
             } catch (error: CancellationException) {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/NeteaseHomeRecommendations.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/NeteaseHomeRecommendations.kt
@@ -158,10 +158,7 @@ internal fun parseNeteasePlaylistDetailSummary(
     fallback: NeteaseRadarPlaylistDefinition
 ): PlaylistSummary = parseNeteasePlaylistDetailSummary(raw, fallback.toPlaylistSummary())
 
-internal fun parseNeteasePlaylistDetailSummary(
-    raw: String,
-    fallback: PlaylistSummary
-): PlaylistSummary {
+internal fun parseNeteasePlaylistDetailSummaryOrNull(raw: String): PlaylistSummary? {
     val root = JSONObject(raw)
     val code = root.optInt("code", 200)
     if (code != 200) {
@@ -169,8 +166,12 @@ internal fun parseNeteasePlaylistDetailSummary(
     }
     val playlist = root.optJSONObject("playlist") ?: root.optJSONObject("result")
     return playlist?.let(::parseNeteasePlaylistSummary)
-        ?: fallback
 }
+
+internal fun parseNeteasePlaylistDetailSummary(
+    raw: String,
+    fallback: PlaylistSummary
+): PlaylistSummary = parseNeteasePlaylistDetailSummaryOrNull(raw) ?: fallback
 
 internal suspend fun loadNeteaseRadarPlaylistSummaries(
     definitions: List<NeteaseRadarPlaylistDefinition>,
@@ -183,7 +184,9 @@ internal suspend fun loadNeteaseRadarPlaylistSummaries(
             val summary = try {
                 val raw = loadMetadata(definition.id)
                 currentCoroutineContext().ensureActive()
-                parseNeteasePlaylistDetailSummary(raw, definition)
+                parseNeteasePlaylistDetailSummaryOrNull(raw)
+                    ?.takeIf { summary -> summary.id == definition.id }
+                    ?: definition.toPlaylistSummary()
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Exception) {

--- a/app/src/test/java/moe/ouom/neriplayer/core/api/netease/NeteaseClientTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/api/netease/NeteaseClientTest.kt
@@ -81,6 +81,21 @@ class NeteaseClientTest {
         )
     }
 
+    @Test
+    fun radarPlaylistMetadataParams_includeMgcContextAndMetadataLimit() {
+        val params = buildNeteaseRadarPlaylistMetadataParams(5_327_906_368L)
+
+        assertEquals("5327906368", params["id"])
+        assertEquals("1", params["n"])
+        assertEquals("0", params["s"])
+        assertEquals("MGC", params["uiPlaylistType"])
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun radarPlaylistMetadataParams_rejectNonPositivePlaylistId() {
+        buildNeteaseRadarPlaylistMetadataParams(0L)
+    }
+
     private fun assertTrueHexSessionCookie(value: String?) {
         assertEquals(32, value?.length)
         assertTrue(value?.all { it in '0'..'9' || it in 'a'..'f' } == true)

--- a/app/src/test/java/moe/ouom/neriplayer/core/api/netease/NeteaseClientTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/api/netease/NeteaseClientTest.kt
@@ -1,7 +1,10 @@
 package moe.ouom.neriplayer.core.api.netease
 
+import okhttp3.Cookie
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -41,6 +44,57 @@ class NeteaseClientTest {
         client.setPersistedCookies(emptyMap())
 
         assertFalse(client.getCookies().containsKey("MUSIC_U"))
+    }
+
+    @Test
+    fun sessionStore_keepsLateCookiesInTheOriginalAccountSession() {
+        val store = NeteaseRequestSessionStore()
+        val accountA = store.setPersistedCookies(mapOf("MUSIC_U" to "account-a"))
+        val accountB = store.setPersistedCookies(mapOf("MUSIC_U" to "account-b"))
+        val requestUrl = "https://music.163.com/".toHttpUrl()
+
+        accountA.cookieJar.saveFromResponse(
+            requestUrl,
+            listOf(newCookie("__csrf", "late-account-a"))
+        )
+
+        assertNotSame(accountA, accountB)
+        assertEquals("late-account-a", accountA.requestCookiesForUrl(requestUrl)["__csrf"])
+        assertFalse(accountB.requestCookiesForUrl(requestUrl).containsKey("__csrf"))
+        assertFalse(store.currentSession().requestCookiesForUrl(requestUrl).containsKey("__csrf"))
+    }
+
+    @Test
+    fun sessionStore_preservesSessionWhenOnlyRuntimeCookiesChange() {
+        val store = NeteaseRequestSessionStore()
+        val original = store.setPersistedCookies(
+            mapOf("MUSIC_U" to "account-a", "__csrf" to "old-session")
+        )
+        val replacement = store.setPersistedCookies(
+            mapOf("MUSIC_U" to "account-a", "__csrf" to "new-session")
+        )
+
+        assertEquals(original, replacement)
+        assertEquals("new-session", replacement.requestCookiesForUrl(
+            "https://music.163.com/".toHttpUrl()
+        )["__csrf"])
+    }
+
+    @Test
+    fun sessionStore_doesNotRestoreAnOlderAccountSnapshotAfterSwitching() {
+        val store = NeteaseRequestSessionStore()
+        val accountA = mapOf("MUSIC_U" to "account-a", "__csrf" to "a-session")
+        val accountB = mapOf("MUSIC_U" to "account-b", "__csrf" to "b-session")
+
+        val firstAccountSession = store.setPersistedCookies(accountA)
+        val secondAccountSession = store.setPersistedCookies(accountB)
+        val restoredAccountSession = store.setPersistedCookies(accountA)
+
+        assertNotSame(firstAccountSession, secondAccountSession)
+        assertNotSame(secondAccountSession, restoredAccountSession)
+        assertEquals("account-a", restoredAccountSession.requestCookiesForUrl(
+            "https://music.163.com/".toHttpUrl()
+        )["MUSIC_U"])
     }
 
     @Test
@@ -99,5 +153,14 @@ class NeteaseClientTest {
     private fun assertTrueHexSessionCookie(value: String?) {
         assertEquals(32, value?.length)
         assertTrue(value?.all { it in '0'..'9' || it in 'a'..'f' } == true)
+    }
+
+    private fun newCookie(name: String, value: String): Cookie {
+        return Cookie.Builder()
+            .name(name)
+            .value(value)
+            .domain("music.163.com")
+            .path("/")
+            .build()
     }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/playlist/NeteaseCollectionDetailViewModelTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/playlist/NeteaseCollectionDetailViewModelTest.kt
@@ -1,9 +1,14 @@
 package moe.ouom.neriplayer.ui.viewmodel.playlist
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistDetail
 import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistHeader
+import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistTrack
+import moe.ouom.neriplayer.data.platform.netease.neteaseRadarCacheContext
 import moe.ouom.neriplayer.ui.viewmodel.tab.NeteaseRadarPlaylistDefinitions
 import moe.ouom.neriplayer.ui.viewmodel.tab.PlaylistSummary
 import moe.ouom.neriplayer.ui.viewmodel.tab.isNeteaseRadarPlaylist
@@ -110,6 +115,452 @@ class NeteaseCollectionDetailViewModelTest {
         assertEquals("https://example.com/account.jpg", refreshed.header.coverUrl)
         assertEquals(1_530_000_000L, refreshed.header.playCount)
         assertEquals(30, refreshed.header.trackCount)
+    }
+
+    @Test
+    fun `radar cache refresh keeps MGC header when fresh metadata is unavailable`() {
+        val cached = CachedNeteasePlaylistDetail(
+            playlistId = 5_320_167_908L,
+            header = CachedNeteasePlaylistHeader(
+                id = 5_320_167_908L,
+                name = "为你定制的时光雷达",
+                coverUrl = "https://example.com/account.jpg",
+                playCount = 1_530_000_000L,
+                trackCount = 30
+            ),
+            recentTrackSignature = "50#0:1|",
+            tracks = emptyList()
+        )
+
+        assertEquals(cached, refreshNeteasePlaylistCachedHeader(cached, fresh = null))
+    }
+
+    @Test
+    fun `cached radar header is not overwritten by generic fallback`() {
+        val cached = CachedNeteasePlaylistHeader(
+            id = 5_320_167_908L,
+            name = "为你定制的时光雷达",
+            coverUrl = "https://example.com/account.jpg",
+            playCount = 1_530_000_000L,
+            trackCount = 30
+        )
+
+        val header = cached.toNeteaseCollectionHeader(
+            PlaylistSummary(
+                id = 5_320_167_908L,
+                name = "时光雷达",
+                picUrl = "https://example.com/visitor.jpg",
+                playCount = 1L,
+                trackCount = 50
+            )
+        )
+
+        assertEquals("为你定制的时光雷达", header.name)
+        assertEquals("https://example.com/account.jpg", header.coverUrl)
+        assertEquals(1_530_000_000L, header.playCount)
+        assertEquals(30, header.trackCount)
+    }
+
+    @Test
+    fun `empty radar metadata keeps matching cached display header during refresh`() {
+        val cachedHeader = CachedNeteasePlaylistHeader(
+            id = 5_320_167_908L,
+            name = "账号雷达",
+            coverUrl = "https://example.com/account.jpg",
+            playCount = 99L,
+            trackCount = 30
+        )
+        val playlist = PlaylistSummary(
+            id = cachedHeader.id,
+            name = "时光雷达",
+            picUrl = "",
+            playCount = 0L,
+            trackCount = 0
+        )
+        val detailHeader = NeteaseCollectionHeader(
+            id = cachedHeader.id,
+            isAlbum = false,
+            name = "通用雷达",
+            coverUrl = "https://example.com/generic.jpg",
+            playCount = 1L,
+            trackCount = 50
+        )
+
+        val resolved = resolveNeteasePlaylistDisplayHeader(
+            playlist = playlist,
+            detailHeader = detailHeader,
+            freshRadarHeader = null,
+            cachedRadarHeader = cachedHeader
+        )
+
+        assertEquals("账号雷达", resolved.name)
+        assertEquals("https://example.com/account.jpg", resolved.coverUrl)
+        assertEquals(99L, resolved.playCount)
+        assertEquals(30, resolved.trackCount)
+    }
+
+    @Test
+    fun `partial radar metadata preserves matching cached fields`() {
+        val cachedHeader = CachedNeteasePlaylistHeader(
+            id = 5_320_167_908L,
+            name = "账号雷达",
+            coverUrl = "https://example.com/account.jpg",
+            playCount = 99L,
+            trackCount = 30
+        )
+        val resolved = resolveNeteasePlaylistDisplayHeader(
+            playlist = PlaylistSummary(
+                id = cachedHeader.id,
+                name = "时光雷达",
+                picUrl = "",
+                playCount = 0L,
+                trackCount = 0
+            ),
+            detailHeader = NeteaseCollectionHeader(
+                id = cachedHeader.id,
+                isAlbum = false,
+                name = "通用雷达",
+                coverUrl = "https://example.com/generic.jpg",
+                playCount = 1L,
+                trackCount = 50
+            ),
+            freshRadarHeader = PlaylistSummary(
+                id = cachedHeader.id,
+                name = "新雷达标题",
+                picUrl = "",
+                playCount = 0L,
+                trackCount = 0
+            ),
+            cachedRadarHeader = cachedHeader
+        )
+
+        assertEquals("新雷达标题", resolved.name)
+        assertEquals("https://example.com/account.jpg", resolved.coverUrl)
+        assertEquals(99L, resolved.playCount)
+        assertEquals(30, resolved.trackCount)
+    }
+
+    @Test
+    fun `radar display fallback ignores a cache from another account context`() {
+        val cached = CachedNeteasePlaylistDetail(
+            playlistId = 5_320_167_908L,
+            header = CachedNeteasePlaylistHeader(
+                id = 5_320_167_908L,
+                name = "账号 A 雷达",
+                coverUrl = "https://example.com/account-a.jpg",
+                playCount = 99L,
+                trackCount = 30
+            ),
+            recentTrackSignature = "30#0:1|",
+            tracks = emptyList(),
+            radarCacheContext = "account-a"
+        )
+
+        assertNull(
+            matchingNeteaseRadarCacheHeader(
+                cached = cached,
+                playlistId = cached.playlistId,
+                expectedRadarCacheContext = "account-b"
+            )
+        )
+        assertEquals(
+            cached.header,
+            matchingNeteaseRadarCacheHeader(
+                cached = cached,
+                playlistId = cached.playlistId,
+                expectedRadarCacheContext = "account-a"
+            )
+        )
+    }
+
+    @Test
+    fun `radar cache validation uses raw detail metadata instead of display count`() {
+        val cached = CachedNeteasePlaylistDetail(
+            playlistId = 5_320_167_908L,
+            header = CachedNeteasePlaylistHeader(
+                id = 5_320_167_908L,
+                name = "为你定制的时光雷达",
+                coverUrl = "https://example.com/account.jpg",
+                playCount = 1_530_000_000L,
+                trackCount = 30
+            ),
+            recentTrackSignature = "50#0:1|",
+            tracks = List(50) { index ->
+                CachedNeteasePlaylistTrack(
+                    id = index + 1L,
+                    name = "Track $index",
+                    artist = "Artist",
+                    album = "Album",
+                    albumId = 1L,
+                    durationMs = 1L,
+                    coverUrl = null,
+                    audioId = null
+                )
+            }
+        )
+
+        assertTrue(
+            shouldReuseNeteasePlaylistCache(
+                cached = cached,
+                expectedTrackCount = 50,
+                recentTrackSignature = "50#0:1|",
+                requireHeaderTrackCountMatch = false
+            )
+        )
+        assertFalse(
+            shouldReuseNeteasePlaylistCache(
+                cached = cached,
+                expectedTrackCount = 50,
+                recentTrackSignature = "50#0:1|",
+                requireHeaderTrackCountMatch = true
+            )
+        )
+        assertFalse(
+            shouldReuseNeteasePlaylistCache(
+                cached = cached,
+                expectedTrackCount = 50,
+                recentTrackSignature = "50#0:2|",
+                requireHeaderTrackCountMatch = false
+            )
+        )
+        assertFalse(
+            shouldReuseNeteasePlaylistCache(
+                cached = cached.copy(tracks = cached.tracks.take(49)),
+                expectedTrackCount = 50,
+                recentTrackSignature = "50#0:1|",
+                requireHeaderTrackCountMatch = false
+            )
+        )
+    }
+
+    @Test
+    fun `radar cache only serves its matching account context`() {
+        val accountAContext = neteaseRadarCacheContext(
+            mapOf("MUSIC_U" to "synthetic-account-a-cookie")
+        )
+        val accountBContext = neteaseRadarCacheContext(
+            mapOf("MUSIC_U" to "synthetic-account-b-cookie")
+        )
+        val publicContext = neteaseRadarCacheContext(emptyMap())
+        val cached = CachedNeteasePlaylistDetail(
+            playlistId = 5_320_167_908L,
+            header = CachedNeteasePlaylistHeader(
+                id = 5_320_167_908L,
+                name = "为你定制的时光雷达",
+                coverUrl = "https://example.com/account-a.jpg",
+                playCount = 1_530_000_000L,
+                trackCount = 30
+            ),
+            recentTrackSignature = "50#0:1|",
+            tracks = emptyList(),
+            radarCacheContext = accountAContext
+        )
+
+        assertTrue(
+            isNeteasePlaylistCacheCompatible(
+                cached = cached,
+                requestedPlaylistId = cached.playlistId,
+                expectedRadarCacheContext = accountAContext
+            )
+        )
+        assertFalse(
+            isNeteasePlaylistCacheCompatible(
+                cached = cached,
+                requestedPlaylistId = cached.playlistId,
+                expectedRadarCacheContext = accountBContext
+            )
+        )
+        assertFalse(
+            isNeteasePlaylistCacheCompatible(
+                cached = cached,
+                requestedPlaylistId = cached.playlistId,
+                expectedRadarCacheContext = publicContext
+            )
+        )
+        assertFalse(
+            isNeteasePlaylistCacheCompatible(
+                cached = cached.copy(radarCacheContext = null),
+                requestedPlaylistId = cached.playlistId,
+                expectedRadarCacheContext = accountAContext
+            )
+        )
+        assertFalse(
+            isNeteasePlaylistCacheCompatible(
+                cached = cached.copy(radarCacheContext = publicContext),
+                requestedPlaylistId = cached.playlistId,
+                expectedRadarCacheContext = accountAContext
+            )
+        )
+        assertFalse(accountAContext.contains("synthetic-account-a-cookie"))
+        assertFalse(accountBContext.contains("synthetic-account-b-cookie"))
+    }
+
+    @Test
+    fun `normal playlist cache ignores radar account context`() {
+        val cached = CachedNeteasePlaylistDetail(
+            playlistId = 42L,
+            header = CachedNeteasePlaylistHeader(
+                id = 42L,
+                name = "普通歌单",
+                coverUrl = "https://example.com/playlist.jpg",
+                playCount = 1L,
+                trackCount = 1
+            ),
+            recentTrackSignature = "1#0:1|",
+            tracks = emptyList(),
+            radarCacheContext = null
+        )
+
+        assertTrue(
+            isNeteasePlaylistCacheCompatible(
+                cached = cached,
+                requestedPlaylistId = 42L,
+                expectedRadarCacheContext = neteaseRadarCacheContext(emptyMap())
+            )
+        )
+    }
+
+    @Test
+    fun `stale radar request is rejected after account context changes`() {
+        val accountAContext = neteaseRadarCacheContext(
+            mapOf("MUSIC_U" to "synthetic-account-a-cookie")
+        )
+        val accountBContext = neteaseRadarCacheContext(
+            mapOf("MUSIC_U" to "synthetic-account-b-cookie")
+        )
+        val radarId = 5_320_167_908L
+
+        assertTrue(
+            shouldAcceptNeteasePlaylistLoadResult(
+                requestedPlaylistId = radarId,
+                activePlaylistId = radarId,
+                requestRadarCacheContext = accountAContext,
+                currentRadarCacheContext = accountAContext
+            )
+        )
+        assertFalse(
+            shouldAcceptNeteasePlaylistLoadResult(
+                requestedPlaylistId = radarId,
+                activePlaylistId = radarId,
+                requestRadarCacheContext = accountAContext,
+                currentRadarCacheContext = accountBContext
+            )
+        )
+        assertFalse(
+            shouldAcceptNeteasePlaylistLoadResult(
+                requestedPlaylistId = radarId,
+                activePlaylistId = 42L,
+                requestRadarCacheContext = accountAContext,
+                currentRadarCacheContext = accountAContext
+            )
+        )
+    }
+
+    @Test
+    fun `stale collection request is rejected after a newer load starts`() {
+        assertTrue(
+            shouldAcceptNeteaseCollectionLoadResult(
+                requestedCollectionId = 42L,
+                activeCollectionId = 42L,
+                requestGeneration = 2L,
+                activeGeneration = 2L
+            )
+        )
+        assertFalse(
+            shouldAcceptNeteaseCollectionLoadResult(
+                requestedCollectionId = 42L,
+                activeCollectionId = 42L,
+                requestGeneration = 1L,
+                activeGeneration = 2L
+            )
+        )
+        assertFalse(
+            shouldAcceptNeteaseCollectionLoadResult(
+                requestedCollectionId = 42L,
+                activeCollectionId = 43L,
+                requestGeneration = 2L,
+                activeGeneration = 2L
+            )
+        )
+    }
+
+    @Test
+    fun `initial radar context emission only skips the unchanged construction snapshot`() {
+        assertFalse(
+            shouldHandleInitialNeteaseRadarContextEmission(
+                isFirstEmission = true,
+                initialRadarCacheContext = "account-a",
+                emittedRadarCacheContext = "account-a"
+            )
+        )
+        assertTrue(
+            shouldHandleInitialNeteaseRadarContextEmission(
+                isFirstEmission = true,
+                initialRadarCacheContext = "account-a",
+                emittedRadarCacheContext = "account-b"
+            )
+        )
+        assertTrue(
+            shouldHandleInitialNeteaseRadarContextEmission(
+                isFirstEmission = false,
+                initialRadarCacheContext = "account-a",
+                emittedRadarCacheContext = "account-a"
+            )
+        )
+    }
+
+    @Test
+    fun `radar context change resets personalized entry metadata`() {
+        val personalized = PlaylistSummary(
+            id = 5_320_167_908L,
+            name = "账号 A 的时光雷达",
+            picUrl = "https://example.com/account-a.jpg",
+            playCount = 42L,
+            trackCount = 30
+        )
+
+        val reset = resetNeteaseRadarPlaylistSummaryForContextChange(personalized)
+
+        assertEquals(personalized.id, reset.id)
+        assertEquals("时光雷达", reset.name)
+        assertEquals("", reset.picUrl)
+        assertEquals(0L, reset.playCount)
+        assertEquals(0, reset.trackCount)
+    }
+
+    @Test
+    fun `normal playlist keeps entry metadata across radar context change`() {
+        val playlist = PlaylistSummary(
+            id = 42L,
+            name = "普通歌单",
+            picUrl = "https://example.com/playlist.jpg",
+            playCount = 1L,
+            trackCount = 1
+        )
+
+        assertEquals(playlist, resetNeteaseRadarPlaylistSummaryForContextChange(playlist))
+    }
+
+    @Test
+    fun `unknown radar entry context falls back to public metadata`() {
+        val personalized = PlaylistSummary(
+            id = 5_320_167_908L,
+            name = "账号 A 的时光雷达",
+            picUrl = "https://example.com/account-a.jpg",
+            playCount = 42L,
+            trackCount = 30
+        )
+
+        val safeEntry = prepareNeteasePlaylistEntryForContext(
+            playlist = personalized,
+            knownCacheContext = null,
+            currentCacheContext = neteaseRadarCacheContext(emptyMap())
+        )
+
+        assertEquals("时光雷达", safeEntry.name)
+        assertEquals("", safeEntry.picUrl)
+        assertEquals(0L, safeEntry.playCount)
+        assertEquals(0, safeEntry.trackCount)
     }
 
     @Test

--- a/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/playlist/NeteaseCollectionDetailViewModelTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/playlist/NeteaseCollectionDetailViewModelTest.kt
@@ -4,7 +4,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistDetail
 import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistHeader
+import moe.ouom.neriplayer.ui.viewmodel.tab.NeteaseRadarPlaylistDefinitions
 import moe.ouom.neriplayer.ui.viewmodel.tab.PlaylistSummary
+import moe.ouom.neriplayer.ui.viewmodel.tab.isNeteaseRadarPlaylist
 
 class NeteaseCollectionDetailViewModelTest {
 
@@ -68,6 +70,56 @@ class NeteaseCollectionDetailViewModelTest {
         assertEquals("https://example.com/account.jpg", refreshed.header.coverUrl)
         assertEquals(cached.tracks, refreshed.tracks)
         assertEquals(cached.recentTrackSignature, refreshed.recentTrackSignature)
+    }
+
+    @Test
+    fun `radar cache refresh uses applied MGC header`() {
+        val cached = CachedNeteasePlaylistDetail(
+            playlistId = 5_320_167_908L,
+            header = CachedNeteasePlaylistHeader(
+                id = 5_320_167_908L,
+                name = "时光雷达",
+                coverUrl = "https://example.com/visitor.jpg",
+                playCount = 1L,
+                trackCount = 50
+            ),
+            recentTrackSignature = "30#0:1|",
+            tracks = emptyList()
+        )
+        val appliedHeader = applyNeteaseRadarPlaylistHeader(
+            playlist = PlaylistSummary(
+                id = 5_320_167_908L,
+                name = "为你定制的时光雷达",
+                picUrl = "http://example.com/account.jpg",
+                playCount = 1_530_000_000L,
+                trackCount = 30
+            ),
+            detailHeader = NeteaseCollectionHeader(
+                id = 5_320_167_908L,
+                isAlbum = false,
+                name = "时光雷达",
+                coverUrl = "https://example.com/visitor.jpg",
+                playCount = 1L,
+                trackCount = 50
+            )
+        )
+
+        val refreshed = refreshNeteasePlaylistCachedHeader(cached, appliedHeader)
+
+        assertEquals("为你定制的时光雷达", refreshed.header.name)
+        assertEquals("https://example.com/account.jpg", refreshed.header.coverUrl)
+        assertEquals(1_530_000_000L, refreshed.header.playCount)
+        assertEquals(30, refreshed.header.trackCount)
+    }
+
+    @Test
+    fun `all radar definitions are treated as radar playlists`() {
+        assertEquals(
+            NeteaseRadarPlaylistDefinitions.map { it.id },
+            NeteaseRadarPlaylistDefinitions
+                .map { it.id }
+                .filter(::isNeteaseRadarPlaylist)
+        )
     }
 
     @Test

--- a/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/playlist/NeteaseCollectionDetailViewModelTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/playlist/NeteaseCollectionDetailViewModelTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistDetail
 import moe.ouom.neriplayer.data.platform.netease.CachedNeteasePlaylistHeader
+import moe.ouom.neriplayer.ui.viewmodel.tab.PlaylistSummary
 
 class NeteaseCollectionDetailViewModelTest {
 
@@ -67,5 +68,80 @@ class NeteaseCollectionDetailViewModelTest {
         assertEquals("https://example.com/account.jpg", refreshed.header.coverUrl)
         assertEquals(cached.tracks, refreshed.tracks)
         assertEquals(cached.recentTrackSignature, refreshed.recentTrackSignature)
+    }
+
+    @Test
+    fun `radar detail keeps MGC header`() {
+        val header = applyNeteaseRadarPlaylistHeader(
+            playlist = PlaylistSummary(
+                id = 5_320_167_908L,
+                name = "为你定制的时光雷达",
+                picUrl = "http://example.com/account.jpg",
+                playCount = 1_530_000_000L,
+                trackCount = 30
+            ),
+            detailHeader = NeteaseCollectionHeader(
+                id = 5_320_167_908L,
+                isAlbum = false,
+                name = "时光雷达",
+                coverUrl = "https://example.com/visitor.jpg",
+                playCount = 1L,
+                trackCount = 50
+            )
+        )
+
+        assertEquals("为你定制的时光雷达", header.name)
+        assertEquals("https://example.com/account.jpg", header.coverUrl)
+        assertEquals(1_530_000_000L, header.playCount)
+        assertEquals(30, header.trackCount)
+    }
+
+    @Test
+    fun `radar detail keeps title when MGC cover is unavailable`() {
+        val header = applyNeteaseRadarPlaylistHeader(
+            playlist = PlaylistSummary(
+                id = 5_320_167_908L,
+                name = "为你定制的时光雷达",
+                picUrl = "",
+                playCount = 0L,
+                trackCount = 0
+            ),
+            detailHeader = NeteaseCollectionHeader(
+                id = 5_320_167_908L,
+                isAlbum = false,
+                name = "时光雷达",
+                coverUrl = "https://example.com/visitor.jpg",
+                playCount = 1L,
+                trackCount = 50
+            )
+        )
+
+        assertEquals("为你定制的时光雷达", header.name)
+        assertEquals("https://example.com/visitor.jpg", header.coverUrl)
+    }
+
+    @Test
+    fun `ordinary playlists keep their detail header`() {
+        val detailHeader = NeteaseCollectionHeader(
+            id = 123L,
+            isAlbum = false,
+            name = "详情标题",
+            coverUrl = "https://example.com/detail.jpg",
+            playCount = 2L,
+            trackCount = 10
+        )
+
+        val header = applyNeteaseRadarPlaylistHeader(
+            playlist = PlaylistSummary(
+                id = 123L,
+                name = "入口标题",
+                picUrl = "https://example.com/entry.jpg",
+                playCount = 3L,
+                trackCount = 20
+            ),
+            detailHeader = detailHeader
+        )
+
+        assertEquals(detailHeader, header)
     }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/tab/NeteaseHomeRecommendationsTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/tab/NeteaseHomeRecommendationsTest.kt
@@ -133,12 +133,12 @@ class NeteaseHomeRecommendationsTest {
     }
 
     @Test
-    fun parsePlaylistDetail_keepsAccountSpecificRadarTitleAndCover() {
+    fun parsePlaylistDetail_readsMgcResultWithAccountSpecificRadarTitleAndCover() {
         val detail = parseNeteasePlaylistDetailSummary(
             raw = """
                 {
                   "code": 200,
-                  "playlist": {
+                  "result": {
                     "id": 5327906368,
                     "name": "为你定制的乐迷雷达",
                     "coverImgUrl": "http://p1.music.126.net/account-radar.jpg",
@@ -156,6 +156,43 @@ class NeteaseHomeRecommendationsTest {
         assertEquals("为你定制的乐迷雷达", detail.name)
         assertEquals("https://p1.music.126.net/account-radar.jpg", detail.picUrl)
         assertEquals(42L, detail.playCount)
+    }
+
+    @Test
+    fun radarPlaylistSummaries_useMgcMetadataForFanAndMysteryRadar() = runTest {
+        val requestedIds = mutableListOf<Long>()
+
+        val summaries = loadNeteaseRadarPlaylistSummaries(
+            definitions = NeteaseRadarPlaylistDefinitions,
+            loadMetadata = { playlistId ->
+                requestedIds += playlistId
+                val metadata = when (playlistId) {
+                    NETEASE_FAN_RADAR_PLAYLIST_ID -> "为你定制的乐迷雷达" to "fan"
+                    5_341_776_086L -> "神秘歌友推荐你听《尘缘》|神秘雷达" to "mystery"
+                    else -> "雷达 $playlistId" to "default"
+                }
+                """
+                    {
+                      "code": 200,
+                      "result": {
+                        "id": $playlistId,
+                        "name": "${metadata.first}",
+                        "coverImgUrl": "https://example.com/${metadata.second}.jpg",
+                        "playCount": 42,
+                        "trackCount": 50
+                      }
+                    }
+                """.trimIndent()
+            }
+        )
+
+        assertEquals(NeteaseRadarPlaylistDefinitions.map { it.id }, summaries.map { it.id })
+        assertEquals("为你定制的乐迷雷达", summaries[3].name)
+        assertEquals("https://example.com/fan.jpg", summaries[3].picUrl)
+        assertEquals("神秘歌友推荐你听《尘缘》|神秘雷达", summaries[4].name)
+        assertEquals("https://example.com/mystery.jpg", summaries[4].picUrl)
+        assertEquals(NeteaseRadarPlaylistDefinitions.map { it.id }, requestedIds)
+        assertTrue(requestedIds.contains(NETEASE_FAN_RADAR_PLAYLIST_ID))
     }
 
     @Test
@@ -252,13 +289,12 @@ class NeteaseHomeRecommendationsTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun radarSummaryRequestsOnlyMetadataAndStopsAfterCancellation() = runTest {
-        val requested = mutableListOf<Triple<Long, Int, Int>>()
+        val requested = mutableListOf<Long>()
         val result = async {
             loadNeteaseRadarPlaylistSummaries(
                 definitions = NeteaseRadarPlaylistDefinitions.take(2),
-                fanRadarSummary = null,
-                loadDetail = { playlistId, n, s ->
-                    requested += Triple(playlistId, n, s)
+                loadMetadata = { playlistId ->
+                    requested += playlistId
                     coroutineContext.cancel()
                     """{"code":200}"""
                 }
@@ -269,7 +305,7 @@ class NeteaseHomeRecommendationsTest {
 
         assertTrue(result.isCancelled)
         assertEquals(
-            listOf(Triple(NeteaseRadarPlaylistDefinitions.first().id, 1, 0)),
+            listOf(NeteaseRadarPlaylistDefinitions.first().id),
             requested
         )
     }

--- a/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/tab/NeteaseHomeRecommendationsTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/tab/NeteaseHomeRecommendationsTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.coroutines.coroutineContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import moe.ouom.neriplayer.core.api.netease.mergeNeteaseSessionCookies
@@ -156,6 +157,42 @@ class NeteaseHomeRecommendationsTest {
         assertEquals("为你定制的乐迷雷达", detail.name)
         assertEquals("https://p1.music.126.net/account-radar.jpg", detail.picUrl)
         assertEquals(42L, detail.playCount)
+    }
+
+    @Test
+    fun parsePlaylistDetailOrNull_rejectsEmptySuccessfulResponse() {
+        assertNull(parseNeteasePlaylistDetailSummaryOrNull("""{"code":200}"""))
+    }
+
+    @Test
+    fun radarPlaylistSummaries_keepDefaultMetadataForEmptyOrMismatchedResponse() = runTest {
+        val first = NeteaseRadarPlaylistDefinitions[0]
+        val second = NeteaseRadarPlaylistDefinitions[1]
+
+        val summaries = loadNeteaseRadarPlaylistSummaries(
+            definitions = listOf(first, second),
+            loadMetadata = { playlistId ->
+                if (playlistId == first.id) {
+                    """{"code":200}"""
+                } else {
+                    """
+                        {
+                          "code": 200,
+                          "result": {
+                            "id": ${first.id},
+                            "name": "wrong radar",
+                            "coverImgUrl": "https://example.com/wrong.jpg"
+                          }
+                        }
+                    """.trimIndent()
+                }
+            }
+        )
+
+        assertEquals(listOf(first.id, second.id), summaries.map { it.id })
+        assertEquals(first.name, summaries[0].name)
+        assertEquals(second.name, summaries[1].name)
+        assertTrue(summaries.all { it.picUrl.isEmpty() })
     }
 
     @Test
@@ -334,6 +371,69 @@ class NeteaseHomeRecommendationsTest {
             shouldRefreshNeteaseHome(
                 loginChanged = false,
                 recommendationsBootstrapped = true
+            )
+        )
+        assertTrue(
+            shouldRefreshNeteaseHome(
+                loginChanged = false,
+                recommendationsBootstrapped = true,
+                accountContextChanged = true
+            )
+        )
+    }
+
+    @Test
+    fun initialCookieEmissionOnlySkipsTheUnchangedConstructionSnapshot() {
+        val accountA = mapOf("MUSIC_U" to "account-a")
+        val accountB = mapOf("MUSIC_U" to "account-b")
+
+        assertFalse(
+            shouldHandleInitialNeteaseHomeCookieEmission(
+                isFirstEmission = true,
+                initialCookies = accountA,
+                emittedCookies = accountA
+            )
+        )
+        assertTrue(
+            shouldHandleInitialNeteaseHomeCookieEmission(
+                isFirstEmission = true,
+                initialCookies = accountA,
+                emittedCookies = accountB
+            )
+        )
+        assertTrue(
+            shouldHandleInitialNeteaseHomeCookieEmission(
+                isFirstEmission = false,
+                initialCookies = accountA,
+                emittedCookies = accountA
+            )
+        )
+    }
+
+    @Test
+    fun radarPlaylistLoadRejectsOlderGenerationAndAccountContext() {
+        assertTrue(
+            shouldAcceptNeteaseRadarPlaylistLoadResult(
+                requestGeneration = 2L,
+                activeGeneration = 2L,
+                requestRadarCacheContext = "account-a",
+                activeRadarCacheContext = "account-a"
+            )
+        )
+        assertFalse(
+            shouldAcceptNeteaseRadarPlaylistLoadResult(
+                requestGeneration = 1L,
+                activeGeneration = 2L,
+                requestRadarCacheContext = "account-a",
+                activeRadarCacheContext = "account-a"
+            )
+        )
+        assertFalse(
+            shouldAcceptNeteaseRadarPlaylistLoadResult(
+                requestGeneration = 2L,
+                activeGeneration = 2L,
+                requestRadarCacheContext = "account-a",
+                activeRadarCacheContext = "account-b"
             )
         )
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 用户可见行为
- 雷达歌单优先显示账户对应的名称、封面、播放量和歌曲数。
- 获取雷达元数据失败时，继续显示默认歌单信息。

## 兼容性影响
- 普通歌单行为保持不变。
- 雷达元数据请求支持取消。
- 非正歌单 ID 会被拒绝。

## 测试
- 新增元数据请求参数和非法 ID 测试。
- 新增雷达元数据覆盖及普通歌单兼容性测试。
- 更新雷达响应解析、批量加载和取消流程测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->