### PR TITLE
feat: persist scroll state for YouTube Music creator detail and sections

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorScrollStateTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorScrollStateTest.kt
@@ -1,21 +1,14 @@
 package moe.ouom.neriplayer.ui.screen.artist
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
@@ -24,7 +17,15 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.launch
+import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorDetail
+import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorHeader
+import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorItem
+import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorItemType
+import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorSection
+import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorSummary
 import moe.ouom.neriplayer.testutil.assumeComposeHostAvailable
+import moe.ouom.neriplayer.ui.screen.host.youtubeMusicCreatorDetailStateKey
+import moe.ouom.neriplayer.ui.viewmodel.artist.YouTubeMusicCreatorDetailUiState
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -48,7 +49,7 @@ class YouTubeMusicCreatorScrollStateTest {
         lateinit var scrollHorizontal: (Int, Int) -> Unit
         lateinit var readPositions: () -> ScrollPositions
         composeRule.setContent {
-            CreatorScrollStateFixture(
+            CreatorDetailNavigationFixture(
                 onShowPlaylistChange = { showPlaylist = it },
                 onScrollVertical = { scrollVertical = it },
                 onScrollHorizontal = { scrollHorizontal = it },
@@ -83,67 +84,126 @@ private data class ScrollPositions(
 )
 
 @Composable
-private fun CreatorScrollStateFixture(
+private fun CreatorDetailNavigationFixture(
     onShowPlaylistChange: ((Boolean) -> Unit) -> Unit,
     onScrollVertical: (((Int, Int) -> Unit)) -> Unit,
     onScrollHorizontal: (((Int, Int) -> Unit)) -> Unit,
     onReadPositions: (() -> ScrollPositions) -> Unit
 ) {
     var playlistVisible by remember { mutableStateOf(false) }
+    val creator = remember {
+        YouTubeMusicCreatorSummary(
+            browseId = "UCdemoCreator",
+            title = "Demo Creator",
+            subtitle = "Artist",
+            coverUrl = ""
+        )
+    }
+    val detail = remember { creatorDetailFixture(creator) }
     val stateHolder = rememberSaveableStateHolder()
     val scope = rememberCoroutineScope()
+    var horizontalState by remember { mutableStateOf<LazyListState?>(null) }
 
-    SideEffect {
-        onShowPlaylistChange { visible -> playlistVisible = visible }
-    }
+    onShowPlaylistChange { visible -> playlistVisible = visible }
     if (playlistVisible) {
         Box(Modifier.fillMaxSize())
         return
     }
 
-    stateHolder.SaveableStateProvider("creator") {
+    stateHolder.SaveableStateProvider(
+        key = youtubeMusicCreatorDetailStateKey(creator)
+    ) {
         val verticalState = rememberSaveable(saver = LazyListState.Saver) {
             LazyListState()
         }
-        val horizontalState = rememberSaveable(saver = LazyListState.Saver) {
-            LazyListState()
+        val sectionStateHolder = rememberSaveableStateHolder()
+        onScrollVertical { index, offset ->
+            scope.launch { verticalState.scrollToItem(index, offset) }
         }
-        SideEffect {
-            onScrollVertical { index, offset ->
-                scope.launch { verticalState.scrollToItem(index, offset) }
-            }
-            onScrollHorizontal { index, offset ->
-                scope.launch { horizontalState.scrollToItem(index, offset) }
-            }
-            onReadPositions {
-                ScrollPositions(
-                    verticalIndex = verticalState.firstVisibleItemIndex,
-                    verticalOffset = verticalState.firstVisibleItemScrollOffset,
-                    horizontalIndex = horizontalState.firstVisibleItemIndex,
-                    horizontalOffset = horizontalState.firstVisibleItemScrollOffset
-                )
-            }
+        onReadPositions {
+            ScrollPositions(
+                verticalIndex = verticalState.firstVisibleItemIndex,
+                verticalOffset = verticalState.firstVisibleItemScrollOffset,
+                horizontalIndex = horizontalState?.firstVisibleItemIndex ?: 0,
+                horizontalOffset = horizontalState?.firstVisibleItemScrollOffset ?: 0
+            )
         }
-        Column(Modifier.fillMaxSize()) {
-            LazyColumn(
-                modifier = Modifier.weight(1f),
-                state = verticalState
-            ) {
-                item(key = "horizontal-section") {
-                    LazyRow(state = horizontalState, modifier = Modifier.height(96.dp)) {
-                        items((0..30).toList()) {
-                            Box(Modifier.width(96.dp).height(96.dp))
+        MaterialTheme {
+            YouTubeMusicCreatorDetailContent(
+                uiState = YouTubeMusicCreatorDetailUiState(
+                    loading = false,
+                    detail = detail
+                ),
+                listState = verticalState,
+                creatorBrowseId = creator.browseId,
+                sectionStateHolder = sectionStateHolder,
+                miniPlayerHeight = 0.dp,
+                offlineMode = false,
+                onRetry = {},
+                onSongClick = { _, _ -> },
+                onSectionSongClick = { _, _ -> },
+                onPlaylistClick = {},
+                onCreatorClick = {},
+                onSectionMoreClick = { playlistVisible = true },
+                isTabletLayout = false,
+                onSectionListState = { key, state ->
+                    if (key == youtubeMusicCreatorSectionScrollStateKey(
+                            creator.browseId,
+                            detail.sections.first()
+                        )
+                    ) {
+                        horizontalState = state
+                        onScrollHorizontal { index, offset ->
+                            scope.launch { state.scrollToItem(index, offset) }
                         }
                     }
                 }
-                items((0..30).toList()) { item ->
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(48.dp)
-                        )
-                }
-            }
+            )
         }
     }
+}
+
+private fun creatorDetailFixture(
+    creator: YouTubeMusicCreatorSummary
+): YouTubeMusicCreatorDetail {
+    val horizontalItems = (0..30).map { index ->
+        YouTubeMusicCreatorItem(
+            type = if (index == 0) {
+                YouTubeMusicCreatorItemType.Creator
+            } else {
+                YouTubeMusicCreatorItemType.Playlist
+            },
+            title = "Item $index",
+            subtitle = creator.title,
+            coverUrl = "",
+            browseId = "item-$index"
+        )
+    }
+    val horizontalSection = YouTubeMusicCreatorSection(
+        title = "Fans also like",
+        items = horizontalItems
+    )
+    val sections = listOf(horizontalSection) + (1..31).map { index ->
+        YouTubeMusicCreatorSection(
+            title = "Section $index",
+            items = listOf(
+                YouTubeMusicCreatorItem(
+                    type = YouTubeMusicCreatorItemType.Playlist,
+                    title = "Section item $index",
+                    subtitle = creator.title,
+                    coverUrl = "",
+                    browseId = "section-item-$index"
+                )
+            )
+        )
+    }
+    return YouTubeMusicCreatorDetail(
+        header = YouTubeMusicCreatorHeader(
+            browseId = creator.browseId,
+            title = creator.title,
+            subtitle = creator.subtitle,
+            coverUrl = creator.coverUrl
+        ),
+        sections = sections
+    )
 }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorScrollStateTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorScrollStateTest.kt
@@ -1,0 +1,149 @@
+package moe.ouom.neriplayer.ui.screen.artist
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.launch
+import moe.ouom.neriplayer.testutil.assumeComposeHostAvailable
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class YouTubeMusicCreatorScrollStateTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun assumeDeviceUnlocked() {
+        assumeComposeHostAvailable()
+    }
+
+    @Test
+    fun creatorRoundTripRestoresVerticalAndHorizontalPositions() {
+        lateinit var showPlaylist: (Boolean) -> Unit
+        lateinit var scrollVertical: (Int, Int) -> Unit
+        lateinit var scrollHorizontal: (Int, Int) -> Unit
+        lateinit var readPositions: () -> ScrollPositions
+        composeRule.setContent {
+            CreatorScrollStateFixture(
+                onShowPlaylistChange = { showPlaylist = it },
+                onScrollVertical = { scrollVertical = it },
+                onScrollHorizontal = { scrollHorizontal = it },
+                onReadPositions = { readPositions = it }
+            )
+        }
+
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { scrollHorizontal(8, 13) }
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { scrollVertical(12, 17) }
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { showPlaylist(true) }
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { showPlaylist(false) }
+        composeRule.waitForIdle()
+        composeRule.runOnIdle {
+            val positions = readPositions()
+            assertEquals(12, positions.verticalIndex)
+            assertEquals(17, positions.verticalOffset)
+            assertEquals(8, positions.horizontalIndex)
+            assertEquals(13, positions.horizontalOffset)
+        }
+    }
+}
+
+private data class ScrollPositions(
+    val verticalIndex: Int,
+    val verticalOffset: Int,
+    val horizontalIndex: Int,
+    val horizontalOffset: Int
+)
+
+@Composable
+private fun CreatorScrollStateFixture(
+    onShowPlaylistChange: ((Boolean) -> Unit) -> Unit,
+    onScrollVertical: (((Int, Int) -> Unit)) -> Unit,
+    onScrollHorizontal: (((Int, Int) -> Unit)) -> Unit,
+    onReadPositions: (() -> ScrollPositions) -> Unit
+) {
+    var playlistVisible by remember { mutableStateOf(false) }
+    val stateHolder = rememberSaveableStateHolder()
+    val scope = rememberCoroutineScope()
+
+    SideEffect {
+        onShowPlaylistChange { visible -> playlistVisible = visible }
+    }
+    if (playlistVisible) {
+        Box(Modifier.fillMaxSize())
+        return
+    }
+
+    stateHolder.SaveableStateProvider("creator") {
+        val verticalState = rememberSaveable(saver = LazyListState.Saver) {
+            LazyListState()
+        }
+        val horizontalState = rememberSaveable(saver = LazyListState.Saver) {
+            LazyListState()
+        }
+        SideEffect {
+            onScrollVertical { index, offset ->
+                scope.launch { verticalState.scrollToItem(index, offset) }
+            }
+            onScrollHorizontal { index, offset ->
+                scope.launch { horizontalState.scrollToItem(index, offset) }
+            }
+            onReadPositions {
+                ScrollPositions(
+                    verticalIndex = verticalState.firstVisibleItemIndex,
+                    verticalOffset = verticalState.firstVisibleItemScrollOffset,
+                    horizontalIndex = horizontalState.firstVisibleItemIndex,
+                    horizontalOffset = horizontalState.firstVisibleItemScrollOffset
+                )
+            }
+        }
+        Column(Modifier.fillMaxSize()) {
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+                state = verticalState
+            ) {
+                item(key = "horizontal-section") {
+                    LazyRow(state = horizontalState, modifier = Modifier.height(96.dp)) {
+                        items((0..30).toList()) {
+                            Box(Modifier.width(96.dp).height(96.dp))
+                        }
+                    }
+                }
+                items((0..30).toList()) { item ->
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(48.dp)
+                        )
+                }
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorScrollStateTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorScrollStateTest.kt
@@ -1,24 +1,29 @@
 package moe.ouom.neriplayer.ui.screen.artist
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsProperties.HorizontalScrollAxisRange
+import androidx.compose.ui.semantics.SemanticsProperties.VerticalScrollAxisRange
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasScrollToIndexAction
 import androidx.compose.ui.test.junit4.v2.createComposeRule
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onAncestors
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import kotlinx.coroutines.launch
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorDetail
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorHeader
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorItem
@@ -27,7 +32,6 @@ import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorSection
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorSummary
 import moe.ouom.neriplayer.testutil.assumeComposeHostAvailable
 import moe.ouom.neriplayer.ui.screen.host.youtubeMusicCreatorDetailStateKey
-import moe.ouom.neriplayer.ui.viewmodel.artist.YouTubeMusicCreatorDetailUiState
 import moe.ouom.neriplayer.ui.viewmodel.artist.YouTubeMusicCreatorDetailViewModel
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -47,52 +51,100 @@ class YouTubeMusicCreatorScrollStateTest {
 
     @Test
     fun creatorRoundTripRestoresVerticalAndHorizontalPositions() {
-        lateinit var showPlaylist: (Boolean) -> Unit
-        lateinit var scrollVertical: (Int, Int) -> Unit
-        lateinit var scrollHorizontal: (Int, Int) -> Unit
-        lateinit var readPositions: () -> ScrollPositions
         composeRule.setContent {
-            CreatorDetailNavigationFixture(
-                onShowPlaylistChange = { showPlaylist = it },
-                onScrollVertical = { scrollVertical = it },
-                onScrollHorizontal = { scrollHorizontal = it },
-                onReadPositions = { readPositions = it }
-            )
+            CreatorDetailNavigationFixture()
         }
 
-        composeRule.waitForIdle()
-        composeRule.runOnIdle { scrollHorizontal(8, 13) }
-        composeRule.waitForIdle()
-        composeRule.runOnIdle { scrollVertical(12, 17) }
-        composeRule.waitForIdle()
-        composeRule.runOnIdle { showPlaylist(true) }
-        composeRule.waitForIdle()
-        composeRule.runOnIdle { showPlaylist(false) }
-        composeRule.waitForIdle()
-        composeRule.runOnIdle {
-            val positions = readPositions()
-            assertEquals(12, positions.verticalIndex)
-            assertEquals(17, positions.verticalOffset)
-            assertEquals(8, positions.horizontalIndex)
-            assertEquals(13, positions.horizontalOffset)
+        waitForInitialCreatorContent()
+        composeRule.onNodeWithText("Item 0")
+            .onAncestors()
+            .filterToOne(horizontalLazyListMatcher)
+            .performScrollToIndex(8)
+        composeRule.waitUntil(timeoutMillis = SCROLL_STATE_TIMEOUT_MS) {
+            horizontalScrollOffset() > 0f
         }
+        val horizontalScrollOffsetBeforeNavigation = horizontalScrollOffset()
+
+        composeRule.onNode(verticalLazyListMatcher).performScrollToIndex(12)
+        composeRule.waitUntil(timeoutMillis = SCROLL_STATE_TIMEOUT_MS) {
+            verticalScrollOffset() > 0f
+        }
+        val verticalScrollOffsetBeforeNavigation = verticalScrollOffset()
+
+        composeRule.waitUntil(timeoutMillis = SCROLL_STATE_TIMEOUT_MS) {
+            composeRule.onAllNodesWithText("Section item 11")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithText("Section item 11").performClick()
+        composeRule.waitUntil(timeoutMillis = SCROLL_STATE_TIMEOUT_MS) {
+            composeRule.onAllNodesWithText(FIXTURE_BACK_LABEL)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithText(FIXTURE_BACK_LABEL).performClick()
+
+        waitForCreatorList()
+        composeRule.waitUntil(timeoutMillis = SCROLL_STATE_TIMEOUT_MS) {
+            verticalScrollOffset() == verticalScrollOffsetBeforeNavigation
+        }
+        assertEquals(
+            verticalScrollOffsetBeforeNavigation,
+            verticalScrollOffset(),
+            0f
+        )
+
+        composeRule.onNode(verticalLazyListMatcher).performScrollToIndex(0)
+        composeRule.waitUntil(timeoutMillis = SCROLL_STATE_TIMEOUT_MS) {
+            verticalScrollOffset() == 0f
+        }
+        assertEquals(
+            horizontalScrollOffsetBeforeNavigation,
+            horizontalScrollOffset(),
+            0f
+        )
+    }
+
+    private fun waitForInitialCreatorContent() {
+        composeRule.waitUntil(timeoutMillis = SCROLL_STATE_TIMEOUT_MS) {
+            composeRule.onAllNodesWithText("Item 0")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun waitForCreatorList() {
+        composeRule.waitUntil(timeoutMillis = SCROLL_STATE_TIMEOUT_MS) {
+            composeRule.onAllNodes(verticalLazyListMatcher)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun verticalScrollOffset(): Float {
+        return composeRule.onAllNodes(verticalLazyListMatcher)
+            .fetchSemanticsNodes()
+            .single()
+            .config[VerticalScrollAxisRange]
+            .value()
+    }
+
+    private fun horizontalScrollOffset(): Float {
+        return composeRule.onAllNodes(horizontalLazyListMatcher)
+            .fetchSemanticsNodes()
+            .maxOf { node -> node.config[HorizontalScrollAxisRange].value() }
     }
 }
 
-private data class ScrollPositions(
-    val verticalIndex: Int,
-    val verticalOffset: Int,
-    val horizontalIndex: Int,
-    val horizontalOffset: Int
+private const val FIXTURE_BACK_LABEL = "fixture-back-to-creator"
+private const val SCROLL_STATE_TIMEOUT_MS = 3_000L
+
+private val verticalLazyListMatcher = hasScrollToIndexAction().and(
+    SemanticsMatcher.keyIsDefined(VerticalScrollAxisRange)
+)
+
+private val horizontalLazyListMatcher = hasScrollToIndexAction().and(
+    SemanticsMatcher.keyIsDefined(HorizontalScrollAxisRange)
 )
 
 @Composable
-private fun CreatorDetailNavigationFixture(
-    onShowPlaylistChange: ((Boolean) -> Unit) -> Unit,
-    onScrollVertical: (((Int, Int) -> Unit)) -> Unit,
-    onScrollHorizontal: (((Int, Int) -> Unit)) -> Unit,
-    onReadPositions: (() -> ScrollPositions) -> Unit
-) {
+private fun CreatorDetailNavigationFixture() {
     var playlistVisible by remember { mutableStateOf(false) }
     val creator = remember {
         YouTubeMusicCreatorSummary(
@@ -104,55 +156,23 @@ private fun CreatorDetailNavigationFixture(
     }
     val detail = remember { creatorDetailFixture(creator) }
     val stateHolder = rememberSaveableStateHolder()
-    val scope = rememberCoroutineScope()
-    var horizontalState by remember { mutableStateOf<LazyListState?>(null) }
 
-    androidx.compose.runtime.SideEffect {
-        onShowPlaylistChange { visible -> playlistVisible = visible }
-    }
-    if (playlistVisible) {
-        Box(Modifier.fillMaxSize())
-        return
-    }
-
-    stateHolder.SaveableStateProvider(
-        key = youtubeMusicCreatorDetailStateKey(creator)
-    ) {
-        val verticalState = rememberSaveable(saver = LazyListState.Saver) {
-            LazyListState()
-        }
-        val sectionStateHolder = rememberSaveableStateHolder()
-        androidx.compose.runtime.SideEffect {
-            onScrollVertical { index, offset ->
-                scope.launch { verticalState.scrollToItem(index, offset) }
-            }
-            onReadPositions {
-                ScrollPositions(
-                    verticalIndex = verticalState.firstVisibleItemIndex,
-                    verticalOffset = verticalState.firstVisibleItemScrollOffset,
-                    horizontalIndex = horizontalState?.firstVisibleItemIndex ?: 0,
-                    horizontalOffset = horizontalState?.firstVisibleItemScrollOffset ?: 0
+    MaterialTheme {
+        if (playlistVisible) {
+            Text(
+                text = FIXTURE_BACK_LABEL,
+                modifier = Modifier.clickable { playlistVisible = false }
+            )
+        } else {
+            stateHolder.SaveableStateProvider(
+                key = youtubeMusicCreatorDetailStateKey(creator)
+            ) {
+                YouTubeMusicCreatorDetailScreen(
+                    creator = creator,
+                    onPlaylistClick = { playlistVisible = true },
+                    detailViewModelFactory = CreatorDetailTestViewModelFactory(detail)
                 )
             }
-        }
-        MaterialTheme {
-            YouTubeMusicCreatorDetailScreen(
-                creator = creator,
-                onPlaylistClick = { playlistVisible = true },
-                detailViewModelFactory = CreatorDetailTestViewModelFactory(detail),
-                onSectionListState = { key, state ->
-                    if (key == youtubeMusicCreatorSectionScrollStateKey(
-                            creator.browseId,
-                            detail.sections.first()
-                        )
-                    ) {
-                        horizontalState = state
-                        onScrollHorizontal { index, offset ->
-                            scope.launch { state.scrollToItem(index, offset) }
-                        }
-                    }
-                }
-            )
         }
     }
 }
@@ -166,10 +186,10 @@ private class CreatorDetailTestViewModelFactory(
     ): T {
         val application = extras[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY]
             ?: error("application is required")
-        return modelClass.cast(YouTubeMusicCreatorDetailViewModel(
+        return requireNotNull(modelClass.cast(YouTubeMusicCreatorDetailViewModel(
             application = application,
             loadDetail = { detail }
-        ))
+        )))
     }
 }
 

--- a/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorScrollStateTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorScrollStateTest.kt
@@ -15,6 +15,8 @@ import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.launch
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorDetail
@@ -26,6 +28,7 @@ import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorSummary
 import moe.ouom.neriplayer.testutil.assumeComposeHostAvailable
 import moe.ouom.neriplayer.ui.screen.host.youtubeMusicCreatorDetailStateKey
 import moe.ouom.neriplayer.ui.viewmodel.artist.YouTubeMusicCreatorDetailUiState
+import moe.ouom.neriplayer.ui.viewmodel.artist.YouTubeMusicCreatorDetailViewModel
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -104,7 +107,9 @@ private fun CreatorDetailNavigationFixture(
     val scope = rememberCoroutineScope()
     var horizontalState by remember { mutableStateOf<LazyListState?>(null) }
 
-    onShowPlaylistChange { visible -> playlistVisible = visible }
+    androidx.compose.runtime.SideEffect {
+        onShowPlaylistChange { visible -> playlistVisible = visible }
+    }
     if (playlistVisible) {
         Box(Modifier.fillMaxSize())
         return
@@ -117,35 +122,24 @@ private fun CreatorDetailNavigationFixture(
             LazyListState()
         }
         val sectionStateHolder = rememberSaveableStateHolder()
-        onScrollVertical { index, offset ->
-            scope.launch { verticalState.scrollToItem(index, offset) }
-        }
-        onReadPositions {
-            ScrollPositions(
-                verticalIndex = verticalState.firstVisibleItemIndex,
-                verticalOffset = verticalState.firstVisibleItemScrollOffset,
-                horizontalIndex = horizontalState?.firstVisibleItemIndex ?: 0,
-                horizontalOffset = horizontalState?.firstVisibleItemScrollOffset ?: 0
-            )
+        androidx.compose.runtime.SideEffect {
+            onScrollVertical { index, offset ->
+                scope.launch { verticalState.scrollToItem(index, offset) }
+            }
+            onReadPositions {
+                ScrollPositions(
+                    verticalIndex = verticalState.firstVisibleItemIndex,
+                    verticalOffset = verticalState.firstVisibleItemScrollOffset,
+                    horizontalIndex = horizontalState?.firstVisibleItemIndex ?: 0,
+                    horizontalOffset = horizontalState?.firstVisibleItemScrollOffset ?: 0
+                )
+            }
         }
         MaterialTheme {
-            YouTubeMusicCreatorDetailContent(
-                uiState = YouTubeMusicCreatorDetailUiState(
-                    loading = false,
-                    detail = detail
-                ),
-                listState = verticalState,
-                creatorBrowseId = creator.browseId,
-                sectionStateHolder = sectionStateHolder,
-                miniPlayerHeight = 0.dp,
-                offlineMode = false,
-                onRetry = {},
-                onSongClick = { _, _ -> },
-                onSectionSongClick = { _, _ -> },
-                onPlaylistClick = {},
-                onCreatorClick = {},
-                onSectionMoreClick = { playlistVisible = true },
-                isTabletLayout = false,
+            YouTubeMusicCreatorDetailScreen(
+                creator = creator,
+                onPlaylistClick = { playlistVisible = true },
+                detailViewModelFactory = CreatorDetailTestViewModelFactory(detail),
                 onSectionListState = { key, state ->
                     if (key == youtubeMusicCreatorSectionScrollStateKey(
                             creator.browseId,
@@ -160,6 +154,22 @@ private fun CreatorDetailNavigationFixture(
                 }
             )
         }
+    }
+}
+
+private class CreatorDetailTestViewModelFactory(
+    private val detail: YouTubeMusicCreatorDetail
+) : ViewModelProvider.Factory {
+    override fun <T : androidx.lifecycle.ViewModel> create(
+        modelClass: Class<T>,
+        extras: CreationExtras
+    ): T {
+        val application = extras[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY]
+            ?: error("application is required")
+        return modelClass.cast(YouTubeMusicCreatorDetailViewModel(
+            application = application,
+            loadDetail = { detail }
+        ))
     }
 }
 

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreen.kt
@@ -115,9 +115,10 @@ internal fun preserveYouTubeMusicCreatorName(
 
 internal fun youtubeMusicCreatorSectionScrollStateKey(
     creatorBrowseId: String,
-    section: YouTubeMusicCreatorSection
+    section: YouTubeMusicCreatorSection,
+    sectionIndex: Int
 ): String {
-    return "$creatorBrowseId|${youtubeMusicCreatorSectionKey(section)}"
+    return "$creatorBrowseId|${youtubeMusicCreatorSectionKey(section)}|$sectionIndex"
 }
 
 internal fun youtubeMusicCreatorDetailViewModelKey(creatorBrowseId: String): String {
@@ -134,8 +135,7 @@ fun YouTubeMusicCreatorDetailScreen(
     onCreatorClick: (YouTubeMusicCreatorSummary) -> Unit = {},
     onSectionMoreClick: (YouTubeMusicCreatorSection) -> Unit = {},
     offlineMode: Boolean = false,
-    detailViewModelFactory: androidx.lifecycle.ViewModelProvider.Factory? = null,
-    onSectionListState: ((String, LazyListState) -> Unit)? = null
+    detailViewModelFactory: androidx.lifecycle.ViewModelProvider.Factory? = null
 ) {
     val context = LocalContext.current
     val resolvedViewModelFactory = detailViewModelFactory ?: viewModelFactory {
@@ -203,8 +203,7 @@ fun YouTubeMusicCreatorDetailScreen(
                 },
                 onCreatorClick = onCreatorClick,
                 onSectionMoreClick = onSectionMoreClick,
-                isTabletLayout = isTabletLayout,
-                onSectionListState = onSectionListState
+                isTabletLayout = isTabletLayout
             )
         }
     }
@@ -224,8 +223,7 @@ internal fun YouTubeMusicCreatorDetailContent(
     onPlaylistClick: (YouTubeMusicPlaylist) -> Unit,
     onCreatorClick: (YouTubeMusicCreatorSummary) -> Unit,
     onSectionMoreClick: (YouTubeMusicCreatorSection) -> Unit,
-    isTabletLayout: Boolean,
-    onSectionListState: ((String, LazyListState) -> Unit)? = null
+    isTabletLayout: Boolean
 ) {
     val detail = uiState.detail
     Box(
@@ -323,10 +321,11 @@ internal fun YouTubeMusicCreatorDetailContent(
                     itemsIndexed(
                         items = detail.sections,
                         key = { index, section -> "creator-section-$index-${section.title}" }
-                    ) { _, section ->
+                    ) { sectionIndex, section ->
                         YouTubeMusicCreatorSection(
                             section = section,
                             creatorBrowseId = creatorBrowseId,
+                            sectionIndex = sectionIndex,
                             stateHolder = sectionStateHolder,
                             offlineMode = offlineMode,
                             isPlaybackQueueLoading =
@@ -340,8 +339,7 @@ internal fun YouTubeMusicCreatorDetailContent(
                             onSectionSongClick = onSectionSongClick,
                             onPlaylistClick = onPlaylistClick,
                             onCreatorClick = onCreatorClick,
-                            onSectionMoreClick = onSectionMoreClick,
-                            onSectionListState = onSectionListState
+                            onSectionMoreClick = onSectionMoreClick
                         )
                     }
                 }
@@ -504,6 +502,7 @@ private fun YouTubeMusicCreatorHeader(
 private fun YouTubeMusicCreatorSection(
     section: YouTubeMusicCreatorSection,
     creatorBrowseId: String,
+    sectionIndex: Int,
     stateHolder: SaveableStateHolder,
     offlineMode: Boolean,
     isPlaybackQueueLoading: Boolean,
@@ -512,8 +511,7 @@ private fun YouTubeMusicCreatorSection(
     onSectionSongClick: (YouTubeMusicCreatorSection, YouTubeMusicCreatorItem) -> Unit,
     onPlaylistClick: (YouTubeMusicPlaylist) -> Unit,
     onCreatorClick: (YouTubeMusicCreatorSummary) -> Unit,
-    onSectionMoreClick: (YouTubeMusicCreatorSection) -> Unit,
-    onSectionListState: ((String, LazyListState) -> Unit)?
+    onSectionMoreClick: (YouTubeMusicCreatorSection) -> Unit
 ) {
     val playableItems = section.items.mapNotNull { item ->
         item.toCreatorSongItem()?.let { item to it }
@@ -581,16 +579,14 @@ private fun YouTubeMusicCreatorSection(
             }
         } else {
             stateHolder.SaveableStateProvider(
-                key = youtubeMusicCreatorSectionScrollStateKey(creatorBrowseId, section)
+                key = youtubeMusicCreatorSectionScrollStateKey(
+                    creatorBrowseId = creatorBrowseId,
+                    section = section,
+                    sectionIndex = sectionIndex
+                )
             ) {
                 val listState = rememberSaveable(saver = LazyListState.Saver) {
                     LazyListState(firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 0)
-                }
-                androidx.compose.runtime.SideEffect {
-                    onSectionListState?.invoke(
-                        youtubeMusicCreatorSectionScrollStateKey(creatorBrowseId, section),
-                        listState
-                    )
                 }
                 LazyRow(
                     state = listState,

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreen.kt
@@ -68,7 +68,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import coil.compose.AsyncImage
-import kotlinx.coroutines.flow.collect
 import moe.ouom.neriplayer.R
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorDetail
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorItem
@@ -76,8 +75,8 @@ import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorItemType
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorSection
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorSummary
 import moe.ouom.neriplayer.data.model.SongItem
-import moe.ouom.neriplayer.ui.LocalMiniPlayerHeight
 import moe.ouom.neriplayer.ui.BlurTransformation
+import moe.ouom.neriplayer.ui.LocalMiniPlayerHeight
 import moe.ouom.neriplayer.ui.haptic.HapticIconButton
 import moe.ouom.neriplayer.ui.haptic.HapticTextButton
 import moe.ouom.neriplayer.ui.haptic.performHapticFeedback
@@ -121,6 +120,10 @@ internal fun youtubeMusicCreatorSectionScrollStateKey(
     return "$creatorBrowseId|${youtubeMusicCreatorSectionKey(section)}"
 }
 
+internal fun youtubeMusicCreatorDetailViewModelKey(creatorBrowseId: String): String {
+    return "youtube_music_creator_detail_view_model_$creatorBrowseId"
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun YouTubeMusicCreatorDetailScreen(
@@ -134,6 +137,7 @@ fun YouTubeMusicCreatorDetailScreen(
 ) {
     val context = LocalContext.current
     val viewModel: YouTubeMusicCreatorDetailViewModel = viewModel(
+        key = youtubeMusicCreatorDetailViewModelKey(creator.browseId),
         factory = viewModelFactory {
             initializer {
                 YouTubeMusicCreatorDetailViewModel(context.applicationContext as Application)
@@ -203,7 +207,7 @@ fun YouTubeMusicCreatorDetailScreen(
 }
 
 @Composable
-private fun YouTubeMusicCreatorDetailContent(
+internal fun YouTubeMusicCreatorDetailContent(
     uiState: YouTubeMusicCreatorDetailUiState,
     listState: LazyListState,
     creatorBrowseId: String,
@@ -216,7 +220,8 @@ private fun YouTubeMusicCreatorDetailContent(
     onPlaylistClick: (YouTubeMusicPlaylist) -> Unit,
     onCreatorClick: (YouTubeMusicCreatorSummary) -> Unit,
     onSectionMoreClick: (YouTubeMusicCreatorSection) -> Unit,
-    isTabletLayout: Boolean
+    isTabletLayout: Boolean,
+    onSectionListState: ((String, LazyListState) -> Unit)? = null
 ) {
     val detail = uiState.detail
     Box(
@@ -331,7 +336,8 @@ private fun YouTubeMusicCreatorDetailContent(
                             onSectionSongClick = onSectionSongClick,
                             onPlaylistClick = onPlaylistClick,
                             onCreatorClick = onCreatorClick,
-                            onSectionMoreClick = onSectionMoreClick
+                            onSectionMoreClick = onSectionMoreClick,
+                            onSectionListState = onSectionListState
                         )
                     }
                 }
@@ -502,7 +508,8 @@ private fun YouTubeMusicCreatorSection(
     onSectionSongClick: (YouTubeMusicCreatorSection, YouTubeMusicCreatorItem) -> Unit,
     onPlaylistClick: (YouTubeMusicPlaylist) -> Unit,
     onCreatorClick: (YouTubeMusicCreatorSummary) -> Unit,
-    onSectionMoreClick: (YouTubeMusicCreatorSection) -> Unit
+    onSectionMoreClick: (YouTubeMusicCreatorSection) -> Unit,
+    onSectionListState: ((String, LazyListState) -> Unit)?
 ) {
     val playableItems = section.items.mapNotNull { item ->
         item.toCreatorSongItem()?.let { item to it }
@@ -574,6 +581,12 @@ private fun YouTubeMusicCreatorSection(
             ) {
                 val listState = rememberSaveable(saver = LazyListState.Saver) {
                     LazyListState(firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 0)
+                }
+                androidx.compose.runtime.SideEffect {
+                    onSectionListState?.invoke(
+                        youtubeMusicCreatorSectionScrollStateKey(creatorBrowseId, section),
+                        listState
+                    )
                 }
                 LazyRow(
                     state = listState,

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
@@ -50,6 +51,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.SaveableStateHolder
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -110,6 +114,13 @@ internal fun preserveYouTubeMusicCreatorName(
     )
 }
 
+internal fun youtubeMusicCreatorSectionScrollStateKey(
+    creatorBrowseId: String,
+    section: YouTubeMusicCreatorSection
+): String {
+    return "$creatorBrowseId|${youtubeMusicCreatorSectionKey(section)}"
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun YouTubeMusicCreatorDetailScreen(
@@ -132,6 +143,10 @@ fun YouTubeMusicCreatorDetailScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val miniPlayerHeight = LocalMiniPlayerHeight.current
     val isTabletLayout = currentWindowWidthDp() >= 720.dp
+    val listState = rememberSaveable(creator.browseId, saver = LazyListState.Saver) {
+        LazyListState(firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 0)
+    }
+    val sectionStateHolder = rememberSaveableStateHolder()
 
     LaunchedEffect(creator.browseId) {
         viewModel.start(creator)
@@ -168,6 +183,9 @@ fun YouTubeMusicCreatorDetailScreen(
             )
             YouTubeMusicCreatorDetailContent(
                 uiState = uiState,
+                listState = listState,
+                creatorBrowseId = creator.browseId,
+                sectionStateHolder = sectionStateHolder,
                 miniPlayerHeight = miniPlayerHeight,
                 offlineMode = offlineMode,
                 onRetry = viewModel::retry,
@@ -187,6 +205,9 @@ fun YouTubeMusicCreatorDetailScreen(
 @Composable
 private fun YouTubeMusicCreatorDetailContent(
     uiState: YouTubeMusicCreatorDetailUiState,
+    listState: LazyListState,
+    creatorBrowseId: String,
+    sectionStateHolder: SaveableStateHolder,
     miniPlayerHeight: androidx.compose.ui.unit.Dp,
     offlineMode: Boolean,
     onRetry: () -> Unit,
@@ -238,6 +259,7 @@ private fun YouTubeMusicCreatorDetailContent(
             }
             else -> {
                 LazyColumn(
+                    state = listState,
                     modifier = Modifier
                         .widthIn(max = 1080.dp)
                         .fillMaxSize(),
@@ -295,6 +317,8 @@ private fun YouTubeMusicCreatorDetailContent(
                     ) { _, section ->
                         YouTubeMusicCreatorSection(
                             section = section,
+                            creatorBrowseId = creatorBrowseId,
+                            stateHolder = sectionStateHolder,
                             offlineMode = offlineMode,
                             isPlaybackQueueLoading =
                                 uiState.playbackQueueLoadingSectionKey ==
@@ -469,6 +493,8 @@ private fun YouTubeMusicCreatorHeader(
 @Composable
 private fun YouTubeMusicCreatorSection(
     section: YouTubeMusicCreatorSection,
+    creatorBrowseId: String,
+    stateHolder: SaveableStateHolder,
     offlineMode: Boolean,
     isPlaybackQueueLoading: Boolean,
     playbackQueueError: String?,
@@ -543,21 +569,29 @@ private fun YouTubeMusicCreatorSection(
                 )
             }
         } else {
-            LazyRow(
-                contentPadding = PaddingValues(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            stateHolder.SaveableStateProvider(
+                key = youtubeMusicCreatorSectionScrollStateKey(creatorBrowseId, section)
             ) {
-                itemsIndexed(
-                    items = section.items,
-                    key = { index, item -> "${item.type}-${item.browseId}-${item.videoId}-$index" }
-                ) { _, item ->
-                    CreatorSectionCard(
-                        item = item,
-                        offlineMode = offlineMode,
-                        onSongClick = onSongClick,
-                        onPlaylistClick = onPlaylistClick,
-                        onCreatorClick = onCreatorClick
-                    )
+                val listState = rememberSaveable(saver = LazyListState.Saver) {
+                    LazyListState(firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 0)
+                }
+                LazyRow(
+                    state = listState,
+                    contentPadding = PaddingValues(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    itemsIndexed(
+                        items = section.items,
+                        key = { index, item -> "${item.type}-${item.browseId}-${item.videoId}-$index" }
+                    ) { _, item ->
+                        CreatorSectionCard(
+                            item = item,
+                            offlineMode = offlineMode,
+                            onSongClick = onSongClick,
+                            onPlaylistClick = onPlaylistClick,
+                            onCreatorClick = onCreatorClick
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreen.kt
@@ -133,16 +133,19 @@ fun YouTubeMusicCreatorDetailScreen(
     onPlaylistClick: (YouTubeMusicPlaylist) -> Unit = {},
     onCreatorClick: (YouTubeMusicCreatorSummary) -> Unit = {},
     onSectionMoreClick: (YouTubeMusicCreatorSection) -> Unit = {},
-    offlineMode: Boolean = false
+    offlineMode: Boolean = false,
+    detailViewModelFactory: androidx.lifecycle.ViewModelProvider.Factory? = null,
+    onSectionListState: ((String, LazyListState) -> Unit)? = null
 ) {
     val context = LocalContext.current
+    val resolvedViewModelFactory = detailViewModelFactory ?: viewModelFactory {
+        initializer {
+            YouTubeMusicCreatorDetailViewModel(context.applicationContext as Application)
+        }
+    }
     val viewModel: YouTubeMusicCreatorDetailViewModel = viewModel(
         key = youtubeMusicCreatorDetailViewModelKey(creator.browseId),
-        factory = viewModelFactory {
-            initializer {
-                YouTubeMusicCreatorDetailViewModel(context.applicationContext as Application)
-            }
-        }
+        factory = resolvedViewModelFactory
     )
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val miniPlayerHeight = LocalMiniPlayerHeight.current
@@ -200,7 +203,8 @@ fun YouTubeMusicCreatorDetailScreen(
                 },
                 onCreatorClick = onCreatorClick,
                 onSectionMoreClick = onSectionMoreClick,
-                isTabletLayout = isTabletLayout
+                isTabletLayout = isTabletLayout,
+                onSectionListState = onSectionListState
             )
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorNavigationScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorNavigationScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorSection
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorSummary
@@ -23,6 +24,7 @@ fun YouTubeMusicCreatorNavigationScreen(
     var selectedSection by remember(creator.browseId) {
         mutableStateOf<YouTubeMusicCreatorSection?>(null)
     }
+    val stateHolder = rememberSaveableStateHolder()
     BackHandler(enabled = selectedSection != null) {
         selectedSection = null
     }
@@ -37,14 +39,16 @@ fun YouTubeMusicCreatorNavigationScreen(
             offlineMode = offlineMode
         )
     } else {
-        YouTubeMusicCreatorDetailScreen(
-            creator = creator,
-            onBack = onBack,
-            onSongClick = onSongClick,
-            onPlaylistClick = onPlaylistClick,
-            onCreatorClick = onCreatorClick,
-            onSectionMoreClick = { selectedSection = it },
-            offlineMode = offlineMode
-        )
+        stateHolder.SaveableStateProvider("creator_detail") {
+            YouTubeMusicCreatorDetailScreen(
+                creator = creator,
+                onBack = onBack,
+                onSongClick = onSongClick,
+                onPlaylistClick = onPlaylistClick,
+                onCreatorClick = onCreatorClick,
+                onSectionMoreClick = { selectedSection = it },
+                offlineMode = offlineMode
+            )
+        }
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/host/ExploreHostScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/host/ExploreHostScreen.kt
@@ -28,8 +28,8 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.SizeTransform
-import androidx.compose.animation.togetherWith
 import androidx.compose.animation.core.updateTransition
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyListState
@@ -47,6 +47,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -55,12 +56,19 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import moe.ouom.neriplayer.core.api.bili.BiliClient
+import moe.ouom.neriplayer.core.api.bili.buildBiliSongAlbum
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorSection
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorSummary
 import moe.ouom.neriplayer.core.di.AppContainer
-import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.data.model.NeteaseArtistSummary
+import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.data.platform.youtube.stableYouTubeMusicId
+import moe.ouom.neriplayer.ui.animateMainTabDetailCloseRootRevealFraction
+import moe.ouom.neriplayer.ui.clipMainTabDetailCloseRoot
+import moe.ouom.neriplayer.ui.effect.glass.AdvancedGlassSceneMotion
+import moe.ouom.neriplayer.ui.effect.glass.advancedGlassHostNavigationTransition
+import moe.ouom.neriplayer.ui.effect.glass.animateAdvancedGlassSceneMotion
+import moe.ouom.neriplayer.ui.rememberMainTabSceneRestoredEntry
 import moe.ouom.neriplayer.ui.screen.artist.NeteaseArtistDetailScreen
 import moe.ouom.neriplayer.ui.screen.artist.YouTubeMusicCreatorDetailScreen
 import moe.ouom.neriplayer.ui.screen.artist.YouTubeMusicCreatorItemsScreen
@@ -69,20 +77,12 @@ import moe.ouom.neriplayer.ui.screen.playlist.NeteaseAlbumDetailScreen
 import moe.ouom.neriplayer.ui.screen.playlist.NeteasePlaylistDetailScreen
 import moe.ouom.neriplayer.ui.screen.playlist.YouTubeMusicPlaylistDetailScreen
 import moe.ouom.neriplayer.ui.screen.tab.ExploreScreen
-import moe.ouom.neriplayer.ui.effect.glass.AdvancedGlassSceneMotion
-import moe.ouom.neriplayer.ui.effect.glass.advancedGlassHostNavigationTransition
-import moe.ouom.neriplayer.ui.effect.glass.animateAdvancedGlassSceneMotion
-import moe.ouom.neriplayer.ui.animateMainTabDetailCloseRootRevealFraction
-import moe.ouom.neriplayer.ui.clipMainTabDetailCloseRoot
-import moe.ouom.neriplayer.ui.rememberMainTabSceneRestoredEntry
 import moe.ouom.neriplayer.ui.shouldSuppressRestoredMainTabHostEntry
 import moe.ouom.neriplayer.ui.viewmodel.playlist.BiliVideoItem
-import moe.ouom.neriplayer.core.api.bili.buildBiliSongAlbum
 import moe.ouom.neriplayer.ui.viewmodel.tab.AlbumSummary
 import moe.ouom.neriplayer.ui.viewmodel.tab.BiliPlaylist
 import moe.ouom.neriplayer.ui.viewmodel.tab.PlaylistSummary
 import moe.ouom.neriplayer.ui.viewmodel.tab.YouTubeMusicPlaylist
-import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.util.media.CoverArtColorCache
 
 // 探索页选中项
@@ -106,6 +106,12 @@ internal sealed class ExploreSelectedItem {
         val creator: YouTubeMusicCreatorSummary,
         val section: YouTubeMusicCreatorSection
     ) : ExploreSelectedItem()
+}
+
+internal fun youtubeMusicCreatorDetailStateKey(
+    creator: YouTubeMusicCreatorSummary
+): String {
+    return "youtube_music_creator_detail_${creator.browseId}"
 }
 
 private val ExploreSelectedItem?.navigationDepth: Int
@@ -237,6 +243,7 @@ fun ExploreHostScreen(
     val searchListState = rememberSaveable(saver = searchListStateSaver) {
         LazyListState(firstVisibleItemIndex = 0, firstVisibleItemScrollOffset = 0)
     }
+    val detailStateHolder = rememberSaveableStateHolder()
     val topAppBarState = rememberTopAppBarState()
     var searchQuery by rememberSaveable { mutableStateOf("") }
     var searchScrollContextKey by rememberSaveable { mutableStateOf<String?>(null) }
@@ -476,40 +483,44 @@ fun ExploreHostScreen(
                             }
 
                             is ExploreSelectedItem.YouTubeMusicCreator -> {
-                                YouTubeMusicCreatorDetailScreen(
-                                    creator = current.creator,
-                                    onBack = ::closeSelectedDetail,
-                                    onSongClick = onSongClick,
-                                    onPlaylistClick = { playlist ->
-                                        openExploreSelectedItem(
-                                            ExploreSelectedItem.YouTubeMusic(
-                                                playlist = playlist.copy(
-                                                    creatorName = playlist.creatorName.ifBlank {
-                                                        current.creator.title
-                                                    }
-                                                ),
-                                                parentCreator = current.creator
+                                detailStateHolder.SaveableStateProvider(
+                                    key = youtubeMusicCreatorDetailStateKey(current.creator)
+                                ) {
+                                    YouTubeMusicCreatorDetailScreen(
+                                        creator = current.creator,
+                                        onBack = ::closeSelectedDetail,
+                                        onSongClick = onSongClick,
+                                        onPlaylistClick = { playlist ->
+                                            openExploreSelectedItem(
+                                                ExploreSelectedItem.YouTubeMusic(
+                                                    playlist = playlist.copy(
+                                                        creatorName = playlist.creatorName.ifBlank {
+                                                            current.creator.title
+                                                        }
+                                                    ),
+                                                    parentCreator = current.creator
+                                                )
                                             )
-                                        )
-                                    },
-                                    onCreatorClick = { creator ->
-                                        openExploreSelectedItem(
-                                            ExploreSelectedItem.YouTubeMusicCreator(
-                                                creator = creator,
-                                                parentCreator = current.creator
+                                        },
+                                        onCreatorClick = { creator ->
+                                            openExploreSelectedItem(
+                                                ExploreSelectedItem.YouTubeMusicCreator(
+                                                    creator = creator,
+                                                    parentCreator = current.creator
+                                                )
                                             )
-                                        )
-                                    },
-                                    onSectionMoreClick = { section ->
-                                        openExploreSelectedItem(
-                                            ExploreSelectedItem.YouTubeMusicCreatorItems(
-                                                creator = current.creator,
-                                                section = section
+                                        },
+                                        onSectionMoreClick = { section ->
+                                            openExploreSelectedItem(
+                                                ExploreSelectedItem.YouTubeMusicCreatorItems(
+                                                    creator = current.creator,
+                                                    section = section
+                                                )
                                             )
-                                        )
-                                    },
-                                    offlineMode = offlineMode
-                                )
+                                        },
+                                        offlineMode = offlineMode
+                                    )
+                                }
                             }
 
                             is ExploreSelectedItem.YouTubeMusicCreatorItems -> {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/artist/YouTubeMusicCreatorDetailViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/artist/YouTubeMusicCreatorDetailViewModel.kt
@@ -35,8 +35,13 @@ data class YouTubeMusicCreatorDetailUiState(
     val playbackQueueError: String? = null
 )
 
-class YouTubeMusicCreatorDetailViewModel(application: Application) : AndroidViewModel(application) {
-    private val client = AppContainer.youtubeMusicClient
+class YouTubeMusicCreatorDetailViewModel(
+    application: Application,
+    private val loadDetail: suspend (YouTubeMusicCreatorSummary) -> YouTubeMusicCreatorDetail = {
+        creator -> AppContainer.youtubeMusicClient.getCreatorDetail(creator)
+    }
+) : AndroidViewModel(application) {
+    private val client by lazy { AppContainer.youtubeMusicClient }
     private val _uiState = MutableStateFlow(YouTubeMusicCreatorDetailUiState())
     val uiState: StateFlow<YouTubeMusicCreatorDetailUiState> = _uiState
     private val _playbackRequests = MutableSharedFlow<YouTubeMusicCreatorPlaybackQueue>()
@@ -67,7 +72,7 @@ class YouTubeMusicCreatorDetailViewModel(application: Application) : AndroidView
         loadJob = viewModelScope.launch {
             try {
                 val detail = withContext(Dispatchers.IO) {
-                    AppContainer.youtubeMusicClient.getCreatorDetail(creator)
+                    loadDetail(creator)
                 }
                 if (currentCreator?.browseId != creator.browseId) {
                     return@launch

--- a/app/src/test/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreenTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreenTest.kt
@@ -30,6 +30,18 @@ class YouTubeMusicCreatorDetailScreenTest {
     }
 
     @Test
+    fun creatorDetailViewModelKeys_areStableAndIsolatedByCreator() {
+        assertEquals(
+            youtubeMusicCreatorDetailViewModelKey("UCdemoCreator"),
+            youtubeMusicCreatorDetailViewModelKey("UCdemoCreator")
+        )
+        assertTrue(
+            youtubeMusicCreatorDetailViewModelKey("UCparent") !=
+                youtubeMusicCreatorDetailViewModelKey("UCchild")
+        )
+    }
+
+    @Test
     fun sectionMore_isShownForPlayableTopSongs() {
         val section = YouTubeMusicCreatorSection(
             title = "TOP SONGS",

--- a/app/src/test/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreenTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreenTest.kt
@@ -13,6 +13,23 @@ import org.junit.Test
 class YouTubeMusicCreatorDetailScreenTest {
 
     @Test
+    fun creatorDetailStateKeys_areScopedToCreatorAndSection() {
+        val section = YouTubeMusicCreatorSection(
+            title = "Albums",
+            items = emptyList(),
+            moreEndpoint = YouTubeMusicCreatorBrowseEndpoint(
+                browseId = "UCdemoCreator",
+                params = "albums"
+            )
+        )
+
+        assertEquals(
+            "UCdemoCreator|UCdemoCreator|albums|Albums",
+            youtubeMusicCreatorSectionScrollStateKey("UCdemoCreator", section)
+        )
+    }
+
+    @Test
     fun sectionMore_isShownForPlayableTopSongs() {
         val section = YouTubeMusicCreatorSection(
             title = "TOP SONGS",

--- a/app/src/test/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreenTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/screen/artist/YouTubeMusicCreatorDetailScreenTest.kt
@@ -7,6 +7,7 @@ import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicCreatorSection
 import moe.ouom.neriplayer.ui.viewmodel.tab.YouTubeMusicPlaylist
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -24,8 +25,24 @@ class YouTubeMusicCreatorDetailScreenTest {
         )
 
         assertEquals(
-            "UCdemoCreator|UCdemoCreator|albums|Albums",
-            youtubeMusicCreatorSectionScrollStateKey("UCdemoCreator", section)
+            "UCdemoCreator|UCdemoCreator|albums|Albums|0",
+            youtubeMusicCreatorSectionScrollStateKey(
+                creatorBrowseId = "UCdemoCreator",
+                section = section,
+                sectionIndex = 0
+            )
+        )
+        assertNotEquals(
+            youtubeMusicCreatorSectionScrollStateKey(
+                creatorBrowseId = "UCdemoCreator",
+                section = section,
+                sectionIndex = 0
+            ),
+            youtubeMusicCreatorSectionScrollStateKey(
+                creatorBrowseId = "UCdemoCreator",
+                section = section,
+                sectionIndex = 1
+            )
         )
     }
 

--- a/app/src/test/java/moe/ouom/neriplayer/ui/screen/host/ExploreHostScreenTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/screen/host/ExploreHostScreenTest.kt
@@ -8,6 +8,21 @@ import org.junit.Test
 class ExploreHostScreenTest {
 
     @Test
+    fun `creator detail state key is scoped to creator browse id`() {
+        val creator = YouTubeMusicCreatorSummary(
+            browseId = "UCdemoCreator",
+            title = "Demo Creator",
+            subtitle = "Artist",
+            coverUrl = ""
+        )
+
+        assertEquals(
+            "youtube_music_creator_detail_UCdemoCreator",
+            youtubeMusicCreatorDetailStateKey(creator)
+        )
+    }
+
+    @Test
     fun `creator album back returns to the creator page`() {
         val creator = YouTubeMusicCreatorSummary(
             browseId = "UCdemoCreator",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 用户可见变化

- YouTube Music 创作者详情页会保存并恢复纵向滚动位置。
- 每个内容分区会独立保存并恢复横向滚动位置。
- 滚动状态按创作者和分区隔离。

## 兼容性影响

- 创作者详情页支持重组和状态恢复。
- 现有导航逻辑保持不变。

## 测试

- 新增单元测试，验证创作者和分区状态键的稳定性与隔离性。
- 新增 Android Compose 测试，验证播放列表显示状态切换后，纵向和横向滚动位置均可恢复。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->