### PR TITLE
feat: implement cached playback descriptors for metadata validation and improve offline cache stall recovery

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -198,6 +198,7 @@ import moe.ouom.neriplayer.core.player.timer.SleepTimerManager
 import moe.ouom.neriplayer.core.player.timer.SleepTimerMode
 import moe.ouom.neriplayer.core.player.url.YOUTUBE_PLAYBACK_PREFER_M4A
 import moe.ouom.neriplayer.core.player.url.refreshCurrentSongUrlImpl
+import moe.ouom.neriplayer.core.player.url.safeCustomPlaybackCacheKey
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathState
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathTracker
 import moe.ouom.neriplayer.core.player.usb.session.UsbExclusiveSessionController
@@ -2340,7 +2341,8 @@ object PlayerManager {
         song: SongItem,
         url: String,
         cacheKey: String,
-        mimeType: String? = null
+        mimeType: String? = null,
+        allowCustomCacheKey: Boolean = true
     ): MediaItem {
         val isLocalFile =
             url.startsWith("file://") ||
@@ -2355,8 +2357,8 @@ object PlayerManager {
                     setMimeType(mimeType)
                 }
                 // Local files do not need a custom cache key.
-                if (!isLocalFile) {
-                    setCustomCacheKey(cacheKey)
+                if (!isLocalFile && allowCustomCacheKey) {
+                    safeCustomPlaybackCacheKey(cacheKey)?.let(::setCustomCacheKey)
                 }
             }
             .build()

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/model/SongUrlResult.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/model/SongUrlResult.kt
@@ -29,6 +29,7 @@ internal data class PlaybackUrlCandidate(
     val mimeType: String? = null,
     val expectedContentLength: Long? = null,
     val audioInfo: PlaybackAudioInfo? = null,
+    val representationIdentity: String? = null,
     val cacheKeyOverride: String? = null
 ) {
     fun playbackUrls(): List<String> = buildList {
@@ -48,6 +49,7 @@ internal sealed class SongUrlResult {
         val noticeMessage: String? = null,
         val expectedContentLength: Long? = null,
         val audioInfo: PlaybackAudioInfo? = null,
+        val representationIdentity: String? = null,
         val cacheKeyOverride: String? = null,
         val isNeteaseLocalFallback: Boolean = false,
         val fallbackCandidates: List<PlaybackUrlCandidate> = emptyList()
@@ -66,6 +68,7 @@ internal sealed class SongUrlResult {
                     mimeType = mimeType,
                     expectedContentLength = expectedContentLength,
                     audioInfo = audioInfo,
+                    representationIdentity = representationIdentity,
                     cacheKeyOverride = cacheKeyOverride
                 )
             }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/playback/PlayerManagerPlaybackExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/playback/PlayerManagerPlaybackExtensions.kt
@@ -66,6 +66,8 @@ import moe.ouom.neriplayer.core.player.resolver.youtube.YouTubeSeekRefreshPolicy
 import moe.ouom.neriplayer.core.player.service.AudioPlayerService
 import moe.ouom.neriplayer.core.player.url.cancelUrlRefreshIfNotReusableForPendingLoad
 import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedResource
+import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedPlaybackDescriptor
+import moe.ouom.neriplayer.core.player.url.persistCachedPlaybackDescriptor
 import moe.ouom.neriplayer.core.player.url.resolveSongUrl
 import moe.ouom.neriplayer.core.player.url.resolveSongUrlOrWaitForAuthoritativeStream
 import moe.ouom.neriplayer.core.player.url.youtubePlaybackRecoveryStrategyForSeek
@@ -878,23 +880,41 @@ internal fun PlayerManager.playAtIndex(
                     )
                     val selectedCandidate = currentPlaybackCandidate()
                     val selectedUrl = selectedCandidate?.url ?: result.url
+                    val selectedAudioInfo = selectedCandidate?.audioInfo ?: result.audioInfo
+                    val selectedMimeType = selectedCandidate?.mimeType ?: result.mimeType
+                    val selectedExpectedContentLength =
+                        selectedCandidate?.expectedContentLength ?: result.expectedContentLength
+                    val selectedRepresentationIdentity =
+                        selectedCandidate?.representationIdentity ?: result.representationIdentity
                     NPLogger.d(
                         "NERI-PlayerManager",
                         "Using custom cache key: $cacheKey for song: ${song.name}"
                     )
                     invalidateMismatchedCachedResource(
                         cacheKey = cacheKey,
-                        expectedContentLength = result.expectedContentLength
+                        expectedContentLength = selectedExpectedContentLength
+                    )
+                    invalidateMismatchedCachedPlaybackDescriptor(
+                        cacheKey = cacheKey,
+                        audioInfo = selectedAudioInfo,
+                        expectedContentLength = selectedExpectedContentLength,
+                        representationIdentity = selectedRepresentationIdentity
+                    )
+                    persistCachedPlaybackDescriptor(
+                        cacheKey = cacheKey,
+                        audioInfo = selectedAudioInfo,
+                        expectedContentLength = selectedExpectedContentLength,
+                        representationIdentity = selectedRepresentationIdentity
                     )
                     val mediaItem = buildMediaItem(
                         _currentSongFlow.value ?: song,
                         selectedUrl,
                         cacheKey,
-                        result.mimeType
+                        selectedMimeType
                     )
                     syncLyriconSong(_currentSongFlow.value ?: song)
                     _currentMediaUrl.value = selectedUrl
-                    _currentPlaybackAudioInfo.value = result.audioInfo
+                    _currentPlaybackAudioInfo.value = selectedAudioInfo
                     updateAudioOffloadPreferences("resolved_stream_source")
                     currentMediaUrlResolvedAtMs = SystemClock.elapsedRealtime()
                     scheduleStatePersist(

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/playback/PlayerManagerPlaybackExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/playback/PlayerManagerPlaybackExtensions.kt
@@ -65,11 +65,10 @@ import moe.ouom.neriplayer.core.player.prefetch.replacePlaybackDemandCacheKey
 import moe.ouom.neriplayer.core.player.resolver.youtube.YouTubeSeekRefreshPolicy
 import moe.ouom.neriplayer.core.player.service.AudioPlayerService
 import moe.ouom.neriplayer.core.player.url.cancelUrlRefreshIfNotReusableForPendingLoad
-import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedResource
-import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedPlaybackDescriptor
-import moe.ouom.neriplayer.core.player.url.persistCachedPlaybackDescriptor
+import moe.ouom.neriplayer.core.player.url.allowsCustomCacheKey
 import moe.ouom.neriplayer.core.player.url.resolveSongUrl
 import moe.ouom.neriplayer.core.player.url.resolveSongUrlOrWaitForAuthoritativeStream
+import moe.ouom.neriplayer.core.player.url.synchronizeCachedPlaybackDescriptor
 import moe.ouom.neriplayer.core.player.url.youtubePlaybackRecoveryStrategyForSeek
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathState
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathTracker
@@ -820,7 +819,10 @@ internal fun PlayerManager.playAtIndex(
         ) {
             resolveSongUrl(
                 song = song,
-                playbackRequestTokenOverride = requestToken
+                playbackRequestTokenOverride = requestToken,
+                shouldApplyCacheMutation = {
+                    shouldApplyResolvedMedia(requestToken, playbackRequestToken) && isActive
+                }
             )
         }
         if (!shouldApplyResolvedMedia(requestToken, playbackRequestToken) || !isActive) {
@@ -890,27 +892,33 @@ internal fun PlayerManager.playAtIndex(
                         "NERI-PlayerManager",
                         "Using custom cache key: $cacheKey for song: ${song.name}"
                     )
-                    invalidateMismatchedCachedResource(
-                        cacheKey = cacheKey,
-                        expectedContentLength = selectedExpectedContentLength
-                    )
-                    invalidateMismatchedCachedPlaybackDescriptor(
+                    val cacheSynchronization = synchronizeCachedPlaybackDescriptor(
                         cacheKey = cacheKey,
                         audioInfo = selectedAudioInfo,
                         expectedContentLength = selectedExpectedContentLength,
-                        representationIdentity = selectedRepresentationIdentity
+                        representationIdentity = selectedRepresentationIdentity,
+                        shouldApplyMutation = {
+                            shouldApplyResolvedMediaSideEffects(
+                                requestGeneration = requestToken,
+                                currentRequestGeneration = playbackRequestToken,
+                                requestActive = true
+                            )
+                        }
                     )
-                    persistCachedPlaybackDescriptor(
-                        cacheKey = cacheKey,
-                        audioInfo = selectedAudioInfo,
-                        expectedContentLength = selectedExpectedContentLength,
-                        representationIdentity = selectedRepresentationIdentity
-                    )
+                    if (!shouldApplyResolvedMediaSideEffects(
+                            requestGeneration = requestToken,
+                            currentRequestGeneration = playbackRequestToken,
+                            requestActive = isActive
+                        )
+                    ) {
+                        return@withContext
+                    }
                     val mediaItem = buildMediaItem(
                         _currentSongFlow.value ?: song,
                         selectedUrl,
                         cacheKey,
-                        selectedMimeType
+                        selectedMimeType,
+                        allowCustomCacheKey = cacheSynchronization.allowsCustomCacheKey()
                     )
                     syncLyriconSong(_currentSongFlow.value ?: song)
                     _currentMediaUrl.value = selectedUrl

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/PlayerManagerGenericUrlPrefetch.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/PlayerManagerGenericUrlPrefetch.kt
@@ -62,7 +62,8 @@ internal fun PlayerManager.prefetchNextGenericTrackUrl() {
             val result = resolveSongUrl(
                 song = nextSong,
                 allowGenericPrefetchCache = false,
-                sideEffects = RefreshResolverSideEffects(RefreshSideEffectGate { false })
+                sideEffects = RefreshResolverSideEffects(RefreshSideEffectGate { false }),
+                shouldApplyCacheMutation = { false }
             )
             // 本地兜底命中的受限歌曲同样值得预取, 否则消费方会白等一个不落盘的任务
             if (result is SongUrlResult.Success &&

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/PlayerManagerYouTubePrefetchExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/PlayerManagerYouTubePrefetchExtensions.kt
@@ -335,6 +335,14 @@ private suspend fun PlayerManager.prefetchYouTubePlayableAudio(spec: YouTubePref
             preferM4a = false,
             isPrefetch = true
         ) ?: return
+        if (playableAudio.streamType != YouTubePlayableStreamType.DIRECT) {
+            NPLogger.d(
+                "NERI-PlayerManager",
+                "skip media prefetch for non-direct YouTube stream: " +
+                    "videoId=${spec.videoId}, type=${playableAudio.streamType}, source=${spec.source}"
+            )
+            return
+        }
         val playbackAudioInfo = buildYouTubePlaybackAudioInfo(playableAudio) { it.toString() }
         val representationIdentity = buildYouTubeRepresentationIdentity(playableAudio)
         val synchronization = synchronizeCachedPlaybackDescriptor(
@@ -366,13 +374,6 @@ private suspend fun PlayerManager.prefetchYouTubePlayableAudio(spec: YouTubePref
                 shouldApplyMutation = { !playbackDemandArbiter.shouldYieldPrefetch(cacheKey) }
             )
         ) {
-            return
-        }
-        if (playableAudio.streamType != YouTubePlayableStreamType.DIRECT) {
-            NPLogger.d(
-                "NERI-PlayerManager",
-                "skip media prefetch for non-direct YouTube stream: videoId=${spec.videoId}, type=${playableAudio.streamType}, source=${spec.source}"
-            )
             return
         }
         val targetBytes = resolveYouTubeWarmupPrefetchBytes(

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/PlayerManagerYouTubePrefetchExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/PlayerManagerYouTubePrefetchExtensions.kt
@@ -17,12 +17,12 @@ import moe.ouom.neriplayer.core.di.AppContainer
 import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.core.player.quality.effectiveYouTubeQuality
 import moe.ouom.neriplayer.core.player.url.CachePrefetchReadiness
+import moe.ouom.neriplayer.core.player.url.allowsCustomCacheKey
 import moe.ouom.neriplayer.core.player.url.buildYouTubePlaybackAudioInfo
+import moe.ouom.neriplayer.core.player.url.buildYouTubeRepresentationIdentity
 import moe.ouom.neriplayer.core.player.url.hasCompleteExoPlayerCache
-import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedResource
-import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedPlaybackDescriptor
-import moe.ouom.neriplayer.core.player.url.persistCachedPlaybackDescriptor
 import moe.ouom.neriplayer.core.player.url.prepareExoPlayerCacheForPrefetch
+import moe.ouom.neriplayer.core.player.url.synchronizeCachedPlaybackDescriptor
 import moe.ouom.neriplayer.core.player.policy.command.resolveYouTubeImmediatePlaybackWarmupTargets
 import moe.ouom.neriplayer.core.player.policy.command.resolveYouTubeWarmupTargets
 import moe.ouom.neriplayer.data.platform.youtube.extractYouTubeMusicVideoId
@@ -265,8 +265,11 @@ private fun PlayerManager.canRunYouTubePrefetch(source: String): Boolean {
     return false
 }
 
-private suspend fun PlayerManager.shouldStartMediaCachePrefetch(cacheKey: String): Boolean {
-    return when (prepareExoPlayerCacheForPrefetch(cacheKey)) {
+private suspend fun PlayerManager.shouldStartMediaCachePrefetch(
+    cacheKey: String,
+    shouldApplyMutation: () -> Boolean = { true }
+): Boolean {
+    return when (prepareExoPlayerCacheForPrefetch(cacheKey, shouldApplyMutation)) {
         CachePrefetchReadiness.COMPLETE -> false
         CachePrefetchReadiness.READY_FOR_PREFETCH -> true
         CachePrefetchReadiness.UNAVAILABLE -> {
@@ -307,7 +310,11 @@ private suspend fun PlayerManager.prefetchYouTubePlayableAudio(spec: YouTubePref
         )
         return
     }
-    if (!shouldStartMediaCachePrefetch(cacheKey)) {
+    if (!shouldStartMediaCachePrefetch(
+            cacheKey = cacheKey,
+            shouldApplyMutation = { !playbackDemandArbiter.shouldYieldPrefetch(cacheKey) }
+        )
+    ) {
         return
     }
     val existingJob = youtubeStreamWarmupJobs[cacheKey]
@@ -328,21 +335,9 @@ private suspend fun PlayerManager.prefetchYouTubePlayableAudio(spec: YouTubePref
             preferM4a = false,
             isPrefetch = true
         ) ?: return
-        invalidateMismatchedCachedResource(
-            cacheKey = cacheKey,
-            expectedContentLength = playableAudio.contentLength,
-            shouldApplyMutation = {
-                !playbackDemandArbiter.shouldYieldPrefetch(cacheKey)
-            }
-        )
         val playbackAudioInfo = buildYouTubePlaybackAudioInfo(playableAudio) { it.toString() }
-        val representationIdentity = listOf(
-            playableAudio.mimeType.orEmpty(),
-            playableAudio.bitrateKbps?.toString().orEmpty(),
-            playableAudio.sampleRateHz?.toString().orEmpty(),
-            playableAudio.streamType.name
-        ).joinToString(separator = "|")
-        invalidateMismatchedCachedPlaybackDescriptor(
+        val representationIdentity = buildYouTubeRepresentationIdentity(playableAudio)
+        val synchronization = synchronizeCachedPlaybackDescriptor(
             cacheKey = cacheKey,
             audioInfo = playbackAudioInfo,
             expectedContentLength = playableAudio.contentLength,
@@ -351,12 +346,14 @@ private suspend fun PlayerManager.prefetchYouTubePlayableAudio(spec: YouTubePref
                 !playbackDemandArbiter.shouldYieldPrefetch(cacheKey)
             }
         )
-        persistCachedPlaybackDescriptor(
-            cacheKey = cacheKey,
-            audioInfo = playbackAudioInfo,
-            expectedContentLength = playableAudio.contentLength,
-            representationIdentity = representationIdentity
-        )
+        if (!synchronization.allowsCustomCacheKey()) {
+            NPLogger.w(
+                "NERI-PlayerManager",
+                "skip YouTube media prefetch because cache descriptor was not synchronized: " +
+                    "key=$cacheKey, result=$synchronization"
+            )
+            return
+        }
         if (playbackDemandArbiter.shouldYieldPrefetch(cacheKey)) {
             NPLogger.d(
                 "NERI-PlayerManager",
@@ -364,7 +361,11 @@ private suspend fun PlayerManager.prefetchYouTubePlayableAudio(spec: YouTubePref
             )
             return
         }
-        if (!shouldStartMediaCachePrefetch(cacheKey)) {
+        if (!shouldStartMediaCachePrefetch(
+                cacheKey = cacheKey,
+                shouldApplyMutation = { !playbackDemandArbiter.shouldYieldPrefetch(cacheKey) }
+            )
+        ) {
             return
         }
         if (playableAudio.streamType != YouTubePlayableStreamType.DIRECT) {

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/PlayerManagerYouTubePrefetchExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/prefetch/PlayerManagerYouTubePrefetchExtensions.kt
@@ -17,8 +17,11 @@ import moe.ouom.neriplayer.core.di.AppContainer
 import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.core.player.quality.effectiveYouTubeQuality
 import moe.ouom.neriplayer.core.player.url.CachePrefetchReadiness
+import moe.ouom.neriplayer.core.player.url.buildYouTubePlaybackAudioInfo
 import moe.ouom.neriplayer.core.player.url.hasCompleteExoPlayerCache
 import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedResource
+import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedPlaybackDescriptor
+import moe.ouom.neriplayer.core.player.url.persistCachedPlaybackDescriptor
 import moe.ouom.neriplayer.core.player.url.prepareExoPlayerCacheForPrefetch
 import moe.ouom.neriplayer.core.player.policy.command.resolveYouTubeImmediatePlaybackWarmupTargets
 import moe.ouom.neriplayer.core.player.policy.command.resolveYouTubeWarmupTargets
@@ -331,6 +334,28 @@ private suspend fun PlayerManager.prefetchYouTubePlayableAudio(spec: YouTubePref
             shouldApplyMutation = {
                 !playbackDemandArbiter.shouldYieldPrefetch(cacheKey)
             }
+        )
+        val playbackAudioInfo = buildYouTubePlaybackAudioInfo(playableAudio) { it.toString() }
+        val representationIdentity = listOf(
+            playableAudio.mimeType.orEmpty(),
+            playableAudio.bitrateKbps?.toString().orEmpty(),
+            playableAudio.sampleRateHz?.toString().orEmpty(),
+            playableAudio.streamType.name
+        ).joinToString(separator = "|")
+        invalidateMismatchedCachedPlaybackDescriptor(
+            cacheKey = cacheKey,
+            audioInfo = playbackAudioInfo,
+            expectedContentLength = playableAudio.contentLength,
+            representationIdentity = representationIdentity,
+            shouldApplyMutation = {
+                !playbackDemandArbiter.shouldYieldPrefetch(cacheKey)
+            }
+        )
+        persistCachedPlaybackDescriptor(
+            cacheKey = cacheKey,
+            audioInfo = playbackAudioInfo,
+            expectedContentLength = playableAudio.contentLength,
+            representationIdentity = representationIdentity
         )
         if (playbackDemandArbiter.shouldYieldPrefetch(cacheKey)) {
             NPLogger.d(

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/resolver/netease/PlayerManagerNeteaseAutoSourceSwitch.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/resolver/netease/PlayerManagerNeteaseAutoSourceSwitch.kt
@@ -82,6 +82,7 @@ private fun SongUrlResult.Success.toPlaybackUrlCandidate(): PlaybackUrlCandidate
         mimeType = mimeType,
         expectedContentLength = expectedContentLength,
         audioInfo = audioInfo,
+        representationIdentity = representationIdentity,
         cacheKeyOverride = cacheKeyOverride
     )
 }
@@ -185,6 +186,12 @@ private suspend fun PlayerManager.resolveNeteaseAutoBiliCandidate(
         audioInfo = buildBiliPlaybackAudioInfo(selectedStream, availableStreams) {
             getLocalizedString(it)
         },
+        representationIdentity = listOf(
+            selectedStream.id?.toString().orEmpty(),
+            selectedStream.qualityTag.orEmpty(),
+            selectedStream.mimeType.trim().lowercase(),
+            selectedStream.bitrateKbps.toString()
+        ).joinToString(separator = "|"),
         cacheKeyOverride = buildNeteaseAutoBiliCacheKey(
             bvid = videoInfo.bvid,
             cid = pageMatch.page.cid,

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/resolver/netease/PlayerManagerNeteaseAutoSourceSwitch.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/resolver/netease/PlayerManagerNeteaseAutoSourceSwitch.kt
@@ -7,6 +7,7 @@ import moe.ouom.neriplayer.core.player.model.PlaybackUrlCandidate
 import moe.ouom.neriplayer.core.player.model.SongUrlResult
 import moe.ouom.neriplayer.core.player.policy.refresh.RefreshResolverSideEffects
 import moe.ouom.neriplayer.core.player.url.buildBiliPlaybackAudioInfo
+import moe.ouom.neriplayer.core.player.url.buildBiliRepresentationIdentity
 import moe.ouom.neriplayer.core.player.url.inferBiliQualityKey
 import moe.ouom.neriplayer.data.platform.bili.BiliAudioStreamInfo
 import moe.ouom.neriplayer.data.model.SongItem
@@ -186,12 +187,7 @@ private suspend fun PlayerManager.resolveNeteaseAutoBiliCandidate(
         audioInfo = buildBiliPlaybackAudioInfo(selectedStream, availableStreams) {
             getLocalizedString(it)
         },
-        representationIdentity = listOf(
-            selectedStream.id?.toString().orEmpty(),
-            selectedStream.qualityTag.orEmpty(),
-            selectedStream.mimeType.trim().lowercase(),
-            selectedStream.bitrateKbps.toString()
-        ).joinToString(separator = "|"),
+        representationIdentity = buildBiliRepresentationIdentity(selectedStream),
         cacheKeyOverride = buildNeteaseAutoBiliCacheKey(
             bvid = videoInfo.bvid,
             cid = pageMatch.page.cid,

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptor.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptor.kt
@@ -1,0 +1,308 @@
+@file:androidx.annotation.OptIn(markerClass = [androidx.media3.common.util.UnstableApi::class])
+
+package moe.ouom.neriplayer.core.player.url
+
+import androidx.media3.datasource.cache.ContentMetadata
+import androidx.media3.datasource.cache.ContentMetadataMutations
+import androidx.media3.datasource.cache.Cache
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.core.player.PlayerManager
+import moe.ouom.neriplayer.core.player.model.PlaybackAudioInfo
+import moe.ouom.neriplayer.core.player.model.PlaybackAudioSource
+import moe.ouom.neriplayer.core.player.model.PlaybackQualityOption
+import org.json.JSONArray
+import org.json.JSONObject
+import java.security.MessageDigest
+
+internal const val CACHED_PLAYBACK_DESCRIPTOR_VERSION = 1
+internal const val CACHED_PLAYBACK_DESCRIPTOR_METADATA_KEY =
+    "${ContentMetadata.KEY_CUSTOM_PREFIX}neriplayer_playback_descriptor"
+
+internal data class CachedPlaybackDescriptor(
+    val version: Int,
+    val source: PlaybackAudioSource,
+    val qualityKey: String?,
+    val mimeType: String?,
+    val codecLabel: String?,
+    val bitrateKbps: Int?,
+    val sampleRateHz: Int?,
+    val bitDepth: Int?,
+    val channelCount: Int?,
+    val qualityOptionKeys: List<String>,
+    val expectedContentLength: Long?,
+    val representationIdentity: String?,
+    val representationFingerprint: String
+)
+
+internal fun cachedPlaybackDescriptorFromAudioInfo(
+    audioInfo: PlaybackAudioInfo,
+    expectedContentLength: Long?,
+    representationIdentity: String? = null
+): CachedPlaybackDescriptor {
+    val descriptor = CachedPlaybackDescriptor(
+        version = CACHED_PLAYBACK_DESCRIPTOR_VERSION,
+        source = audioInfo.source,
+        qualityKey = audioInfo.qualityKey.normalizedDescriptorValue(),
+        mimeType = audioInfo.mimeType.normalizedDescriptorValue(),
+        codecLabel = audioInfo.codecLabel.normalizedDescriptorValue(),
+        bitrateKbps = audioInfo.bitrateKbps,
+        sampleRateHz = audioInfo.sampleRateHz,
+        bitDepth = audioInfo.bitDepth,
+        channelCount = audioInfo.channelCount,
+        qualityOptionKeys = audioInfo.qualityOptions
+            .mapNotNull { it.key.normalizedDescriptorValue() }
+            .distinct(),
+        expectedContentLength = expectedContentLength?.takeIf { it > 0L },
+        representationIdentity = representationIdentity.normalizedDescriptorValue(),
+        representationFingerprint = ""
+    )
+    return descriptor.copy(representationFingerprint = descriptor.fingerprint())
+}
+
+private fun String?.normalizedDescriptorValue(): String? = this
+    ?.trim()
+    ?.takeIf { it.isNotBlank() }
+
+private fun CachedPlaybackDescriptor.fingerprint(): String {
+    val canonical = listOf(
+        source.name,
+        qualityKey.orEmpty(),
+        mimeType.orEmpty(),
+        codecLabel.orEmpty(),
+        bitrateKbps?.toString().orEmpty(),
+        sampleRateHz?.toString().orEmpty(),
+        bitDepth?.toString().orEmpty(),
+        channelCount?.toString().orEmpty(),
+        qualityOptionKeys.joinToString(separator = ","),
+        expectedContentLength?.toString().orEmpty(),
+        representationIdentity.orEmpty()
+    ).joinToString(separator = "|")
+    return MessageDigest.getInstance("SHA-256")
+        .digest(canonical.toByteArray(Charsets.UTF_8))
+        .joinToString(separator = "") { byte -> "%02x".format(byte) }
+}
+
+internal fun CachedPlaybackDescriptor.matches(
+    audioInfo: PlaybackAudioInfo,
+    expectedContentLength: Long?,
+    representationIdentity: String? = null
+): Boolean {
+    val expected = cachedPlaybackDescriptorFromAudioInfo(
+        audioInfo = audioInfo,
+        expectedContentLength = expectedContentLength,
+        representationIdentity = representationIdentity
+    )
+    return version == CACHED_PLAYBACK_DESCRIPTOR_VERSION &&
+        representationFingerprint == fingerprint() &&
+        representationFingerprint == expected.representationFingerprint &&
+        (representationIdentity == null ||
+            expected.representationIdentity == null ||
+            representationIdentity == expected.representationIdentity) &&
+        source == expected.source &&
+        qualityKey == expected.qualityKey &&
+        mimeType == expected.mimeType &&
+        codecLabel == expected.codecLabel &&
+        bitrateKbps == expected.bitrateKbps &&
+        sampleRateHz == expected.sampleRateHz &&
+        bitDepth == expected.bitDepth &&
+        channelCount == expected.channelCount &&
+        (expected.expectedContentLength == null ||
+            expectedContentLength == null ||
+            expected.expectedContentLength == this.expectedContentLength)
+}
+
+internal fun CachedPlaybackDescriptor.matchesCachedContentLength(
+    cachedContentLength: Long
+): Boolean {
+    return expectedContentLength == null || expectedContentLength == cachedContentLength
+}
+
+internal fun CachedPlaybackDescriptor.toPlaybackAudioInfo(
+    getLocalizedString: (Int) -> String
+): PlaybackAudioInfo? {
+    if (version != CACHED_PLAYBACK_DESCRIPTOR_VERSION) return null
+    if (representationFingerprint != fingerprint()) return null
+    val options = qualityOptionKeys.map { key ->
+        PlaybackQualityOption(key, qualityLabelForCachedSource(source, key, getLocalizedString))
+    }
+    return PlaybackAudioInfo(
+        source = source,
+        qualityKey = qualityKey,
+        qualityLabel = qualityKey?.let {
+            qualityLabelForCachedSource(source, it, getLocalizedString)
+        },
+        qualityOptions = options,
+        codecLabel = codecLabel,
+        mimeType = mimeType,
+        bitrateKbps = bitrateKbps,
+        sampleRateHz = sampleRateHz,
+        bitDepth = bitDepth,
+        channelCount = channelCount
+    )
+}
+
+private fun qualityLabelForCachedSource(
+    source: PlaybackAudioSource,
+    key: String,
+    getLocalizedString: (Int) -> String
+): String {
+    return when (source) {
+        PlaybackAudioSource.NETEASE -> qualityLabelForNetease(key, getLocalizedString)
+        PlaybackAudioSource.BILIBILI -> qualityLabelForBili(key, getLocalizedString)
+        PlaybackAudioSource.YOUTUBE_MUSIC -> qualityLabelForYouTube(key, getLocalizedString)
+        PlaybackAudioSource.LOCAL -> key
+    }
+}
+
+internal fun encodeCachedPlaybackDescriptor(
+    descriptor: CachedPlaybackDescriptor
+): String {
+    return JSONObject().apply {
+        put("version", descriptor.version)
+        put("source", descriptor.source.name)
+        putNullable("qualityKey", descriptor.qualityKey)
+        putNullable("mimeType", descriptor.mimeType)
+        putNullable("codecLabel", descriptor.codecLabel)
+        putNullable("bitrateKbps", descriptor.bitrateKbps)
+        putNullable("sampleRateHz", descriptor.sampleRateHz)
+        putNullable("bitDepth", descriptor.bitDepth)
+        putNullable("channelCount", descriptor.channelCount)
+        put("qualityOptionKeys", JSONArray(descriptor.qualityOptionKeys))
+        putNullable("expectedContentLength", descriptor.expectedContentLength)
+        putNullable("representationIdentity", descriptor.representationIdentity)
+        put("representationFingerprint", descriptor.representationFingerprint)
+    }.toString()
+}
+
+internal fun decodeCachedPlaybackDescriptor(raw: String?): CachedPlaybackDescriptor? {
+    if (raw.isNullOrBlank()) return null
+    return runCatching {
+        val json = JSONObject(raw)
+        val source = PlaybackAudioSource.valueOf(json.getString("source"))
+        val qualityOptionKeys = buildList {
+            val options = json.optJSONArray("qualityOptionKeys") ?: return@buildList
+            for (index in 0 until options.length()) {
+                options.optString(index).normalizedDescriptorValue()?.let(::add)
+            }
+        }
+        CachedPlaybackDescriptor(
+            version = json.optInt("version", 0),
+            source = source,
+            qualityKey = json.optNullableString("qualityKey"),
+            mimeType = json.optNullableString("mimeType"),
+            codecLabel = json.optNullableString("codecLabel"),
+            bitrateKbps = json.optNullableInt("bitrateKbps"),
+            sampleRateHz = json.optNullableInt("sampleRateHz"),
+            bitDepth = json.optNullableInt("bitDepth"),
+            channelCount = json.optNullableInt("channelCount"),
+            qualityOptionKeys = qualityOptionKeys,
+            expectedContentLength = json.optNullableLong("expectedContentLength"),
+            representationIdentity = json.optNullableString("representationIdentity"),
+            representationFingerprint = json.optString("representationFingerprint")
+        )
+    }.getOrNull()
+}
+
+private fun JSONObject.putNullable(key: String, value: Any?) {
+    put(key, value ?: JSONObject.NULL)
+}
+
+private fun JSONObject.optNullableString(key: String): String? {
+    return optString(key).normalizedDescriptorValue()
+}
+
+private fun JSONObject.optNullableInt(key: String): Int? {
+    if (!has(key) || isNull(key)) return null
+    return optInt(key).takeIf { it > 0 }
+}
+
+private fun JSONObject.optNullableLong(key: String): Long? {
+    if (!has(key) || isNull(key)) return null
+    return optLong(key).takeIf { it > 0L }
+}
+
+internal fun Cache.readCachedPlaybackDescriptor(cacheKey: String): CachedPlaybackDescriptor? {
+    return decodeCachedPlaybackDescriptor(
+        getContentMetadata(cacheKey).get(
+            CACHED_PLAYBACK_DESCRIPTOR_METADATA_KEY,
+            null as String?
+        )
+    )
+}
+
+internal fun Cache.writeCachedPlaybackDescriptor(
+    cacheKey: String,
+    descriptor: CachedPlaybackDescriptor
+) {
+    applyContentMetadataMutations(
+        cacheKey,
+        ContentMetadataMutations().set(
+            CACHED_PLAYBACK_DESCRIPTOR_METADATA_KEY,
+            encodeCachedPlaybackDescriptor(descriptor)
+        )
+    )
+}
+
+internal suspend fun PlayerManager.invalidateMismatchedCachedPlaybackDescriptor(
+    cacheKey: String,
+    audioInfo: PlaybackAudioInfo?,
+    expectedContentLength: Long?,
+    representationIdentity: String?,
+    shouldApplyMutation: () -> Boolean = { true }
+): Boolean = withContext(Dispatchers.IO) {
+    if (cacheKey.isBlank() || audioInfo == null || audioInfo.source == PlaybackAudioSource.LOCAL) {
+        return@withContext false
+    }
+    val mediaCache = cache ?: return@withContext false
+    runCatching {
+        if (mediaCache.getCachedSpans(cacheKey).isEmpty()) return@runCatching false
+        val existing = mediaCache.readCachedPlaybackDescriptor(cacheKey)
+        val matches = existing?.matches(
+            audioInfo = audioInfo,
+            expectedContentLength = expectedContentLength,
+            representationIdentity = representationIdentity
+        ) == true
+        if (matches || !shouldApplyMutation()) return@runCatching false
+        mediaCache.removeResource(cacheKey)
+        NPLogger.w(
+            "NERI-PlayerManager",
+            "缓存表示描述符不匹配，移除旧资源: key=$cacheKey, source=${audioInfo.source}"
+        )
+        true
+    }.getOrElse { error ->
+        NPLogger.w(
+            "NERI-PlayerManager",
+            "检查缓存表示描述符失败: key=$cacheKey, error=${error.message}"
+        )
+        false
+    }
+}
+
+internal suspend fun PlayerManager.persistCachedPlaybackDescriptor(
+    cacheKey: String,
+    audioInfo: PlaybackAudioInfo?,
+    expectedContentLength: Long?,
+    representationIdentity: String?
+) = withContext(Dispatchers.IO) {
+    if (cacheKey.isBlank() || audioInfo == null || audioInfo.source == PlaybackAudioSource.LOCAL) {
+        return@withContext
+    }
+    val mediaCache = cache ?: return@withContext
+    runCatching {
+        mediaCache.writeCachedPlaybackDescriptor(
+            cacheKey = cacheKey,
+            descriptor = cachedPlaybackDescriptorFromAudioInfo(
+                audioInfo = audioInfo,
+                expectedContentLength = expectedContentLength,
+                representationIdentity = representationIdentity
+            )
+        )
+    }.onFailure { error ->
+        NPLogger.w(
+            "NERI-PlayerManager",
+            "写入播放缓存描述符失败: key=$cacheKey, error=${error.message}"
+        )
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptor.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptor.kt
@@ -14,11 +14,23 @@ import moe.ouom.neriplayer.core.player.model.PlaybackAudioSource
 import moe.ouom.neriplayer.core.player.model.PlaybackQualityOption
 import org.json.JSONArray
 import org.json.JSONObject
+import java.lang.ref.WeakReference
 import java.security.MessageDigest
 
-internal const val CACHED_PLAYBACK_DESCRIPTOR_VERSION = 1
+internal const val CACHED_PLAYBACK_DESCRIPTOR_VERSION = 2
 internal const val CACHED_PLAYBACK_DESCRIPTOR_METADATA_KEY =
     "${ContentMetadata.KEY_CUSTOM_PREFIX}neriplayer_playback_descriptor"
+internal const val CACHED_PLAYBACK_CACHE_UNSAFE_METADATA_KEY =
+    "${ContentMetadata.KEY_CUSTOM_PREFIX}neriplayer_playback_cache_unsafe"
+
+private const val CACHED_PLAYBACK_CACHE_UNSAFE_VALUE = "1"
+
+internal enum class CachedPlaybackDescriptorSynchronizationResult {
+    APPLIED,
+    NO_METADATA,
+    SKIPPED,
+    CACHE_UNUSABLE
+}
 
 internal data class CachedPlaybackDescriptor(
     val version: Int,
@@ -96,10 +108,6 @@ internal fun CachedPlaybackDescriptor.matches(
     )
     return version == CACHED_PLAYBACK_DESCRIPTOR_VERSION &&
         representationFingerprint == fingerprint() &&
-        representationFingerprint == expected.representationFingerprint &&
-        (representationIdentity == null ||
-            expected.representationIdentity == null ||
-            representationIdentity == expected.representationIdentity) &&
         source == expected.source &&
         qualityKey == expected.qualityKey &&
         mimeType == expected.mimeType &&
@@ -108,15 +116,19 @@ internal fun CachedPlaybackDescriptor.matches(
         sampleRateHz == expected.sampleRateHz &&
         bitDepth == expected.bitDepth &&
         channelCount == expected.channelCount &&
-        (expected.expectedContentLength == null ||
-            expectedContentLength == null ||
-            expected.expectedContentLength == this.expectedContentLength)
+        this.representationIdentity == expected.representationIdentity &&
+        expected.expectedContentLength == this.expectedContentLength
 }
 
 internal fun CachedPlaybackDescriptor.matchesCachedContentLength(
     cachedContentLength: Long
 ): Boolean {
     return expectedContentLength == null || expectedContentLength == cachedContentLength
+}
+
+internal fun CachedPlaybackDescriptorSynchronizationResult.allowsCustomCacheKey(): Boolean {
+    return this == CachedPlaybackDescriptorSynchronizationResult.APPLIED ||
+        this == CachedPlaybackDescriptorSynchronizationResult.NO_METADATA
 }
 
 internal fun CachedPlaybackDescriptor.toPlaybackAudioInfo(
@@ -238,71 +250,265 @@ internal fun Cache.writeCachedPlaybackDescriptor(
 ) {
     applyContentMetadataMutations(
         cacheKey,
-        ContentMetadataMutations().set(
-            CACHED_PLAYBACK_DESCRIPTOR_METADATA_KEY,
-            encodeCachedPlaybackDescriptor(descriptor)
-        )
+        ContentMetadataMutations()
+            .set(
+                CACHED_PLAYBACK_DESCRIPTOR_METADATA_KEY,
+                encodeCachedPlaybackDescriptor(descriptor)
+            )
+            .remove(CACHED_PLAYBACK_CACHE_UNSAFE_METADATA_KEY)
     )
 }
 
-internal suspend fun PlayerManager.invalidateMismatchedCachedPlaybackDescriptor(
-    cacheKey: String,
-    audioInfo: PlaybackAudioInfo?,
-    expectedContentLength: Long?,
-    representationIdentity: String?,
-    shouldApplyMutation: () -> Boolean = { true }
-): Boolean = withContext(Dispatchers.IO) {
-    if (cacheKey.isBlank() || audioInfo == null || audioInfo.source == PlaybackAudioSource.LOCAL) {
-        return@withContext false
-    }
-    val mediaCache = cache ?: return@withContext false
-    runCatching {
-        if (mediaCache.getCachedSpans(cacheKey).isEmpty()) return@runCatching false
-        val existing = mediaCache.readCachedPlaybackDescriptor(cacheKey)
-        val matches = existing?.matches(
-            audioInfo = audioInfo,
-            expectedContentLength = expectedContentLength,
-            representationIdentity = representationIdentity
-        ) == true
-        if (matches || !shouldApplyMutation()) return@runCatching false
-        mediaCache.removeResource(cacheKey)
-        NPLogger.w(
-            "NERI-PlayerManager",
-            "缓存表示描述符不匹配，移除旧资源: key=$cacheKey, source=${audioInfo.source}"
-        )
-        true
-    }.getOrElse { error ->
-        NPLogger.w(
-            "NERI-PlayerManager",
-            "检查缓存表示描述符失败: key=$cacheKey, error=${error.message}"
-        )
-        false
-    }
+private fun Cache.isCachedPlaybackResourceUnsafe(cacheKey: String): Boolean {
+    if (cacheKey.isBlank()) return false
+    return runCatching {
+        getContentMetadata(cacheKey).get(
+            CACHED_PLAYBACK_CACHE_UNSAFE_METADATA_KEY,
+            null as String?
+        ) == CACHED_PLAYBACK_CACHE_UNSAFE_VALUE
+    }.getOrDefault(false)
 }
 
-internal suspend fun PlayerManager.persistCachedPlaybackDescriptor(
-    cacheKey: String,
-    audioInfo: PlaybackAudioInfo?,
-    expectedContentLength: Long?,
-    representationIdentity: String?
-) = withContext(Dispatchers.IO) {
-    if (cacheKey.isBlank() || audioInfo == null || audioInfo.source == PlaybackAudioSource.LOCAL) {
-        return@withContext
-    }
-    val mediaCache = cache ?: return@withContext
+private fun Cache.markCachedPlaybackResourceUnsafe(cacheKey: String) {
     runCatching {
-        mediaCache.writeCachedPlaybackDescriptor(
-            cacheKey = cacheKey,
-            descriptor = cachedPlaybackDescriptorFromAudioInfo(
-                audioInfo = audioInfo,
-                expectedContentLength = expectedContentLength,
-                representationIdentity = representationIdentity
+        applyContentMetadataMutations(
+            cacheKey,
+            ContentMetadataMutations().set(
+                CACHED_PLAYBACK_CACHE_UNSAFE_METADATA_KEY,
+                CACHED_PLAYBACK_CACHE_UNSAFE_VALUE
             )
         )
     }.onFailure { error ->
         NPLogger.w(
             "NERI-PlayerManager",
-            "写入播放缓存描述符失败: key=$cacheKey, error=${error.message}"
+            "标记异常播放缓存失败: key=$cacheKey, error=${error.message}"
         )
+    }
+}
+
+private fun Cache.clearCachedPlaybackResourceUnsafe(cacheKey: String): Boolean {
+    if (cacheKey.isBlank()) return true
+    return runCatching {
+        if (!getContentMetadata(cacheKey).contains(CACHED_PLAYBACK_CACHE_UNSAFE_METADATA_KEY)) {
+            return@runCatching true
+        }
+        applyContentMetadataMutations(
+            cacheKey,
+            ContentMetadataMutations().remove(CACHED_PLAYBACK_CACHE_UNSAFE_METADATA_KEY)
+        )
+        true
+    }.getOrElse { error ->
+        NPLogger.w(
+            "NERI-PlayerManager",
+            "清除异常播放缓存标记失败: key=$cacheKey, error=${error.message}"
+        )
+        false
+    }
+}
+
+private object PlaybackCacheSafetyTracker {
+    private val lock = Any()
+    private var cacheOwner: WeakReference<Cache>? = null
+    private val unsafeKeys = mutableSetOf<String>()
+
+    fun markUnsafe(cache: Cache, cacheKey: String) {
+        synchronized(lock) {
+            resetFor(cache)
+            unsafeKeys += cacheKey
+        }
+    }
+
+    fun clearUnsafe(cache: Cache, cacheKey: String) {
+        synchronized(lock) {
+            resetFor(cache)
+            unsafeKeys -= cacheKey
+        }
+    }
+
+    fun isUnsafe(cache: Cache?, cacheKey: String): Boolean {
+        if (cache == null || cacheKey.isBlank()) return false
+        return synchronized(lock) {
+            resetFor(cache)
+            cacheKey in unsafeKeys
+        }
+    }
+
+    private fun resetFor(cache: Cache) {
+        if (cacheOwner?.get() !== cache) {
+            cacheOwner = WeakReference(cache)
+            unsafeKeys.clear()
+        }
+    }
+}
+
+internal fun PlayerManager.markPlaybackCacheKeyUnsafe(
+    mediaCache: Cache,
+    cacheKey: String
+) {
+    if (cache !== mediaCache || cacheKey.isBlank()) return
+    PlaybackCacheSafetyTracker.markUnsafe(mediaCache, cacheKey)
+    mediaCache.markCachedPlaybackResourceUnsafe(cacheKey)
+}
+
+internal fun PlayerManager.clearPlaybackCacheKeyUnsafe(
+    mediaCache: Cache,
+    cacheKey: String
+): Boolean {
+    if (cacheKey.isBlank()) return true
+    if (cache !== mediaCache) return false
+    return if (mediaCache.clearCachedPlaybackResourceUnsafe(cacheKey)) {
+        if (cache !== mediaCache) return false
+        PlaybackCacheSafetyTracker.clearUnsafe(mediaCache, cacheKey)
+        true
+    } else {
+        if (cache === mediaCache) {
+            PlaybackCacheSafetyTracker.markUnsafe(mediaCache, cacheKey)
+        }
+        false
+    }
+}
+
+internal fun PlayerManager.isPlaybackCacheKeyUnsafe(cacheKey: String): Boolean {
+    return PlaybackCacheSafetyTracker.isUnsafe(cache, cacheKey)
+}
+
+private fun PlayerManager.loadPersistedPlaybackCacheKeySafety(
+    mediaCache: Cache,
+    cacheKey: String
+): Boolean {
+    if (cache !== mediaCache) return false
+    if (!mediaCache.isCachedPlaybackResourceUnsafe(cacheKey)) return false
+    if (cache !== mediaCache) return false
+    PlaybackCacheSafetyTracker.markUnsafe(mediaCache, cacheKey)
+    return true
+}
+
+internal suspend fun PlayerManager.loadPlaybackCacheKeySafety(cacheKey: String): Boolean {
+    return withContext(Dispatchers.IO) {
+        val mediaCache = cache ?: return@withContext false
+        PlaybackCacheSafetyTracker.isUnsafe(mediaCache, cacheKey) ||
+            loadPersistedPlaybackCacheKeySafety(mediaCache, cacheKey)
+    }
+}
+
+internal fun PlayerManager.safeCustomPlaybackCacheKey(cacheKey: String): String? {
+    return cacheKey.takeIf {
+        it.isNotBlank() &&
+            !PlaybackCacheSafetyTracker.isUnsafe(cache, it)
+    }
+}
+
+internal suspend fun PlayerManager.synchronizeCachedPlaybackDescriptor(
+    cacheKey: String,
+    audioInfo: PlaybackAudioInfo?,
+    expectedContentLength: Long?,
+    representationIdentity: String?,
+    shouldApplyMutation: () -> Boolean = { true }
+): CachedPlaybackDescriptorSynchronizationResult = withContext(Dispatchers.IO) {
+    if (cacheKey.isBlank()) {
+        return@withContext CachedPlaybackDescriptorSynchronizationResult.NO_METADATA
+    }
+    val mediaCache = cache
+        ?: return@withContext CachedPlaybackDescriptorSynchronizationResult.NO_METADATA
+    if (cache !== mediaCache) {
+        return@withContext CachedPlaybackDescriptorSynchronizationResult.SKIPPED
+    }
+    loadPersistedPlaybackCacheKeySafety(mediaCache, cacheKey)
+    val remoteAudioInfo = audioInfo
+        ?.takeUnless { it.source == PlaybackAudioSource.LOCAL }
+        ?: return@withContext CachedPlaybackDescriptorSynchronizationResult.NO_METADATA
+    val descriptor = cachedPlaybackDescriptorFromAudioInfo(
+        audioInfo = remoteAudioInfo,
+        expectedContentLength = expectedContentLength,
+        representationIdentity = representationIdentity
+    )
+    val expectedLength = expectedContentLength?.takeIf { it > 0L }
+
+    runCatching<CachedPlaybackDescriptorSynchronizationResult> {
+        fun canMutate(): Boolean = cache === mediaCache && shouldApplyMutation()
+
+        if (!canMutate()) {
+            return@runCatching CachedPlaybackDescriptorSynchronizationResult.SKIPPED
+        }
+
+        val cachedSpans = mediaCache.getCachedSpans(cacheKey)
+        if (cache !== mediaCache) {
+            return@runCatching CachedPlaybackDescriptorSynchronizationResult.SKIPPED
+        }
+        val hasCachedData = cachedSpans.isNotEmpty()
+        val cachedContentLength = if (hasCachedData) {
+            ContentMetadata.getContentLength(mediaCache.getContentMetadata(cacheKey))
+        } else {
+            0L
+        }
+        val existingDescriptor = if (hasCachedData) {
+            mediaCache.readCachedPlaybackDescriptor(cacheKey)
+        } else {
+            null
+        }
+        if (cache !== mediaCache) {
+            return@runCatching CachedPlaybackDescriptorSynchronizationResult.SKIPPED
+        }
+        val shouldReplaceForLength = expectedLength != null &&
+            hasCachedData &&
+            shouldReplaceCachedPreviewResource(cachedContentLength, expectedLength)
+        val shouldReplaceForDescriptor = hasCachedData &&
+            existingDescriptor?.matches(
+                audioInfo = remoteAudioInfo,
+                expectedContentLength = expectedContentLength,
+                representationIdentity = representationIdentity
+            ) != true
+        val shouldReplaceUnsafeResource = hasCachedData &&
+            PlaybackCacheSafetyTracker.isUnsafe(mediaCache, cacheKey)
+
+        if (
+            shouldReplaceForLength ||
+                shouldReplaceForDescriptor ||
+                shouldReplaceUnsafeResource
+        ) {
+            if (!canMutate()) {
+                return@runCatching CachedPlaybackDescriptorSynchronizationResult.SKIPPED
+            }
+            mediaCache.removeResource(cacheKey)
+            if (cache !== mediaCache) {
+                return@runCatching CachedPlaybackDescriptorSynchronizationResult.SKIPPED
+            }
+            if (mediaCache.getCachedSpans(cacheKey).isNotEmpty()) {
+                markPlaybackCacheKeyUnsafe(mediaCache, cacheKey)
+                NPLogger.w(
+                    "NERI-PlayerManager",
+                    "缓存资源未完全移除，保留旧描述符: key=$cacheKey"
+                )
+                return@runCatching CachedPlaybackDescriptorSynchronizationResult.CACHE_UNUSABLE
+            }
+            NPLogger.w(
+                "NERI-PlayerManager",
+                "缓存表示不匹配，移除旧资源: key=$cacheKey, " +
+                    "source=${remoteAudioInfo.source}, lengthMismatch=$shouldReplaceForLength"
+            )
+        }
+
+        if (!canMutate()) {
+            return@runCatching CachedPlaybackDescriptorSynchronizationResult.SKIPPED
+        }
+        mediaCache.writeCachedPlaybackDescriptor(cacheKey, descriptor)
+        if (cache !== mediaCache) {
+            return@runCatching CachedPlaybackDescriptorSynchronizationResult.SKIPPED
+        }
+        PlaybackCacheSafetyTracker.clearUnsafe(mediaCache, cacheKey)
+        CachedPlaybackDescriptorSynchronizationResult.APPLIED
+    }.getOrElse { error ->
+        if (cache === mediaCache) {
+            markPlaybackCacheKeyUnsafe(mediaCache, cacheKey)
+        }
+        NPLogger.w(
+            "NERI-PlayerManager",
+            "同步播放缓存描述符失败: key=$cacheKey, error=${error.message}"
+        )
+        if (cache === mediaCache) {
+            CachedPlaybackDescriptorSynchronizationResult.CACHE_UNUSABLE
+        } else {
+            CachedPlaybackDescriptorSynchronizationResult.SKIPPED
+        }
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptor.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptor.kt
@@ -2,6 +2,7 @@
 
 package moe.ouom.neriplayer.core.player.url
 
+import androidx.annotation.VisibleForTesting
 import androidx.media3.datasource.cache.ContentMetadata
 import androidx.media3.datasource.cache.ContentMetadataMutations
 import androidx.media3.datasource.cache.Cache
@@ -117,7 +118,11 @@ internal fun CachedPlaybackDescriptor.matches(
         bitDepth == expected.bitDepth &&
         channelCount == expected.channelCount &&
         this.representationIdentity == expected.representationIdentity &&
-        expected.expectedContentLength == this.expectedContentLength
+        (
+            this.expectedContentLength == null ||
+                expected.expectedContentLength == null ||
+                expected.expectedContentLength == this.expectedContentLength
+            )
 }
 
 internal fun CachedPlaybackDescriptor.matchesCachedContentLength(
@@ -333,12 +338,25 @@ private object PlaybackCacheSafetyTracker {
         }
     }
 
+    @VisibleForTesting
+    fun clearForTesting() {
+        synchronized(lock) {
+            cacheOwner = null
+            unsafeKeys.clear()
+        }
+    }
+
     private fun resetFor(cache: Cache) {
         if (cacheOwner?.get() !== cache) {
             cacheOwner = WeakReference(cache)
             unsafeKeys.clear()
         }
     }
+}
+
+@VisibleForTesting
+internal fun clearPlaybackCacheSafetyForTesting() {
+    PlaybackCacheSafetyTracker.clearForTesting()
 }
 
 internal fun PlayerManager.markPlaybackCacheKeyUnsafe(

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerManagerUrlExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerManagerUrlExtensions.kt
@@ -143,7 +143,8 @@ internal suspend fun PlayerManager.resolveSongUrl(
     youtubeRecoveryStrategy: YouTubePlaybackRecoveryStrategy? = null,
     sideEffects: RefreshResolverSideEffects = RefreshResolverSideEffects(),
     allowGenericPrefetchCache: Boolean = true,
-    playbackRequestTokenOverride: Long? = null
+    playbackRequestTokenOverride: Long? = null,
+    shouldApplyCacheMutation: () -> Boolean = { true }
 ): SongUrlResult {
     NPLogger.d(
         "NERI-PlayerManager",
@@ -177,7 +178,8 @@ internal suspend fun PlayerManager.resolveSongUrl(
                 youtubeRecoveryStrategy = youtubeRecoveryStrategy,
                 sideEffects = sideEffects,
                 allowGenericPrefetchCache = allowGenericPrefetchCache,
-                playbackRequestTokenOverride = playbackRequestTokenOverride
+                playbackRequestTokenOverride = playbackRequestTokenOverride,
+                shouldApplyCacheMutation = shouldApplyCacheMutation
             )
         }
         sideEffects.emitError {
@@ -201,6 +203,7 @@ internal suspend fun PlayerManager.resolveSongUrl(
         youtubeQualityOverride = youtubeRecoveryStrategy?.preferredQualityOverride,
         youtubePreferM4aOverride = youtubeRecoveryStrategy?.preferM4a
     )
+    val cacheKeyIsUnsafe = loadPlaybackCacheKeySafety(cacheKey)
     val cacheIntegrity = if (forceRefresh) {
         NPLogger.d(
             "NERI-PlayerManager",
@@ -213,10 +216,13 @@ internal suspend fun PlayerManager.resolveSongUrl(
     if (cacheIntegrity.requiresRepair) {
         invalidateCachedResourceForPlaybackRecovery(
             cacheKey = cacheKey,
-            reason = "resolve_integrity_check"
+            reason = "resolve_integrity_check",
+            shouldApplyMutation = shouldApplyCacheMutation
         )
     }
-    var hasCachedData = !forceRefresh && cacheIntegrity.isComplete
+    var hasCachedData = !forceRefresh &&
+        cacheIntegrity.isComplete &&
+        !cacheKeyIsUnsafe
     if (hasCachedData) {
         val cachedDescriptor = cache?.readCachedPlaybackDescriptor(cacheKey)
         val cachedAudioInfo = cachedDescriptor?.toPlaybackAudioInfo {
@@ -233,11 +239,18 @@ internal suspend fun PlayerManager.resolveSongUrl(
                 "NERI-PlayerManager",
                 "完整缓存描述符缺失或长度不匹配，淘汰旧资源并重新解析: key=$cacheKey"
             )
-            invalidateCachedResourceForPlaybackRecovery(
+            val removed = invalidateCachedResourceForPlaybackRecovery(
                 cacheKey = cacheKey,
-                reason = "missing_playback_descriptor"
+                reason = "missing_playback_descriptor",
+                shouldApplyMutation = shouldApplyCacheMutation
             )
             hasCachedData = false
+            if (!removed) {
+                NPLogger.w(
+                    "NERI-PlayerManager",
+                    "无法移除缺少描述符的缓存，跳过离线复用: key=$cacheKey"
+                )
+            }
         }
     }
     if (hasCachedData) {
@@ -827,7 +840,8 @@ private suspend fun PlayerManager.runRefreshOperation(
         semantics.cacheKeyToInvalidateBeforeResolve?.let { staleCacheKey ->
             invalidateCachedResourceBeforeResolve(
                 cacheKey = staleCacheKey,
-                reason = semantics.reason
+                reason = semantics.reason,
+                shouldApplyMutation = { canApplyRefreshResult(semantics, song) }
             )
         }
         val result = resolveSongUrl(
@@ -835,7 +849,8 @@ private suspend fun PlayerManager.runRefreshOperation(
             forceRefresh = isYouTubeMusicTrack(song),
             youtubeRecoveryStrategy = semantics.youtubeRecoveryStrategy,
             sideEffects = RefreshResolverSideEffects(refreshSideEffectGate(semantics, song)),
-            playbackRequestTokenOverride = semantics.requestGeneration
+            playbackRequestTokenOverride = semantics.requestGeneration,
+            shouldApplyCacheMutation = { canApplyRefreshResult(semantics, song) }
         )
         deferred.complete(result)
         handleRefreshResult(semantics, song, result)
@@ -1025,25 +1040,21 @@ private suspend fun PlayerManager.applyResolvedMediaItem(
         selectedCandidate?.expectedContentLength ?: expectedContentLength
     val selectedRepresentationIdentity =
         selectedCandidate?.representationIdentity ?: result.representationIdentity
-    invalidateMismatchedCachedResource(
-        cacheKey = cacheKey,
-        expectedContentLength = selectedExpectedContentLength,
-        shouldApplyMutation = { gate.runMutation {} }
-    )
-    invalidateMismatchedCachedPlaybackDescriptor(
+    val cacheSynchronization = synchronizeCachedPlaybackDescriptor(
         cacheKey = cacheKey,
         audioInfo = selectedAudioInfo,
         expectedContentLength = selectedExpectedContentLength,
         representationIdentity = selectedRepresentationIdentity,
         shouldApplyMutation = { gate.runMutation {} }
     )
-    persistCachedPlaybackDescriptor(
+    if (!gate.runMutation {}) return false
+    val mediaItem = buildMediaItem(
+        song = song,
+        url = selectedUrl,
         cacheKey = cacheKey,
-        audioInfo = selectedAudioInfo,
-        expectedContentLength = selectedExpectedContentLength,
-        representationIdentity = selectedRepresentationIdentity
+        mimeType = selectedMimeType,
+        allowCustomCacheKey = cacheSynchronization.allowsCustomCacheKey()
     )
-    val mediaItem = buildMediaItem(song, selectedUrl, cacheKey, selectedMimeType)
 
     if (!gate.runMutation { _currentMediaUrl.value = selectedUrl }) return false
     if (!gate.runMutation { _currentPlaybackAudioInfo.value = selectedAudioInfo }) return false
@@ -1202,9 +1213,25 @@ internal fun PlayerManager.hasCompleteExoPlayerCache(cacheKey: String): Boolean 
 }
 
 internal suspend fun PlayerManager.prepareExoPlayerCacheForPrefetch(
-    cacheKey: String
+    cacheKey: String,
+    shouldApplyMutation: () -> Boolean = { true }
 ): CachePrefetchReadiness {
     val currentCache = cache ?: return CachePrefetchReadiness.UNAVAILABLE
+
+    if (loadPlaybackCacheKeySafety(cacheKey)) {
+        if (cache !== currentCache) return CachePrefetchReadiness.UNAVAILABLE
+        return if (
+            invalidateCachedResourceForPlaybackRecovery(
+                cacheKey = cacheKey,
+                reason = "prefetch_unsafe_cache_key",
+                shouldApplyMutation = shouldApplyMutation
+            )
+        ) {
+            CachePrefetchReadiness.READY_FOR_PREFETCH
+        } else {
+            CachePrefetchReadiness.UNAVAILABLE
+        }
+    }
 
     val integrity = inspectExoPlayerCache(cacheKey)
     if (cache !== currentCache) return CachePrefetchReadiness.UNAVAILABLE
@@ -1214,7 +1241,8 @@ internal suspend fun PlayerManager.prepareExoPlayerCacheForPrefetch(
     return if (
         invalidateCachedResourceForPlaybackRecovery(
             cacheKey = cacheKey,
-            reason = "prefetch_integrity_check"
+            reason = "prefetch_integrity_check",
+            shouldApplyMutation = shouldApplyMutation
         )
     ) {
         CachePrefetchReadiness.READY_FOR_PREFETCH
@@ -1274,18 +1302,41 @@ internal fun PlayerManager.currentPlaybackCacheKeyForRecovery(): String? {
 
 internal suspend fun PlayerManager.invalidateCachedResourceForPlaybackRecovery(
     cacheKey: String,
-    reason: String
+    reason: String,
+    shouldApplyMutation: () -> Boolean = { true }
 ): Boolean = withContext(Dispatchers.IO) {
     if (cacheKey.isBlank()) return@withContext false
     val mediaCache = cache ?: return@withContext false
+    if (cache !== mediaCache || !shouldApplyMutation()) return@withContext false
     try {
+        if (cache !== mediaCache || !shouldApplyMutation()) return@withContext false
         mediaCache.removeResource(cacheKey)
+        if (cache !== mediaCache) return@withContext false
+        if (mediaCache.getCachedSpans(cacheKey).isNotEmpty()) {
+            markPlaybackCacheKeyUnsafe(mediaCache, cacheKey)
+            NPLogger.w(
+                "NERI-PlayerManager",
+                "异常播放缓存未完全移除: key=$cacheKey, reason=$reason"
+            )
+            return@withContext false
+        }
+        if (cache !== mediaCache || !shouldApplyMutation()) return@withContext false
+        if (!clearPlaybackCacheKeyUnsafe(mediaCache, cacheKey)) {
+            NPLogger.w(
+                "NERI-PlayerManager",
+                "异常播放缓存标记未清除，跳过缓存复用: key=$cacheKey, reason=$reason"
+            )
+            return@withContext false
+        }
         NPLogger.w(
             "NERI-PlayerManager",
             "已移除异常播放缓存: key=$cacheKey, reason=$reason"
         )
         true
     } catch (e: Exception) {
+        if (cache === mediaCache) {
+            markPlaybackCacheKeyUnsafe(mediaCache, cacheKey)
+        }
         NPLogger.w(
             "NERI-PlayerManager",
             "移除异常播放缓存失败: key=$cacheKey, reason=$reason, error=${e.message}"
@@ -1296,8 +1347,9 @@ internal suspend fun PlayerManager.invalidateCachedResourceForPlaybackRecovery(
 
 private suspend fun PlayerManager.invalidateCachedResourceBeforeResolve(
     cacheKey: String,
-    reason: String
-) = invalidateCachedResourceForPlaybackRecovery(cacheKey, reason)
+    reason: String,
+    shouldApplyMutation: () -> Boolean
+) = invalidateCachedResourceForPlaybackRecovery(cacheKey, reason, shouldApplyMutation)
 
 private suspend fun PlayerManager.getNeteaseSongUrl(
     song: SongItem,
@@ -1609,26 +1661,4 @@ private suspend fun PlayerManager.getYouTubeMusicAudioUrl(
         }
         SongUrlResult.Failure
     }
-}
-
-private fun buildBiliRepresentationIdentity(
-    stream: moe.ouom.neriplayer.data.platform.bili.BiliAudioStreamInfo
-): String {
-    return listOf(
-        stream.id?.toString().orEmpty(),
-        stream.qualityTag.orEmpty(),
-        stream.mimeType.trim().lowercase(),
-        stream.bitrateKbps.toString()
-    ).joinToString(separator = "|")
-}
-
-private fun buildYouTubeRepresentationIdentity(
-    playableAudio: moe.ouom.neriplayer.core.api.youtube.YouTubePlayableAudio
-): String {
-    return listOf(
-        playableAudio.mimeType.orEmpty(),
-        playableAudio.bitrateKbps?.toString().orEmpty(),
-        playableAudio.sampleRateHz?.toString().orEmpty(),
-        playableAudio.streamType.name
-    ).joinToString(separator = "|")
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerManagerUrlExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerManagerUrlExtensions.kt
@@ -196,8 +196,6 @@ internal suspend fun PlayerManager.resolveSongUrl(
         return localResult
     }
     val isYouTubeTrack = isYouTubeMusicTrack(song)
-    val resolvedYouTubeQuality = youtubeRecoveryStrategy?.preferredQualityOverride
-        ?: effectiveYouTubeQuality()
     val cacheKey = computeCacheKey(
         song = song,
         youtubeQualityOverride = youtubeRecoveryStrategy?.preferredQualityOverride,
@@ -218,35 +216,47 @@ internal suspend fun PlayerManager.resolveSongUrl(
             reason = "resolve_integrity_check"
         )
     }
-    val hasCachedData = !forceRefresh && cacheIntegrity.isComplete
+    var hasCachedData = !forceRefresh && cacheIntegrity.isComplete
+    if (hasCachedData) {
+        val cachedDescriptor = cache?.readCachedPlaybackDescriptor(cacheKey)
+        val cachedAudioInfo = cachedDescriptor?.toPlaybackAudioInfo {
+            getLocalizedString(it)
+        }
+        val cachedContentLength = cache?.let {
+            ContentMetadata.getContentLength(it.getContentMetadata(cacheKey))
+        } ?: 0L
+        if (
+            cachedAudioInfo == null ||
+            !cachedDescriptor.matchesCachedContentLength(cachedContentLength)
+        ) {
+            NPLogger.w(
+                "NERI-PlayerManager",
+                "完整缓存描述符缺失或长度不匹配，淘汰旧资源并重新解析: key=$cacheKey"
+            )
+            invalidateCachedResourceForPlaybackRecovery(
+                cacheKey = cacheKey,
+                reason = "missing_playback_descriptor"
+            )
+            hasCachedData = false
+        }
+    }
     if (hasCachedData) {
         NPLogger.d(
             "NERI-PlayerManager",
             "命中完整缓存，直接走离线缓存地址: $cacheKey"
         )
-        val cachedAudioInfo = _currentPlaybackAudioInfo.value
-            ?.takeIf { _currentSongFlow.value?.sameIdentityAs(song) == true }
-            ?.takeIf { youtubeRecoveryStrategy == null }
-            ?: when {
-                isYouTubeTrack -> {
-                    buildYouTubeOfflineCacheAudioInfo(resolvedYouTubeQuality) {
-                        getLocalizedString(it)
-                    }
-                }
-
-                !isBiliTrack(song) -> {
-                    buildNeteaseOfflineCacheAudioInfo(effectiveNeteaseQuality()) {
-                        getLocalizedString(it)
-                    }
-                }
-
-                else -> null
-            }
+        val cachedDescriptor = cache?.readCachedPlaybackDescriptor(cacheKey)
+        val cachedAudioInfo = cachedDescriptor?.toPlaybackAudioInfo {
+            getLocalizedString(it)
+        } ?: return SongUrlResult.Failure
         prepareBiliPlaybackSkipsForResolvedPlayback(song, playbackRequestTokenOverride)
         return SongUrlResult.Success(
             url = "$OFFLINE_CACHE_URL_PREFIX$cacheKey",
             durationMs = song.durationMs.takeIf { it > 0L },
             audioInfo = cachedAudioInfo,
+            mimeType = cachedAudioInfo.mimeType,
+            expectedContentLength = cachedDescriptor.expectedContentLength,
+            representationIdentity = cachedDescriptor.representationIdentity,
             cacheKeyOverride = cacheKey
         )
     }
@@ -310,11 +320,16 @@ internal suspend fun PlayerManager.resolveSongUrl(
 
     return if (result is SongUrlResult.Failure && hasCachedData) {
         NPLogger.d("NERI-PlayerManager", "远端解析失败但缓存完整，回退到离线缓存地址: $cacheKey")
-        val fallbackAudioInfo = _currentPlaybackAudioInfo.value
-            ?.takeIf { _currentSongFlow.value?.sameIdentityAs(song) == true }
+        val fallbackDescriptor = cache?.readCachedPlaybackDescriptor(cacheKey)
+        val fallbackAudioInfo = fallbackDescriptor?.toPlaybackAudioInfo {
+            getLocalizedString(it)
+        }
         SongUrlResult.Success(
             url = "$OFFLINE_CACHE_URL_PREFIX$cacheKey",
             audioInfo = fallbackAudioInfo,
+            mimeType = fallbackAudioInfo?.mimeType,
+            expectedContentLength = fallbackDescriptor?.expectedContentLength,
+            representationIdentity = fallbackDescriptor?.representationIdentity,
             cacheKeyOverride = cacheKey,
             durationMs = song.durationMs.takeIf { it > 0L }
         )
@@ -1004,15 +1019,34 @@ private suspend fun PlayerManager.applyResolvedMediaItem(
     )
     val selectedCandidate = currentPlaybackCandidate()
     val selectedUrl = selectedCandidate?.url ?: result.url
+    val selectedAudioInfo = selectedCandidate?.audioInfo ?: audioInfo
+    val selectedMimeType = selectedCandidate?.mimeType ?: mimeType
+    val selectedExpectedContentLength =
+        selectedCandidate?.expectedContentLength ?: expectedContentLength
+    val selectedRepresentationIdentity =
+        selectedCandidate?.representationIdentity ?: result.representationIdentity
     invalidateMismatchedCachedResource(
         cacheKey = cacheKey,
-        expectedContentLength = expectedContentLength,
+        expectedContentLength = selectedExpectedContentLength,
         shouldApplyMutation = { gate.runMutation {} }
     )
-    val mediaItem = buildMediaItem(song, selectedUrl, cacheKey, mimeType)
+    invalidateMismatchedCachedPlaybackDescriptor(
+        cacheKey = cacheKey,
+        audioInfo = selectedAudioInfo,
+        expectedContentLength = selectedExpectedContentLength,
+        representationIdentity = selectedRepresentationIdentity,
+        shouldApplyMutation = { gate.runMutation {} }
+    )
+    persistCachedPlaybackDescriptor(
+        cacheKey = cacheKey,
+        audioInfo = selectedAudioInfo,
+        expectedContentLength = selectedExpectedContentLength,
+        representationIdentity = selectedRepresentationIdentity
+    )
+    val mediaItem = buildMediaItem(song, selectedUrl, cacheKey, selectedMimeType)
 
     if (!gate.runMutation { _currentMediaUrl.value = selectedUrl }) return false
-    if (!gate.runMutation { _currentPlaybackAudioInfo.value = audioInfo }) return false
+    if (!gate.runMutation { _currentPlaybackAudioInfo.value = selectedAudioInfo }) return false
     if (!gate.runMutation { currentMediaUrlResolvedAtMs = SystemClock.elapsedRealtime() }) return false
     if (!gate.runSuspendingMutation { persistState() }) return false
 
@@ -1450,9 +1484,11 @@ private suspend fun PlayerManager.getBiliAudioUrl(
                 url = audioStream.url,
                 candidateUrls = audioStream.candidateUrls,
                 mimeType = audioStream.mimeType,
+                expectedContentLength = null,
                 audioInfo = buildBiliPlaybackAudioInfo(audioStream, availableStreams) {
                     getLocalizedString(it)
-                }
+                },
+                representationIdentity = buildBiliRepresentationIdentity(audioStream)
             )
         } else {
             if (!suppressError) {
@@ -1531,6 +1567,7 @@ private suspend fun PlayerManager.getYouTubeMusicAudioUrl(
                 audioInfo = buildYouTubePlaybackAudioInfo(resolvedPlayableAudio) {
                     getLocalizedString(it)
                 },
+                representationIdentity = buildYouTubeRepresentationIdentity(resolvedPlayableAudio),
                 cacheKeyOverride = youtubeRecoveryStrategy?.let { strategy ->
                     computeYouTubeCacheKey(
                         videoId = videoId,
@@ -1572,4 +1609,26 @@ private suspend fun PlayerManager.getYouTubeMusicAudioUrl(
         }
         SongUrlResult.Failure
     }
+}
+
+private fun buildBiliRepresentationIdentity(
+    stream: moe.ouom.neriplayer.data.platform.bili.BiliAudioStreamInfo
+): String {
+    return listOf(
+        stream.id?.toString().orEmpty(),
+        stream.qualityTag.orEmpty(),
+        stream.mimeType.trim().lowercase(),
+        stream.bitrateKbps.toString()
+    ).joinToString(separator = "|")
+}
+
+private fun buildYouTubeRepresentationIdentity(
+    playableAudio: moe.ouom.neriplayer.core.api.youtube.YouTubePlayableAudio
+): String {
+    return listOf(
+        playableAudio.mimeType.orEmpty(),
+        playableAudio.bitrateKbps?.toString().orEmpty(),
+        playableAudio.sampleRateHz?.toString().orEmpty(),
+        playableAudio.streamType.name
+    ).joinToString(separator = "|")
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerUrlResolver.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerUrlResolver.kt
@@ -2,6 +2,7 @@ package moe.ouom.neriplayer.core.player.url
 
 import android.net.Uri
 import moe.ouom.neriplayer.R
+import moe.ouom.neriplayer.core.api.youtube.YouTubePlayableAudio
 import moe.ouom.neriplayer.core.player.model.PlaybackAudioInfo
 import moe.ouom.neriplayer.core.player.model.PlaybackAudioSource
 import moe.ouom.neriplayer.core.player.model.PlaybackQualityOption
@@ -11,6 +12,7 @@ import moe.ouom.neriplayer.core.player.model.estimateBitrateKbps
 import moe.ouom.neriplayer.core.player.model.inferYouTubeQualityKeyFromBitrate
 import moe.ouom.neriplayer.data.platform.bili.BiliAudioStreamInfo
 import moe.ouom.neriplayer.core.player.resolver.netease.NeteasePlaybackResponseParser
+import java.net.URLDecoder
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -167,6 +169,41 @@ internal fun buildYouTubePlaybackAudioInfo(
         sampleRateHz = playableAudio.sampleRateHz
     )
 }
+
+internal fun buildBiliRepresentationIdentity(stream: BiliAudioStreamInfo): String {
+    return listOf(
+        stream.id?.toString().orEmpty(),
+        stream.qualityTag.orEmpty().trim().lowercase(),
+        stream.mimeType.trim().lowercase(),
+        stream.bitrateKbps.toString()
+    ).joinToString(separator = "|")
+}
+
+internal fun buildYouTubeRepresentationIdentity(playableAudio: YouTubePlayableAudio): String {
+    return listOf(
+        extractYouTubeRepresentationItag(playableAudio.url).orEmpty(),
+        playableAudio.mimeType.orEmpty().trim().lowercase(),
+        playableAudio.bitrateKbps?.toString().orEmpty(),
+        playableAudio.sampleRateHz?.toString().orEmpty(),
+        playableAudio.streamType.name
+    ).joinToString(separator = "|")
+}
+
+private fun extractYouTubeRepresentationItag(url: String): String? {
+    val decodedUrl = runCatching {
+        URLDecoder.decode(url, Charsets.UTF_8.name())
+    }.getOrElse { url }
+    return youtubeItagQueryPattern.findAll(decodedUrl)
+        .lastOrNull()
+        ?.groupValues
+        ?.getOrNull(1)
+        ?: youtubeItagPathPattern.find(decodedUrl)
+            ?.groupValues
+            ?.getOrNull(1)
+}
+
+private val youtubeItagQueryPattern = Regex("""(?:^|[;/?&])itag=(\d+)""")
+private val youtubeItagPathPattern = Regex("""/itag/(\d+)""")
 
 internal fun buildYouTubeOfflineCacheAudioInfo(
     preferredQualityKey: String,

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/watchdog/PlayerManagerStartupWatchdogExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/watchdog/PlayerManagerStartupWatchdogExtensions.kt
@@ -25,10 +25,9 @@ import moe.ouom.neriplayer.core.player.policy.refresh.YouTubePlaybackRecoveryStr
 import moe.ouom.neriplayer.core.player.url.YOUTUBE_STABLE_RECOVERY_QUALITY
 import moe.ouom.neriplayer.core.player.url.currentPlaybackCacheKeyForRecovery
 import moe.ouom.neriplayer.core.player.url.invalidateCachedResourceForPlaybackRecovery
-import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedResource
-import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedPlaybackDescriptor
+import moe.ouom.neriplayer.core.player.url.allowsCustomCacheKey
 import moe.ouom.neriplayer.core.player.url.offlineCacheKeyFromUrl
-import moe.ouom.neriplayer.core.player.url.persistCachedPlaybackDescriptor
+import moe.ouom.neriplayer.core.player.url.synchronizeCachedPlaybackDescriptor
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathState
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathTracker
 import moe.ouom.neriplayer.core.player.usb.session.UsbExclusiveSessionController
@@ -379,30 +378,28 @@ private suspend fun PlayerManager.applyPlaybackCandidate(
     ) {
         invalidateCachedResourceForPlaybackRecovery(
             cacheKey = staleCacheKey.orEmpty(),
-            reason = recoveryReason
+            reason = recoveryReason,
+            shouldApplyMutation = { requestToken == playbackRequestToken }
         )
     }
     if (requestToken != playbackRequestToken) return
-    invalidateMismatchedCachedResource(
-        cacheKey = cacheKey,
-        expectedContentLength = candidate.expectedContentLength
-    )
-    invalidateMismatchedCachedPlaybackDescriptor(
+    val cacheSynchronization = synchronizeCachedPlaybackDescriptor(
         cacheKey = cacheKey,
         audioInfo = candidate.audioInfo,
         expectedContentLength = candidate.expectedContentLength,
-        representationIdentity = candidate.representationIdentity
+        representationIdentity = candidate.representationIdentity,
+        shouldApplyMutation = { requestToken == playbackRequestToken }
     )
     if (requestToken != playbackRequestToken) return
-    persistCachedPlaybackDescriptor(
-        cacheKey = cacheKey,
-        audioInfo = candidate.audioInfo,
-        expectedContentLength = candidate.expectedContentLength,
-        representationIdentity = candidate.representationIdentity
-    )
     _currentPlaybackAudioInfo.value = candidate.audioInfo
     updateAudioOffloadPreferences("playback_candidate_source")
-    val mediaItem = buildMediaItem(song, candidate.url, cacheKey, candidate.mimeType)
+    val mediaItem = buildMediaItem(
+        song = song,
+        url = candidate.url,
+        cacheKey = cacheKey,
+        mimeType = candidate.mimeType,
+        allowCustomCacheKey = cacheSynchronization.allowsCustomCacheKey()
+    )
     preparePlayerForManagedStart(resolvePlaybackStartPlan(shouldFadeIn = false, fadeDurationMs = 0L))
     resetTrackEndDeduplicationState()
     applyWakeModeForPlaybackUrl(candidate.url)

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/watchdog/PlayerManagerStartupWatchdogExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/watchdog/PlayerManagerStartupWatchdogExtensions.kt
@@ -26,6 +26,9 @@ import moe.ouom.neriplayer.core.player.url.YOUTUBE_STABLE_RECOVERY_QUALITY
 import moe.ouom.neriplayer.core.player.url.currentPlaybackCacheKeyForRecovery
 import moe.ouom.neriplayer.core.player.url.invalidateCachedResourceForPlaybackRecovery
 import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedResource
+import moe.ouom.neriplayer.core.player.url.invalidateMismatchedCachedPlaybackDescriptor
+import moe.ouom.neriplayer.core.player.url.offlineCacheKeyFromUrl
+import moe.ouom.neriplayer.core.player.url.persistCachedPlaybackDescriptor
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathState
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathTracker
 import moe.ouom.neriplayer.core.player.usb.session.UsbExclusiveSessionController
@@ -53,6 +56,14 @@ internal fun PlayerManager.clearActivePlaybackCandidates() {
     activePlaybackCommandSource = PlaybackCommandSource.LOCAL
     startupStallRecoveryAttempts = 0
     resetPlaybackProgressAdvanceBaseline(0L)
+}
+
+internal fun shouldInvalidateOfflineCacheForStartupStall(
+    recoveryAttempt: Int,
+    currentUrl: String?
+): Boolean {
+    return recoveryAttempt == 1 &&
+        offlineCacheKeyFromUrl(currentUrl) != null
 }
 
 internal fun PlayerManager.currentPlaybackCandidate(): PlaybackUrlCandidate? {
@@ -188,6 +199,31 @@ private fun PlayerManager.recoverPlaybackStartupStall(requestToken: Long) {
     if (requestToken != playbackRequestToken) return
     startupStallRecoveryAttempts += 1
 
+    val offlineCacheKey = offlineCacheKeyFromUrl(_currentMediaUrl.value)
+    if (
+        offlineCacheKey != null &&
+        shouldInvalidateOfflineCacheForStartupStall(
+            recoveryAttempt = startupStallRecoveryAttempts,
+            currentUrl = _currentMediaUrl.value
+        )
+    ) {
+        val song = _currentSongFlow.value
+        if (song != null && !isLocalSong(song)) {
+            val resumePositionMs = player.currentPosition.coerceAtLeast(0L)
+            refreshCurrentSongUrl(
+                resumePositionMs = resumePositionMs,
+                allowFallback = false,
+                reason = "startup_stall_offline_cache",
+                bypassCooldown = true,
+                fallbackSeekPositionMs = resumePositionMs,
+                resumePlaybackAfterRefresh = true,
+                resumedPlaybackCommandSource = activePlaybackCommandSource,
+                cacheKeyToInvalidateBeforeResolve = offlineCacheKey
+            )
+            return
+        }
+    }
+
     if (tryRecoverUsbExclusiveStartupStall(requestToken)) {
         return
     }
@@ -238,7 +274,8 @@ private fun PlayerManager.recoverPlaybackStartupStall(requestToken: Long) {
             fallbackSeekPositionMs = resumePositionMs,
             resumePlaybackAfterRefresh = true,
             resumedPlaybackCommandSource = activePlaybackCommandSource,
-            youtubeRecoveryStrategy = stallRecoveryStrategy
+            youtubeRecoveryStrategy = stallRecoveryStrategy,
+            cacheKeyToInvalidateBeforeResolve = null
         )
         return
     }
@@ -350,7 +387,19 @@ private suspend fun PlayerManager.applyPlaybackCandidate(
         cacheKey = cacheKey,
         expectedContentLength = candidate.expectedContentLength
     )
+    invalidateMismatchedCachedPlaybackDescriptor(
+        cacheKey = cacheKey,
+        audioInfo = candidate.audioInfo,
+        expectedContentLength = candidate.expectedContentLength,
+        representationIdentity = candidate.representationIdentity
+    )
     if (requestToken != playbackRequestToken) return
+    persistCachedPlaybackDescriptor(
+        cacheKey = cacheKey,
+        audioInfo = candidate.audioInfo,
+        expectedContentLength = candidate.expectedContentLength,
+        representationIdentity = candidate.representationIdentity
+    )
     _currentPlaybackAudioInfo.value = candidate.audioInfo
     updateAudioOffloadPreferences("playback_candidate_source")
     val mediaItem = buildMediaItem(song, candidate.url, cacheKey, candidate.mimeType)

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptorTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptorTest.kt
@@ -1,15 +1,39 @@
 package moe.ouom.neriplayer.core.player.url
 
+import androidx.media3.datasource.cache.Cache
+import androidx.media3.datasource.cache.CacheSpan
+import androidx.media3.datasource.cache.ContentMetadataMutations
+import androidx.media3.datasource.cache.DefaultContentMetadata
+import java.io.File
+import java.util.TreeSet
+import kotlinx.coroutines.runBlocking
+import moe.ouom.neriplayer.core.api.youtube.YouTubePlayableAudio
+import moe.ouom.neriplayer.core.api.youtube.YouTubePlayableStreamType
+import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.core.player.model.PlaybackAudioInfo
 import moe.ouom.neriplayer.core.player.model.PlaybackAudioSource
 import moe.ouom.neriplayer.core.player.model.PlaybackQualityOption
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 
 class CachedPlaybackDescriptorTest {
+
+    @After
+    fun clearCacheReference() {
+        PlayerManager.cache = null
+    }
 
     @Test
     fun `descriptor round trip restores actual quality and mime`() {
@@ -145,5 +169,420 @@ class CachedPlaybackDescriptorTest {
 
         assertTrue(descriptor.matchesCachedContentLength(4_268_241L))
         assertTrue(!descriptor.matchesCachedContentLength(2_506_865L))
+    }
+
+    @Test
+    fun `descriptor rejects a current representation with missing identity`() {
+        val descriptor = cachedPlaybackDescriptorFromAudioInfo(
+            audioInfo = PlaybackAudioInfo(
+                source = PlaybackAudioSource.YOUTUBE_MUSIC,
+                qualityKey = "high",
+                mimeType = "audio/mp4",
+                bitrateKbps = 128,
+                sampleRateHz = 44_100
+            ),
+            expectedContentLength = 3_606_154L,
+            representationIdentity = "140|audio/mp4|128|44100|DIRECT"
+        )
+
+        assertFalse(
+            descriptor.matches(
+                audioInfo = PlaybackAudioInfo(
+                    source = PlaybackAudioSource.YOUTUBE_MUSIC,
+                    qualityKey = "high",
+                    mimeType = "audio/mp4",
+                    bitrateKbps = 128,
+                    sampleRateHz = 44_100
+                ),
+                expectedContentLength = 3_606_154L,
+                representationIdentity = null
+            )
+        )
+    }
+
+    @Test
+    fun `descriptor rejects a current representation with missing content length`() {
+        val audioInfo = PlaybackAudioInfo(
+            source = PlaybackAudioSource.BILIBILI,
+            qualityKey = "high",
+            mimeType = "audio/mp4",
+            bitrateKbps = 192
+        )
+        val descriptor = cachedPlaybackDescriptorFromAudioInfo(
+            audioInfo = audioInfo,
+            expectedContentLength = 2_000_000L,
+            representationIdentity = "new-representation"
+        )
+
+        assertFalse(
+            descriptor.matches(
+                audioInfo = audioInfo,
+                expectedContentLength = null,
+                representationIdentity = "new-representation"
+            )
+        )
+    }
+
+    @Test
+    fun `descriptor match ignores available quality options`() {
+        val descriptor = cachedPlaybackDescriptorFromAudioInfo(
+            audioInfo = biliAudioInfo().copy(
+                qualityOptions = listOf(PlaybackQualityOption("high", "high"))
+            ),
+            expectedContentLength = 2_000_000L,
+            representationIdentity = "new-representation"
+        )
+
+        assertTrue(
+            descriptor.matches(
+                audioInfo = biliAudioInfo().copy(
+                    qualityOptions = listOf(
+                        PlaybackQualityOption("high", "high"),
+                        PlaybackQualityOption("medium", "medium")
+                    )
+                ),
+                expectedContentLength = 2_000_000L,
+                representationIdentity = "new-representation"
+            )
+        )
+    }
+
+    @Test
+    fun `only applied or metadata-free synchronization allows cache writes`() {
+        assertTrue(CachedPlaybackDescriptorSynchronizationResult.APPLIED.allowsCustomCacheKey())
+        assertTrue(CachedPlaybackDescriptorSynchronizationResult.NO_METADATA.allowsCustomCacheKey())
+        assertFalse(CachedPlaybackDescriptorSynchronizationResult.SKIPPED.allowsCustomCacheKey())
+        assertFalse(CachedPlaybackDescriptorSynchronizationResult.CACHE_UNUSABLE.allowsCustomCacheKey())
+    }
+
+    @Test
+    fun `descriptor synchronization does not overwrite metadata when stale cache removal fails`() = runBlocking {
+        val cacheKey = "stale-cache"
+        val cachedFile = temporaryFile(length = 1)
+        val mediaCache = cacheWithSpan(cacheKey, cachedFile)
+        doThrow(IllegalStateException("cache removal failed"))
+            .`when`(mediaCache)
+            .removeResource(cacheKey)
+        PlayerManager.cache = mediaCache
+
+        try {
+            val result = PlayerManager.synchronizeCachedPlaybackDescriptor(
+                cacheKey = cacheKey,
+                audioInfo = biliAudioInfo(),
+                expectedContentLength = 2_000_000L,
+                representationIdentity = "new-representation"
+            )
+
+            assertEquals(CachedPlaybackDescriptorSynchronizationResult.CACHE_UNUSABLE, result)
+            assertTrue(PlayerManager.isPlaybackCacheKeyUnsafe(cacheKey))
+            assertNull(PlayerManager.safeCustomPlaybackCacheKey(cacheKey))
+            verify(mediaCache).removeResource(cacheKey)
+            val mutations = ArgumentCaptor.forClass(ContentMetadataMutations::class.java)
+            verify(mediaCache).applyContentMetadataMutations(
+                org.mockito.ArgumentMatchers.eq(cacheKey),
+                mutations.capture()
+            )
+            assertEquals(
+                "1",
+                mutations.value.editedValues[CACHED_PLAYBACK_CACHE_UNSAFE_METADATA_KEY]
+            )
+            assertFalse(
+                mutations.value.editedValues.containsKey(CACHED_PLAYBACK_DESCRIPTOR_METADATA_KEY)
+            )
+        } finally {
+            cachedFile.delete()
+        }
+    }
+
+    @Test
+    fun `descriptor synchronization does not mutate cache after ownership is lost`() = runBlocking {
+        val cacheKey = "stale-cache"
+        val cachedFile = temporaryFile(length = 1)
+        val mediaCache = cacheWithSpan(cacheKey, cachedFile)
+        PlayerManager.cache = mediaCache
+
+        try {
+            PlayerManager.synchronizeCachedPlaybackDescriptor(
+                cacheKey = cacheKey,
+                audioInfo = biliAudioInfo(),
+                expectedContentLength = 2_000_000L,
+                representationIdentity = "new-representation",
+                shouldApplyMutation = { false }
+            )
+
+            verify(mediaCache, never()).removeResource(cacheKey)
+            verify(mediaCache, never()).applyContentMetadataMutations(
+                org.mockito.ArgumentMatchers.eq(cacheKey),
+                org.mockito.ArgumentMatchers.any(ContentMetadataMutations::class.java)
+            )
+        } finally {
+            cachedFile.delete()
+        }
+    }
+
+    @Test
+    fun `descriptor synchronization rechecks ownership before writing replacement metadata`() = runBlocking {
+        val cacheKey = "stale-cache"
+        val cachedFile = temporaryFile(length = 1)
+        val initialSpans = cachedSpans(cacheKey, cachedFile)
+        val emptySpans = TreeSet<CacheSpan>()
+        val mediaCache = mock(Cache::class.java)
+        `when`(mediaCache.getCachedSpans(cacheKey)).thenReturn(initialSpans, emptySpans)
+        `when`(mediaCache.getContentMetadata(cacheKey)).thenReturn(
+            contentMetadata(length = 1_000_000L)
+        )
+        var ownershipChecks = 0
+        PlayerManager.cache = mediaCache
+
+        try {
+            val result = PlayerManager.synchronizeCachedPlaybackDescriptor(
+                cacheKey = cacheKey,
+                audioInfo = biliAudioInfo(),
+                expectedContentLength = 2_000_000L,
+                representationIdentity = "new-representation",
+                shouldApplyMutation = { ++ownershipChecks < 3 }
+            )
+
+            assertEquals(CachedPlaybackDescriptorSynchronizationResult.SKIPPED, result)
+            verify(mediaCache).removeResource(cacheKey)
+            verify(mediaCache, never()).applyContentMetadataMutations(
+                org.mockito.ArgumentMatchers.eq(cacheKey),
+                org.mockito.ArgumentMatchers.any(ContentMetadataMutations::class.java)
+            )
+        } finally {
+            cachedFile.delete()
+        }
+    }
+
+    @Test
+    fun `youtube representation identity distinguishes matching formats with different itags`() {
+        val first = YouTubePlayableAudio(
+            url = "https://googlevideo.example/videoplayback?itag=140",
+            mimeType = "audio/mp4",
+            bitrateKbps = 128,
+            sampleRateHz = 44_100,
+            streamType = YouTubePlayableStreamType.DIRECT
+        )
+        val second = first.copy(
+            url = "https://googlevideo.example/videoplayback?itag=141"
+        )
+
+        assertFalse(buildYouTubeRepresentationIdentity(first) == buildYouTubeRepresentationIdentity(second))
+    }
+
+    @Test
+    fun `persisted unsafe cache key is reloaded after cache recreation`() = runBlocking {
+        val cacheKey = "stale-cache"
+        val mediaCache = mock(Cache::class.java)
+        `when`(mediaCache.getContentMetadata(cacheKey)).thenReturn(
+            contentMetadata(
+                customValues = mapOf(
+                    CACHED_PLAYBACK_CACHE_UNSAFE_METADATA_KEY to "1"
+                )
+            )
+        )
+        PlayerManager.cache = mediaCache
+
+        assertTrue(PlayerManager.loadPlaybackCacheKeySafety(cacheKey))
+        assertTrue(PlayerManager.isPlaybackCacheKeyUnsafe(cacheKey))
+        assertNull(PlayerManager.safeCustomPlaybackCacheKey(cacheKey))
+        verify(mediaCache, never()).applyContentMetadataMutations(
+            org.mockito.ArgumentMatchers.eq(cacheKey),
+            org.mockito.ArgumentMatchers.any(ContentMetadataMutations::class.java)
+        )
+    }
+
+    @Test
+    fun `custom cache key remains available when no cache is initialized`() {
+        PlayerManager.cache = null
+        assertEquals("remote-cache", PlayerManager.safeCustomPlaybackCacheKey("remote-cache"))
+    }
+
+    @Test
+    fun `custom cache key only checks the in memory safety state`() {
+        val cacheKey = "remote-cache"
+        val mediaCache = mock(Cache::class.java)
+        PlayerManager.cache = mediaCache
+
+        assertEquals(cacheKey, PlayerManager.safeCustomPlaybackCacheKey(cacheKey))
+        verify(mediaCache, never()).getContentMetadata(cacheKey)
+    }
+
+    @Test
+    fun `synchronization keeps a safe custom cache key without audio metadata`() = runBlocking {
+        val cacheKey = "listen-together-cache"
+        val mediaCache = mock(Cache::class.java)
+        `when`(mediaCache.getContentMetadata(cacheKey)).thenReturn(DefaultContentMetadata.EMPTY)
+        PlayerManager.cache = mediaCache
+
+        val result = PlayerManager.synchronizeCachedPlaybackDescriptor(
+            cacheKey = cacheKey,
+            audioInfo = null,
+            expectedContentLength = null,
+            representationIdentity = null
+        )
+
+        assertEquals(CachedPlaybackDescriptorSynchronizationResult.NO_METADATA, result)
+        assertTrue(result.allowsCustomCacheKey())
+        assertEquals(cacheKey, PlayerManager.safeCustomPlaybackCacheKey(cacheKey))
+        verify(mediaCache, never()).applyContentMetadataMutations(
+            org.mockito.ArgumentMatchers.eq(cacheKey),
+            org.mockito.ArgumentMatchers.any(ContentMetadataMutations::class.java)
+        )
+    }
+
+    @Test
+    fun `synchronization leaves an unsafe marker untouched without audio metadata`() = runBlocking {
+        val cacheKey = "stale-cache"
+        val mediaCache = mock(Cache::class.java)
+        `when`(mediaCache.getCachedSpans(cacheKey)).thenReturn(TreeSet())
+        `when`(mediaCache.getContentMetadata(cacheKey)).thenReturn(
+            contentMetadata(
+                customValues = mapOf(
+                    CACHED_PLAYBACK_CACHE_UNSAFE_METADATA_KEY to "1"
+                )
+            )
+        )
+        PlayerManager.cache = mediaCache
+
+        val result = PlayerManager.synchronizeCachedPlaybackDescriptor(
+            cacheKey = cacheKey,
+            audioInfo = null,
+            expectedContentLength = 1L,
+            representationIdentity = null
+        )
+
+        assertEquals(CachedPlaybackDescriptorSynchronizationResult.NO_METADATA, result)
+        assertTrue(result.allowsCustomCacheKey())
+        assertNull(PlayerManager.safeCustomPlaybackCacheKey(cacheKey))
+        verify(mediaCache, never()).applyContentMetadataMutations(
+            org.mockito.ArgumentMatchers.eq(cacheKey),
+            org.mockito.ArgumentMatchers.any(ContentMetadataMutations::class.java)
+        )
+    }
+
+    @Test
+    fun `unsafe cache key is cleared after a successful replacement`() = runBlocking {
+        val cacheKey = "stale-cache"
+        val staleFile = temporaryFile(length = 1)
+        val initialSpans = cachedSpans(cacheKey, staleFile)
+        val emptySpans = TreeSet<CacheSpan>()
+        val mediaCache = mock(Cache::class.java)
+        `when`(mediaCache.getCachedSpans(cacheKey)).thenReturn(initialSpans, emptySpans)
+        `when`(mediaCache.getContentMetadata(cacheKey)).thenReturn(
+            contentMetadata(length = 1_000_000L)
+        )
+        PlayerManager.cache = mediaCache
+        PlayerManager.markPlaybackCacheKeyUnsafe(mediaCache, cacheKey)
+
+        try {
+            val result = PlayerManager.synchronizeCachedPlaybackDescriptor(
+                cacheKey = cacheKey,
+                audioInfo = biliAudioInfo(),
+                expectedContentLength = 2_000_000L,
+                representationIdentity = "new-representation"
+            )
+
+            assertEquals(CachedPlaybackDescriptorSynchronizationResult.APPLIED, result)
+            assertFalse(PlayerManager.isPlaybackCacheKeyUnsafe(cacheKey))
+            assertEquals(cacheKey, PlayerManager.safeCustomPlaybackCacheKey(cacheKey))
+            verify(mediaCache).removeResource(cacheKey)
+            val mutations = ArgumentCaptor.forClass(ContentMetadataMutations::class.java)
+            verify(mediaCache, times(2)).applyContentMetadataMutations(
+                org.mockito.ArgumentMatchers.eq(cacheKey),
+                mutations.capture()
+            )
+            assertTrue(
+                mutations.allValues.any { mutation ->
+                    CACHED_PLAYBACK_DESCRIPTOR_METADATA_KEY in mutation.editedValues &&
+                        CACHED_PLAYBACK_CACHE_UNSAFE_METADATA_KEY in mutation.removedValues
+                }
+            )
+        } finally {
+            staleFile.delete()
+        }
+    }
+
+    @Test
+    fun `descriptor synchronization does not mutate a cache replaced during inspection`() = runBlocking {
+        val cacheKey = "stale-cache"
+        val cachedFile = temporaryFile(length = 1)
+        val replacementCache = mock(Cache::class.java)
+        val staleCache = mock(Cache::class.java)
+        `when`(staleCache.getCachedSpans(cacheKey)).thenAnswer {
+            PlayerManager.cache = replacementCache
+            cachedSpans(cacheKey, cachedFile)
+        }
+        `when`(staleCache.getContentMetadata(cacheKey)).thenReturn(
+            contentMetadata(length = 1_000_000L)
+        )
+        PlayerManager.cache = staleCache
+
+        try {
+            val result = PlayerManager.synchronizeCachedPlaybackDescriptor(
+                cacheKey = cacheKey,
+                audioInfo = biliAudioInfo(),
+                expectedContentLength = 2_000_000L,
+                representationIdentity = "new-representation"
+            )
+
+            assertEquals(CachedPlaybackDescriptorSynchronizationResult.SKIPPED, result)
+            verify(staleCache, never()).removeResource(cacheKey)
+            verify(staleCache, never()).applyContentMetadataMutations(
+                org.mockito.ArgumentMatchers.eq(cacheKey),
+                org.mockito.ArgumentMatchers.any(ContentMetadataMutations::class.java)
+            )
+            verify(replacementCache, never()).applyContentMetadataMutations(
+                org.mockito.ArgumentMatchers.eq(cacheKey),
+                org.mockito.ArgumentMatchers.any(ContentMetadataMutations::class.java)
+            )
+        } finally {
+            cachedFile.delete()
+        }
+    }
+
+    private fun biliAudioInfo() = PlaybackAudioInfo(
+        source = PlaybackAudioSource.BILIBILI,
+        qualityKey = "high",
+        mimeType = "audio/mp4",
+        bitrateKbps = 192
+    )
+
+    private fun cacheWithSpan(cacheKey: String, cachedFile: File): Cache {
+        val mediaCache = mock(Cache::class.java)
+        val spans = cachedSpans(cacheKey, cachedFile)
+        `when`(mediaCache.getCachedSpans(cacheKey)).thenReturn(spans)
+        `when`(mediaCache.getContentMetadata(cacheKey)).thenReturn(
+            contentMetadata(length = 1_000_000L)
+        )
+        return mediaCache
+    }
+
+    private fun cachedSpans(cacheKey: String, cachedFile: File): TreeSet<CacheSpan> {
+        return TreeSet<CacheSpan>().apply {
+            add(CacheSpan(cacheKey, 0L, 1L, 0L, cachedFile))
+        }
+    }
+
+    private fun contentMetadata(
+        length: Long = 0L,
+        customValues: Map<String, String> = emptyMap()
+    ): DefaultContentMetadata {
+        val mutations = ContentMetadataMutations()
+        if (length > 0L) {
+            ContentMetadataMutations.setContentLength(mutations, length)
+        }
+        customValues.forEach { (key, value) ->
+            mutations.set(key, value)
+        }
+        return DefaultContentMetadata.EMPTY.copyWithMutationsApplied(mutations)
+    }
+
+    private fun temporaryFile(length: Int): File {
+        return File.createTempFile("neriplayer-descriptor-cache", ".exo").also { file ->
+            file.outputStream().use { output ->
+                output.write(ByteArray(length))
+            }
+        }
     }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptorTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptorTest.kt
@@ -1,0 +1,149 @@
+package moe.ouom.neriplayer.core.player.url
+
+import moe.ouom.neriplayer.core.player.model.PlaybackAudioInfo
+import moe.ouom.neriplayer.core.player.model.PlaybackAudioSource
+import moe.ouom.neriplayer.core.player.model.PlaybackQualityOption
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CachedPlaybackDescriptorTest {
+
+    @Test
+    fun `descriptor round trip restores actual quality and mime`() {
+        val audioInfo = PlaybackAudioInfo(
+            source = PlaybackAudioSource.BILIBILI,
+            qualityKey = "hires",
+            qualityLabel = "hires",
+            qualityOptions = listOf(
+                PlaybackQualityOption("hires", "hires"),
+                PlaybackQualityOption("high", "high")
+            ),
+            codecLabel = "FLAC",
+            mimeType = "audio/flac",
+            bitrateKbps = 1_024
+        )
+        val descriptor = cachedPlaybackDescriptorFromAudioInfo(
+            audioInfo = audioInfo,
+            expectedContentLength = 4_268_241L,
+            representationIdentity = "id-30251|hires|audio/flac|1024"
+        )
+
+        val decoded = decodeCachedPlaybackDescriptor(encodeCachedPlaybackDescriptor(descriptor))
+        val restored = decoded?.toPlaybackAudioInfo { it.toString() }
+
+        assertNotNull(decoded)
+        assertEquals(PlaybackAudioSource.BILIBILI, restored?.source)
+        assertEquals("hires", restored?.qualityKey)
+        assertEquals("audio/flac", restored?.mimeType)
+        assertEquals(2, restored?.qualityOptions?.size)
+    }
+
+    @Test
+    fun `tampered descriptor is rejected`() {
+        val descriptor = cachedPlaybackDescriptorFromAudioInfo(
+            audioInfo = PlaybackAudioInfo(
+                source = PlaybackAudioSource.NETEASE,
+                qualityKey = "hires",
+                mimeType = "audio/flac"
+            ),
+            expectedContentLength = 100L,
+            representationIdentity = "netease-hires"
+        )
+        val encoded = encodeCachedPlaybackDescriptor(descriptor)
+            .replace("hires", "standard")
+
+        assertNull(
+            decodeCachedPlaybackDescriptor(encoded)?.toPlaybackAudioInfo { it.toString() }
+        )
+    }
+
+    @Test
+    fun `descriptor match distinguishes actual representation identity`() {
+        val audioInfo = PlaybackAudioInfo(
+            source = PlaybackAudioSource.BILIBILI,
+            qualityKey = "high",
+            mimeType = "audio/mp4",
+            bitrateKbps = 192
+        )
+        val descriptor = cachedPlaybackDescriptorFromAudioInfo(
+            audioInfo = audioInfo,
+            expectedContentLength = null,
+            representationIdentity = "id-30280|high|audio/mp4|192"
+        )
+
+        assertTrue(
+            descriptor.matches(
+                audioInfo = audioInfo,
+                expectedContentLength = null,
+                representationIdentity = "id-30280|high|audio/mp4|192"
+            )
+        )
+        assertTrue(
+            !descriptor.matches(
+                audioInfo = audioInfo,
+                expectedContentLength = null,
+                representationIdentity = "id-30232|medium|audio/mp4|128"
+            )
+        )
+    }
+
+    @Test
+    fun `legacy descriptor without representation identity remains readable`() {
+        val descriptor = cachedPlaybackDescriptorFromAudioInfo(
+            audioInfo = PlaybackAudioInfo(
+                source = PlaybackAudioSource.NETEASE,
+                qualityKey = "exhigh",
+                mimeType = "audio/mp4"
+            ),
+            expectedContentLength = null,
+            representationIdentity = null
+        )
+
+        assertNotNull(descriptor.toPlaybackAudioInfo { it.toString() })
+    }
+
+    @Test
+    fun `offline cache result preserves descriptor identity for replay`() {
+        val descriptor = cachedPlaybackDescriptorFromAudioInfo(
+            audioInfo = PlaybackAudioInfo(
+                source = PlaybackAudioSource.BILIBILI,
+                qualityKey = "high",
+                mimeType = "audio/mp4",
+                bitrateKbps = 196
+            ),
+            expectedContentLength = 4_268_241L,
+            representationIdentity = "30280|high|audio/mp4|196"
+        )
+        val decoded = decodeCachedPlaybackDescriptor(encodeCachedPlaybackDescriptor(descriptor))
+        val decodedDescriptor = decoded ?: error("descriptor did not decode")
+        val restored = decodedDescriptor.toPlaybackAudioInfo { it.toString() }
+
+        assertEquals(4_268_241L, decodedDescriptor.expectedContentLength)
+        assertEquals("30280|high|audio/mp4|196", decodedDescriptor.representationIdentity)
+        assertTrue(
+            decodedDescriptor.matches(
+                audioInfo = restored ?: error("descriptor did not restore audio info"),
+                expectedContentLength = decodedDescriptor.expectedContentLength,
+                representationIdentity = decodedDescriptor.representationIdentity
+            )
+        )
+    }
+
+    @Test
+    fun `descriptor rejects a different cached content length`() {
+        val descriptor = cachedPlaybackDescriptorFromAudioInfo(
+            audioInfo = PlaybackAudioInfo(
+                source = PlaybackAudioSource.BILIBILI,
+                qualityKey = "high",
+                mimeType = "audio/mp4"
+            ),
+            expectedContentLength = 4_268_241L
+        )
+
+        assertTrue(descriptor.matchesCachedContentLength(4_268_241L))
+        assertTrue(!descriptor.matchesCachedContentLength(2_506_865L))
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptorTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptorTest.kt
@@ -33,6 +33,7 @@ class CachedPlaybackDescriptorTest {
     @After
     fun clearCacheReference() {
         PlayerManager.cache = null
+        clearPlaybackCacheSafetyForTesting()
     }
 
     @Test
@@ -201,7 +202,7 @@ class CachedPlaybackDescriptorTest {
     }
 
     @Test
-    fun `descriptor rejects a current representation with missing content length`() {
+    fun `descriptor match allows a current representation with missing content length`() {
         val audioInfo = PlaybackAudioInfo(
             source = PlaybackAudioSource.BILIBILI,
             qualityKey = "high",
@@ -214,10 +215,28 @@ class CachedPlaybackDescriptorTest {
             representationIdentity = "new-representation"
         )
 
-        assertFalse(
+        assertTrue(
             descriptor.matches(
                 audioInfo = audioInfo,
                 expectedContentLength = null,
+                representationIdentity = "new-representation"
+            )
+        )
+    }
+
+    @Test
+    fun `descriptor match allows a cached representation with missing content length`() {
+        val audioInfo = biliAudioInfo()
+        val descriptor = cachedPlaybackDescriptorFromAudioInfo(
+            audioInfo = audioInfo,
+            expectedContentLength = null,
+            representationIdentity = "new-representation"
+        )
+
+        assertTrue(
+            descriptor.matches(
+                audioInfo = audioInfo,
+                expectedContentLength = 2_000_000L,
                 representationIdentity = "new-representation"
             )
         )

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerManagerCachePrefetchPreparationTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerManagerCachePrefetchPreparationTest.kt
@@ -15,6 +15,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
@@ -31,7 +32,7 @@ class PlayerManagerCachePrefetchPreparationTest {
     fun `prefetch waits for damaged cache removal before it may write`() = runBlocking {
         val cacheKey = "damaged-cache"
         val damagedFile = temporaryFile(length = 3)
-        val mediaCache = cacheWithDamagedSpan(cacheKey, damagedFile)
+        val mediaCache = cacheWithDamagedSpanRemovedOnRequest(cacheKey, damagedFile)
         PlayerManager.cache = mediaCache
 
         try {
@@ -48,7 +49,12 @@ class PlayerManagerCachePrefetchPreparationTest {
     fun `prefetch is skipped when damaged cache removal fails`() = runBlocking {
         val cacheKey = "damaged-cache"
         val damagedFile = temporaryFile(length = 3)
-        val mediaCache = cacheWithDamagedSpan(cacheKey, damagedFile)
+        val mediaCache = cacheWithSpan(
+            cacheKey = cacheKey,
+            cachedFile = damagedFile,
+            spanLength = 4L,
+            contentLength = 4L
+        )
         doThrow(IllegalStateException("cache write failed"))
             .`when`(mediaCache)
             .removeResource(cacheKey)
@@ -58,10 +64,59 @@ class PlayerManagerCachePrefetchPreparationTest {
             val readiness = PlayerManager.prepareExoPlayerCacheForPrefetch(cacheKey)
 
             assertEquals(CachePrefetchReadiness.UNAVAILABLE, readiness)
+            assertTrue(PlayerManager.isPlaybackCacheKeyUnsafe(cacheKey))
             verify(mediaCache).removeResource(cacheKey)
         } finally {
             damagedFile.delete()
         }
+    }
+
+    @Test
+    fun `prefetch removes a complete resource marked unsafe before writing`() = runBlocking {
+        val cacheKey = "unsafe-cache"
+        val cachedFile = temporaryFile(length = 1)
+        val mediaCache = cacheWithSpanRemovedOnRequest(
+            cacheKey = cacheKey,
+            cachedFile = cachedFile,
+            spanLength = 1L,
+            contentLength = 1L
+        )
+        PlayerManager.cache = mediaCache
+        PlayerManager.markPlaybackCacheKeyUnsafe(mediaCache, cacheKey)
+
+        try {
+            assertTrue(PlayerManager.isPlaybackCacheKeyUnsafe(cacheKey))
+            val readiness = PlayerManager.prepareExoPlayerCacheForPrefetch(cacheKey)
+
+            assertEquals(CachePrefetchReadiness.READY_FOR_PREFETCH, readiness)
+            verify(mediaCache).removeResource(cacheKey)
+        } finally {
+            cachedFile.delete()
+        }
+    }
+
+    @Test
+    fun `prefetch clears a persisted unsafe marker after an empty resource removal`() = runBlocking {
+        val cacheKey = "unsafe-cache"
+        val mediaCache = mock(Cache::class.java)
+        `when`(mediaCache.getCachedSpans(cacheKey)).thenReturn(TreeSet())
+        `when`(mediaCache.getContentMetadata(cacheKey)).thenReturn(
+            contentMetadataWithUnsafeMarker()
+        )
+        PlayerManager.cache = mediaCache
+
+        val readiness = PlayerManager.prepareExoPlayerCacheForPrefetch(cacheKey)
+
+        assertEquals(CachePrefetchReadiness.READY_FOR_PREFETCH, readiness)
+        verify(mediaCache).removeResource(cacheKey)
+        val mutations = org.mockito.ArgumentCaptor.forClass(ContentMetadataMutations::class.java)
+        verify(mediaCache).applyContentMetadataMutations(
+            org.mockito.ArgumentMatchers.eq(cacheKey),
+            mutations.capture()
+        )
+        assertTrue(
+            CACHED_PLAYBACK_CACHE_UNSAFE_METADATA_KEY in mutations.value.removedValues
+        )
     }
 
     @Test
@@ -89,13 +144,115 @@ class PlayerManagerCachePrefetchPreparationTest {
         }
     }
 
-    private fun cacheWithDamagedSpan(cacheKey: String, damagedFile: File): Cache {
-        return cacheWithSpan(
+    @Test
+    fun `prefetch does not repair a damaged cache after ownership is lost`() = runBlocking {
+        val cacheKey = "active-playback-cache"
+        val cachedFile = temporaryFile(length = 1)
+        val mediaCache = cacheWithSpan(
+            cacheKey = cacheKey,
+            cachedFile = cachedFile,
+            spanLength = 2L,
+            contentLength = 2L
+        )
+        PlayerManager.cache = mediaCache
+
+        try {
+            val readiness = PlayerManager.prepareExoPlayerCacheForPrefetch(
+                cacheKey = cacheKey,
+                shouldApplyMutation = { false }
+            )
+
+            assertEquals(CachePrefetchReadiness.UNAVAILABLE, readiness)
+            verify(mediaCache, never()).removeResource(cacheKey)
+        } finally {
+            cachedFile.delete()
+        }
+    }
+
+    @Test
+    fun `playback recovery bypasses a cache key when removal leaves spans behind`() = runBlocking {
+        val cacheKey = "stale-cache"
+        val cachedFile = temporaryFile(length = 1)
+        val mediaCache = cacheWithSpan(
+            cacheKey = cacheKey,
+            cachedFile = cachedFile,
+            spanLength = 1L,
+            contentLength = 1L
+        )
+        PlayerManager.cache = mediaCache
+
+        try {
+            val removed = PlayerManager.invalidateCachedResourceForPlaybackRecovery(
+                cacheKey = cacheKey,
+                reason = "test"
+            )
+
+            assertEquals(false, removed)
+            assertTrue(PlayerManager.isPlaybackCacheKeyUnsafe(cacheKey))
+            verify(mediaCache).removeResource(cacheKey)
+        } finally {
+            cachedFile.delete()
+        }
+    }
+
+    @Test
+    fun `playback recovery does not clear metadata after ownership is lost`() = runBlocking {
+        val cacheKey = "stale-cache"
+        val cachedFile = temporaryFile(length = 1)
+        val mediaCache = mock(Cache::class.java)
+        `when`(mediaCache.getCachedSpans(cacheKey)).thenReturn(TreeSet())
+        `when`(mediaCache.getContentMetadata(cacheKey)).thenReturn(
+            contentMetadataWithUnsafeMarker()
+        )
+        PlayerManager.cache = mediaCache
+        var ownershipChecks = 0
+
+        try {
+            val removed = PlayerManager.invalidateCachedResourceForPlaybackRecovery(
+                cacheKey = cacheKey,
+                reason = "test",
+                shouldApplyMutation = { ++ownershipChecks < 3 }
+            )
+
+            assertEquals(false, removed)
+            verify(mediaCache).removeResource(cacheKey)
+            verify(mediaCache, never()).applyContentMetadataMutations(
+                org.mockito.ArgumentMatchers.eq(cacheKey),
+                org.mockito.ArgumentMatchers.any(ContentMetadataMutations::class.java)
+            )
+        } finally {
+            cachedFile.delete()
+        }
+    }
+
+    private fun cacheWithDamagedSpanRemovedOnRequest(
+        cacheKey: String,
+        damagedFile: File
+    ): Cache {
+        return cacheWithSpanRemovedOnRequest(
             cacheKey = cacheKey,
             cachedFile = damagedFile,
             spanLength = 4L,
             contentLength = 4L
         )
+    }
+
+    private fun cacheWithSpanRemovedOnRequest(
+        cacheKey: String,
+        cachedFile: File,
+        spanLength: Long,
+        contentLength: Long
+    ): Cache {
+        val mediaCache = mock(Cache::class.java)
+        var spans = cachedSpans(cacheKey, cachedFile, spanLength)
+        `when`(mediaCache.getCachedSpans(cacheKey)).thenAnswer { spans }
+        doAnswer {
+            spans = TreeSet()
+        }.`when`(mediaCache).removeResource(cacheKey)
+        `when`(mediaCache.getContentMetadata(cacheKey)).thenReturn(
+            contentMetadata(length = contentLength)
+        )
+        return mediaCache
     }
 
     private fun cacheWithSpan(
@@ -105,9 +262,7 @@ class PlayerManagerCachePrefetchPreparationTest {
         contentLength: Long
     ): Cache {
         val mediaCache = mock(Cache::class.java)
-        val spans = TreeSet<CacheSpan>().apply {
-            add(CacheSpan(cacheKey, 0L, spanLength, 0L, cachedFile))
-        }
+        val spans = cachedSpans(cacheKey, cachedFile, spanLength)
         `when`(mediaCache.getCachedSpans(cacheKey)).thenReturn(spans)
         `when`(mediaCache.getContentMetadata(cacheKey)).thenReturn(
             contentMetadata(length = contentLength)
@@ -115,10 +270,29 @@ class PlayerManagerCachePrefetchPreparationTest {
         return mediaCache
     }
 
+    private fun cachedSpans(
+        cacheKey: String,
+        cachedFile: File,
+        spanLength: Long
+    ): TreeSet<CacheSpan> {
+        return TreeSet<CacheSpan>().apply {
+            add(CacheSpan(cacheKey, 0L, spanLength, 0L, cachedFile))
+        }
+    }
+
     private fun contentMetadata(length: Long): DefaultContentMetadata {
         val mutations = ContentMetadataMutations()
         ContentMetadataMutations.setContentLength(mutations, length)
         return DefaultContentMetadata.EMPTY.copyWithMutationsApplied(mutations)
+    }
+
+    private fun contentMetadataWithUnsafeMarker(): DefaultContentMetadata {
+        return DefaultContentMetadata.EMPTY.copyWithMutationsApplied(
+            ContentMetadataMutations().set(
+                CACHED_PLAYBACK_CACHE_UNSAFE_METADATA_KEY,
+                "1"
+            )
+        )
     }
 
     private fun temporaryFile(length: Int): File {

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerManagerCachePrefetchPreparationTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerManagerCachePrefetchPreparationTest.kt
@@ -26,6 +26,7 @@ class PlayerManagerCachePrefetchPreparationTest {
     @After
     fun clearCacheReference() {
         PlayerManager.cache = null
+        clearPlaybackCacheSafetyForTesting()
     }
 
     @Test

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/watchdog/PlayerManagerPlaybackCandidateRecoveryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/watchdog/PlayerManagerPlaybackCandidateRecoveryTest.kt
@@ -1,6 +1,8 @@
 package moe.ouom.neriplayer.core.player.watchdog
 
+import moe.ouom.neriplayer.core.player.url.offlineCacheKeyFromUrl
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -36,6 +38,38 @@ class PlayerManagerPlaybackCandidateRecoveryTest {
                 staleCacheKey = "stale-cache",
                 nextCacheKey = "fallback-cache"
             )
+        )
+    }
+
+    @Test
+    fun `startup stall invalidates an offline cache only on the first recovery`() {
+        val url = "http://offline.cache/bili-277912748-1320700970-hires"
+
+        assertTrue(
+            shouldInvalidateOfflineCacheForStartupStall(
+                recoveryAttempt = 1,
+                currentUrl = url
+            )
+        )
+        assertFalse(
+            shouldInvalidateOfflineCacheForStartupStall(
+                recoveryAttempt = 2,
+                currentUrl = url
+            )
+        )
+        assertFalse(
+            shouldInvalidateOfflineCacheForStartupStall(
+                recoveryAttempt = 1,
+                currentUrl = "https://example.com/audio.m4a"
+            )
+        )
+    }
+
+    @Test
+    fun `offline cache key parser keeps only the synthetic resource key`() {
+        assertEquals(
+            "bili-277912748-1320700970-hires",
+            offlineCacheKeyFromUrl("http://offline.cache/bili-277912748-1320700970-hires")
         )
     }
 }


### PR DESCRIPTION
fix #340


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 为播放缓存增加播放描述符校验。系统校验音质、编码、MIME、码率、采样率、声道、内容长度和表示身份。
- 当描述符缺失或不匹配时，系统清理缓存并重新解析媒体资源。
- 系统区分 Bilibili 和 YouTube 的不同音频表示，避免复用错误缓存。
- 启动卡顿恢复仅在首次恢复且确认使用离线缓存时失效缓存。
- 保持旧格式缓存的兼容性。
- 新增测试，覆盖描述符编解码、音频信息恢复、防篡改校验、表示身份匹配、内容长度校验、缓存安全状态、缓存清理失败及离线缓存恢复。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->