### PR TITLE
fix(library): support SAF local lyric sidecars

### DIFF
--- a/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/15.json
+++ b/app/schemas/moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase/15.json
@@ -1,0 +1,3505 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 15,
+    "identityHash": "eb0339978de00d8fa7d8768164c1a741",
+    "entities": [
+      {
+        "tableName": "local_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `custom_cover_url` TEXT, `modified_at` INTEGER NOT NULL, `song_order_version` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songOrderVersion",
+            "columnName": "song_order_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_display_position",
+            "unique": false,
+            "columnNames": [
+              "display_position"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_display_position` ON `${TABLE_NAME}` (`display_position` ASC)"
+          },
+          {
+            "name": "index_local_playlist_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `song_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `payload_schema_version` INTEGER NOT NULL, `durable_payload_json` TEXT NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "payloadSchemaVersion",
+            "columnName": "payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durablePayloadJson",
+            "columnName": "durable_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_track_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          },
+          {
+            "name": "index_track_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_track_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_track_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `added_at` INTEGER NOT NULL, `order_tie_break` INTEGER NOT NULL, `playlist_context_id` TEXT, `member_payload_schema_version` INTEGER NOT NULL, `member_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identity_key`) REFERENCES `track`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderTieBreak",
+            "columnName": "order_tie_break",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "memberPayloadSchemaVersion",
+            "columnName": "member_payload_schema_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberPayloadJson",
+            "columnName": "member_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_display_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_display_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_playlist_member_added_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "added_at",
+              "order_tie_break"
+            ],
+            "orders": [
+              "ASC",
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_added_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `added_at` DESC, `order_tie_break` ASC)"
+          },
+          {
+            "name": "index_playlist_member_identity_key",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_identity_key` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          },
+          {
+            "table": "track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_member_token",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `counter` INTEGER NOT NULL, `token_index` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `identity_key`, `device_id`, `counter`), FOREIGN KEY(`playlist_id`, `identity_key`) REFERENCES `playlist_member`(`playlist_id`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counter",
+            "columnName": "counter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tokenIndex",
+            "columnName": "token_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "identity_key",
+            "device_id",
+            "counter"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_member_token_member",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_member_token_member` ON `${TABLE_NAME}` (`playlist_id`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_member",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sync_outbox",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sequence` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `operation_id` TEXT NOT NULL, `expected_domain_revision` INTEGER NOT NULL, `payload_version` INTEGER NOT NULL, `mutation_payload_json` TEXT NOT NULL, `status` TEXT NOT NULL, `attempt_count` INTEGER NOT NULL, `last_error_type` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "operationId",
+            "columnName": "operation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedDomainRevision",
+            "columnName": "expected_domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadVersion",
+            "columnName": "payload_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutationPayloadJson",
+            "columnName": "mutation_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attemptCount",
+            "columnName": "attempt_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastErrorType",
+            "columnName": "last_error_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "sequence"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sync_outbox_operation_id",
+            "unique": true,
+            "columnNames": [
+              "operation_id"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sync_outbox_operation_id` ON `${TABLE_NAME}` (`operation_id` ASC)"
+          },
+          {
+            "name": "index_sync_outbox_status_sequence",
+            "unique": false,
+            "columnNames": [
+              "status",
+              "sequence"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sync_outbox_status_sequence` ON `${TABLE_NAME}` (`status` ASC, `sequence` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_replica_checkpoint",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`transport_id` TEXT NOT NULL, `domain_revision` INTEGER NOT NULL, `remote_version` TEXT, `remote_fingerprint` TEXT, `status` TEXT NOT NULL, `last_synced_at` INTEGER NOT NULL, `last_attempt_at` INTEGER NOT NULL, PRIMARY KEY(`transport_id`))",
+        "fields": [
+          {
+            "fieldPath": "transportId",
+            "columnName": "transport_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domainRevision",
+            "columnName": "domain_revision",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteVersion",
+            "columnName": "remote_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteFingerprint",
+            "columnName": "remote_fingerprint",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "last_synced_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "last_attempt_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "transport_id"
+          ]
+        }
+      },
+      {
+        "tableName": "migration_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "play_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `identity_id` INTEGER NOT NULL, `identity_album` TEXT NOT NULL, `identity_media_uri` TEXT, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `resume_position_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `source_stable_key` TEXT, `played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityId",
+            "columnName": "identity_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityMediaUri",
+            "columnName": "identity_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resumePositionMs",
+            "columnName": "resume_position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playedAt",
+            "columnName": "played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_play_history_played_at",
+            "unique": false,
+            "columnNames": [
+              "played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_played_at` ON `${TABLE_NAME}` (`played_at` DESC)"
+          },
+          {
+            "name": "index_play_history_identity_parts",
+            "unique": false,
+            "columnNames": [
+              "identity_id",
+              "identity_album",
+              "identity_media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_play_history_identity_parts` ON `${TABLE_NAME}` (`identity_id`, `identity_album`, `identity_media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `pic_url` TEXT, `track_count` INTEGER NOT NULL, `source` TEXT NOT NULL, `last_opened` INTEGER NOT NULL, `open_count` INTEGER NOT NULL, `first_opened` INTEGER NOT NULL, `counter_base_open_count` INTEGER NOT NULL, `fid` INTEGER, `mid` INTEGER, `browse_id` TEXT, `playlist_id` TEXT, `subtype` TEXT, `subtitle` TEXT, PRIMARY KEY(`usage_key`))",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "picUrl",
+            "columnName": "pic_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastOpened",
+            "columnName": "last_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "openCount",
+            "columnName": "open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstOpened",
+            "columnName": "first_opened",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBaseOpenCount",
+            "columnName": "counter_base_open_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fid",
+            "columnName": "fid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "mid",
+            "columnName": "mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_last_opened",
+            "unique": false,
+            "columnNames": [
+              "last_opened"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_last_opened` ON `${TABLE_NAME}` (`last_opened` DESC)"
+          },
+          {
+            "name": "index_playlist_usage_source_id",
+            "unique": false,
+            "columnNames": [
+              "source",
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_source_id` ON `${TABLE_NAME}` (`source`, `playlist_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_usage_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`usage_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`usage_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`usage_key`) REFERENCES `playlist_usage`(`usage_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "usageKey",
+            "columnName": "usage_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "usage_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_usage_counter_usage_key",
+            "unique": false,
+            "columnNames": [
+              "usage_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_usage_counter_usage_key` ON `${TABLE_NAME}` (`usage_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist_usage",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "usage_key"
+            ],
+            "referencedColumns": [
+              "usage_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `total_play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPlayCount",
+            "columnName": "total_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `counter_base_play_count` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "counterBasePlayCount",
+            "columnName": "counter_base_play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_bucket_day` ON `${TABLE_NAME}` (`playlist_id` ASC, `day_start_at` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_playlist_playback_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `day_start_at` INTEGER NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `day_start_at`, `device_id`, `epoch_started_at`), FOREIGN KEY(`playlist_id`) REFERENCES `local_playlist_playback_stat`(`playlist_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "day_start_at",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_playlist_playback_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "day_start_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_playlist_playback_counter_scope` ON `${TABLE_NAME}` (`playlist_id`, `day_start_at`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_playlist_playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "playlist_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`identity_key`))",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_last_played",
+            "unique": false,
+            "columnNames": [
+              "last_played_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_last_played` ON `${TABLE_NAME}` (`last_played_at` DESC)"
+          },
+          {
+            "name": "index_playback_stat_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `cover_url` TEXT, `duration_ms` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `media_uri` TEXT, `local_file_path` TEXT, `local_file_name` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `custom_cover_url` TEXT, PRIMARY KEY(`day_start_at`, `identity_key`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [
+              "DESC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC, `identity_key` ASC)"
+          },
+          {
+            "name": "index_playback_stat_bucket_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_bucket_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`identity_key`) REFERENCES `playback_stat`(`identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_counter_identity",
+            "unique": false,
+            "columnNames": [
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_counter_identity` ON `${TABLE_NAME}` (`identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playback_stat_daily_counter_shard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `identity_key` TEXT NOT NULL, `device_id` TEXT NOT NULL, `epoch_started_at` INTEGER NOT NULL, `total_listen_ms` INTEGER NOT NULL, `play_count` INTEGER NOT NULL, `first_played_at` INTEGER NOT NULL, `last_played_at` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`, `identity_key`, `device_id`, `epoch_started_at`), FOREIGN KEY(`day_start_at`, `identity_key`) REFERENCES `playback_stat_bucket`(`day_start_at`, `identity_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityKey",
+            "columnName": "identity_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epochStartedAt",
+            "columnName": "epoch_started_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalListenMs",
+            "columnName": "total_listen_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstPlayedAt",
+            "columnName": "first_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at",
+            "identity_key",
+            "device_id",
+            "epoch_started_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playback_stat_daily_counter_scope",
+            "unique": false,
+            "columnNames": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playback_stat_daily_counter_scope` ON `${TABLE_NAME}` (`day_start_at`, `identity_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playback_stat_bucket",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "day_start_at",
+              "identity_key"
+            ],
+            "referencedColumns": [
+              "day_start_at",
+              "identity_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `name` TEXT NOT NULL, `cover_url` TEXT, `track_count` INTEGER NOT NULL, `browse_id` TEXT, `remote_playlist_id` TEXT, `subtitle` TEXT, `added_time` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`playlist_id`, `source`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browse_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remotePlaylistId",
+            "columnName": "remote_playlist_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedTime",
+            "columnName": "added_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_sort",
+            "unique": false,
+            "columnNames": [
+              "sort_order",
+              "modified_at"
+            ],
+            "orders": [
+              "DESC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_sort` ON `${TABLE_NAME}` (`sort_order` DESC, `modified_at` DESC)"
+          },
+          {
+            "name": "index_favorite_playlist_visibility",
+            "unique": false,
+            "columnNames": [
+              "is_deleted",
+              "sort_order"
+            ],
+            "orders": [
+              "ASC",
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_visibility` ON `${TABLE_NAME}` (`is_deleted` ASC, `sort_order` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorite_playlist_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `source` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `song_payload_json` TEXT NOT NULL, PRIMARY KEY(`playlist_id`, `source`, `display_position`), FOREIGN KEY(`playlist_id`, `source`) REFERENCES `favorite_playlist`(`playlist_id`, `source`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songPayloadJson",
+            "columnName": "song_payload_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "source",
+            "display_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorite_playlist_song_order",
+            "unique": false,
+            "columnNames": [
+              "playlist_id",
+              "source",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorite_playlist_song_order` ON `${TABLE_NAME}` (`playlist_id` ASC, `source` ASC, `display_position` ASC)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "favorite_playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id",
+              "source"
+            ],
+            "referencedColumns": [
+              "playlist_id",
+              "source"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "traffic_stats_bucket",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`day_start_at` INTEGER NOT NULL, `wifi_bytes` INTEGER NOT NULL, `mobile_bytes` INTEGER NOT NULL, `roaming_bytes` INTEGER NOT NULL, `playback_network_bytes` INTEGER NOT NULL, `download_network_bytes` INTEGER NOT NULL, `cache_hit_bytes` INTEGER NOT NULL, `request_count` INTEGER NOT NULL, `cache_hit_count` INTEGER NOT NULL, PRIMARY KEY(`day_start_at`))",
+        "fields": [
+          {
+            "fieldPath": "dayStartAt",
+            "columnName": "day_start_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wifiBytes",
+            "columnName": "wifi_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mobileBytes",
+            "columnName": "mobile_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roamingBytes",
+            "columnName": "roaming_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackNetworkBytes",
+            "columnName": "playback_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadNetworkBytes",
+            "columnName": "download_network_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitBytes",
+            "columnName": "cache_hit_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requestCount",
+            "columnName": "request_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheHitCount",
+            "columnName": "cache_hit_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "day_start_at"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_traffic_stats_bucket_day",
+            "unique": false,
+            "columnNames": [
+              "day_start_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_traffic_stats_bucket_day` ON `${TABLE_NAME}` (`day_start_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "playback_queue_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `current_index` INTEGER NOT NULL, `media_url` TEXT, `position_ms` INTEGER NOT NULL, `should_resume_playback` INTEGER NOT NULL, `repeat_mode` INTEGER, `shuffle_enabled` INTEGER, `shuffle_restore_index` INTEGER, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentIndex",
+            "columnName": "current_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUrl",
+            "columnName": "media_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "positionMs",
+            "columnName": "position_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shouldResumePlayback",
+            "columnName": "should_resume_playback",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatMode",
+            "columnName": "repeat_mode",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffle_enabled",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "shuffleRestoreIndex",
+            "columnName": "shuffle_restore_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playback_queue_song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`queue_id` TEXT NOT NULL, `position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `stream_url` TEXT, PRIMARY KEY(`queue_id`, `position`))",
+        "fields": [
+          {
+            "fieldPath": "queueId",
+            "columnName": "queue_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "queue_id",
+            "position"
+          ]
+        }
+      },
+      {
+        "tableName": "bili_video_skip_rule",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `modified_at` INTEGER NOT NULL, `is_deleted` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`))",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "is_deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bili_video_skip_rule_modified_at",
+            "unique": false,
+            "columnNames": [
+              "modified_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bili_video_skip_rule_modified_at` ON `${TABLE_NAME}` (`modified_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_interval",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `position` INTEGER NOT NULL, `start_ms` INTEGER NOT NULL, `end_ms` INTEGER NOT NULL, PRIMARY KEY(`bvid`, `cid`, `position`), FOREIGN KEY(`bvid`, `cid`) REFERENCES `bili_video_skip_rule`(`bvid`, `cid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startMs",
+            "columnName": "start_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endMs",
+            "columnName": "end_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bvid",
+            "cid",
+            "position"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "bili_video_skip_rule",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "bvid",
+              "cid"
+            ],
+            "referencedColumns": [
+              "bvid",
+              "cid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "bili_video_skip_draft",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`target_key` TEXT NOT NULL, `bvid` TEXT NOT NULL, `cid` INTEGER NOT NULL, `start_text` TEXT NOT NULL, `end_text` TEXT NOT NULL, `modified_at` INTEGER NOT NULL, PRIMARY KEY(`target_key`))",
+        "fields": [
+          {
+            "fieldPath": "targetKey",
+            "columnName": "target_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bvid",
+            "columnName": "bvid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cid",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startText",
+            "columnName": "start_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endText",
+            "columnName": "end_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedAt",
+            "columnName": "modified_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "target_key"
+          ]
+        }
+      },
+      {
+        "tableName": "download_pending_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `queue_order` INTEGER NOT NULL, `queued_at_ms` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER NOT NULL, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `media_uri` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `local_file_name` TEXT, `local_file_path` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `source_stable_key` TEXT, `stream_url` TEXT, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queueOrder",
+            "columnName": "queue_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queuedAtMs",
+            "columnName": "queued_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFileName",
+            "columnName": "local_file_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceStableKey",
+            "columnName": "source_stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "streamUrl",
+            "columnName": "stream_url",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_pending_queue_order",
+            "unique": false,
+            "columnNames": [
+              "queue_order"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_pending_queue_order` ON `${TABLE_NAME}` (`queue_order` ASC)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_cancelled_key",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stable_key` TEXT NOT NULL, `cancelled_at_ms` INTEGER NOT NULL, PRIMARY KEY(`stable_key`))",
+        "fields": [
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cancelledAtMs",
+            "columnName": "cancelled_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "stable_key"
+          ]
+        }
+      },
+      {
+        "tableName": "downloaded_song_catalog",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`catalog_key` TEXT NOT NULL, `root_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `id` INTEGER NOT NULL, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `file_path` TEXT NOT NULL, `file_size` INTEGER NOT NULL, `download_time` INTEGER NOT NULL, `cover_path` TEXT, `cover_url` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `media_uri` TEXT, `duration_ms` INTEGER NOT NULL, `stable_key` TEXT, `source_identity_album` TEXT, `source_media_uri` TEXT, `source_channel_id` TEXT, `source_audio_id` TEXT, `source_sub_audio_id` TEXT, `source_playlist_context_id` TEXT, PRIMARY KEY(`catalog_key`))",
+        "fields": [
+          {
+            "fieldPath": "catalogKey",
+            "columnName": "catalog_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceIdentityAlbum",
+            "columnName": "source_identity_album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceMediaUri",
+            "columnName": "source_media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceChannelId",
+            "columnName": "source_channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceAudioId",
+            "columnName": "source_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourceSubAudioId",
+            "columnName": "source_sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sourcePlaylistContextId",
+            "columnName": "source_playlist_context_id",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "catalog_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_downloaded_song_catalog_root_position",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_root_position` ON `${TABLE_NAME}` (`root_key` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_file_path",
+            "unique": false,
+            "columnNames": [
+              "file_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_file_path` ON `${TABLE_NAME}` (`file_path`)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_media_uri",
+            "unique": false,
+            "columnNames": [
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_media_uri` ON `${TABLE_NAME}` (`media_uri`)"
+          },
+          {
+            "name": "index_downloaded_song_catalog_stable_key",
+            "unique": false,
+            "columnNames": [
+              "stable_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_downloaded_song_catalog_stable_key` ON `${TABLE_NAME}` (`stable_key`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cover_url_mapping",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`local_url` TEXT NOT NULL, `network_url` TEXT NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`local_url`))",
+        "fields": [
+          {
+            "fieldPath": "localUrl",
+            "columnName": "local_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "networkUrl",
+            "columnName": "network_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "local_url"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cover_url_mapping_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [
+              "DESC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cover_url_mapping_updated_at` ON `${TABLE_NAME}` (`updated_at` DESC)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_snapshot_entry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`root_key` TEXT NOT NULL, `bucket` TEXT NOT NULL, `entry_key` TEXT NOT NULL, `display_position` INTEGER NOT NULL, `name` TEXT NOT NULL, `reference` TEXT NOT NULL, `media_uri` TEXT NOT NULL, `local_file_path` TEXT, `size_bytes` INTEGER NOT NULL, `last_modified_ms` INTEGER NOT NULL, `is_directory` INTEGER NOT NULL, PRIMARY KEY(`root_key`, `bucket`, `entry_key`))",
+        "fields": [
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bucket",
+            "columnName": "bucket",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entryKey",
+            "columnName": "entry_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayPosition",
+            "columnName": "display_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reference",
+            "columnName": "reference",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localFilePath",
+            "columnName": "local_file_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedMs",
+            "columnName": "last_modified_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isDirectory",
+            "columnName": "is_directory",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "root_key",
+            "bucket",
+            "entry_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_snapshot_entry_root_bucket_position",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "bucket",
+              "display_position"
+            ],
+            "orders": [
+              "ASC",
+              "ASC",
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_entry_root_bucket_position` ON `${TABLE_NAME}` (`root_key` ASC, `bucket` ASC, `display_position` ASC)"
+          },
+          {
+            "name": "index_download_snapshot_entry_root_bucket_name",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "bucket",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_entry_root_bucket_name` ON `${TABLE_NAME}` (`root_key`, `bucket`, `name`)"
+          },
+          {
+            "name": "index_download_snapshot_entry_root_reference",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "reference"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_entry_root_reference` ON `${TABLE_NAME}` (`root_key`, `reference`)"
+          }
+        ]
+      },
+      {
+        "tableName": "download_snapshot_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`root_key` TEXT NOT NULL, `audio_name` TEXT NOT NULL, `stable_key` TEXT, `song_id` INTEGER, `identity_album` TEXT, `name` TEXT, `artist` TEXT, `cover_url` TEXT, `matched_lyric` TEXT, `matched_translated_lyric` TEXT, `matched_lyric_source` TEXT, `matched_song_id` TEXT, `user_lyric_offset_ms` INTEGER NOT NULL, `custom_cover_url` TEXT, `custom_name` TEXT, `custom_artist` TEXT, `original_name` TEXT, `original_artist` TEXT, `original_cover_url` TEXT, `original_lyric` TEXT, `original_translated_lyric` TEXT, `media_uri` TEXT, `channel_id` TEXT, `audio_id` TEXT, `sub_audio_id` TEXT, `playlist_context_id` TEXT, `cover_path` TEXT, `lyric_path` TEXT, `translated_lyric_path` TEXT, `romanized_lyric_path` TEXT, `duration_ms` INTEGER NOT NULL, `download_finalized` INTEGER, PRIMARY KEY(`root_key`, `audio_name`))",
+        "fields": [
+          {
+            "fieldPath": "rootKey",
+            "columnName": "root_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioName",
+            "columnName": "audio_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stableKey",
+            "columnName": "stable_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "song_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "identityAlbum",
+            "columnName": "identity_album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyric",
+            "columnName": "matched_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedTranslatedLyric",
+            "columnName": "matched_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedLyricSource",
+            "columnName": "matched_lyric_source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "matchedSongId",
+            "columnName": "matched_song_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userLyricOffsetMs",
+            "columnName": "user_lyric_offset_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customCoverUrl",
+            "columnName": "custom_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customArtist",
+            "columnName": "custom_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalName",
+            "columnName": "original_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalArtist",
+            "columnName": "original_artist",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalCoverUrl",
+            "columnName": "original_cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalLyric",
+            "columnName": "original_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalTranslatedLyric",
+            "columnName": "original_translated_lyric",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaUri",
+            "columnName": "media_uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subAudioId",
+            "columnName": "sub_audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistContextId",
+            "columnName": "playlist_context_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "cover_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lyricPath",
+            "columnName": "lyric_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "translatedLyricPath",
+            "columnName": "translated_lyric_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "romanizedLyricPath",
+            "columnName": "romanized_lyric_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadFinalized",
+            "columnName": "download_finalized",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "root_key",
+            "audio_name"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_snapshot_metadata_root_stable_key",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "stable_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_stable_key` ON `${TABLE_NAME}` (`root_key`, `stable_key`)"
+          },
+          {
+            "name": "index_download_snapshot_metadata_root_song_id",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "song_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_song_id` ON `${TABLE_NAME}` (`root_key`, `song_id`)"
+          },
+          {
+            "name": "index_download_snapshot_metadata_root_media_uri",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "media_uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_media_uri` ON `${TABLE_NAME}` (`root_key`, `media_uri`)"
+          },
+          {
+            "name": "index_download_snapshot_metadata_root_remote_track",
+            "unique": false,
+            "columnNames": [
+              "root_key",
+              "channel_id",
+              "audio_id",
+              "sub_audio_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_snapshot_metadata_root_remote_track` ON `${TABLE_NAME}` (`root_key`, `channel_id`, `audio_id`, `sub_audio_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "platform_playlist_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platform` TEXT NOT NULL, `cache_key` TEXT NOT NULL, `source_id` INTEGER, `alternate_key` TEXT, `kind` TEXT, `title` TEXT, `subtitle` TEXT, `creator_name` TEXT, `cover_url` TEXT, `play_count` INTEGER, `track_count` INTEGER NOT NULL, `total_count` INTEGER NOT NULL, `signature_primary` TEXT, `signature_secondary` TEXT, `has_more` INTEGER, `saved_at_ms` INTEGER NOT NULL, PRIMARY KEY(`platform`, `cache_key`))",
+        "fields": [
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "alternateKey",
+            "columnName": "alternate_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creatorName",
+            "columnName": "creator_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "play_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "trackCount",
+            "columnName": "track_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalCount",
+            "columnName": "total_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "signaturePrimary",
+            "columnName": "signature_primary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "signatureSecondary",
+            "columnName": "signature_secondary",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hasMore",
+            "columnName": "has_more",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "savedAtMs",
+            "columnName": "saved_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platform",
+            "cache_key"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_platform_playlist_cache_source_id",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "source_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_source_id` ON `${TABLE_NAME}` (`platform`, `source_id`)"
+          },
+          {
+            "name": "index_platform_playlist_cache_saved_at",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "saved_at_ms"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_saved_at` ON `${TABLE_NAME}` (`platform`, `saved_at_ms`)"
+          }
+        ]
+      },
+      {
+        "tableName": "platform_playlist_cache_track",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platform` TEXT NOT NULL, `cache_key` TEXT NOT NULL, `position` INTEGER NOT NULL, `item_id` INTEGER, `item_key` TEXT, `name` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT NOT NULL, `album_id` INTEGER, `duration_ms` INTEGER NOT NULL, `cover_url` TEXT, `audio_id` TEXT, `uploader_mid` INTEGER, `added_at` INTEGER NOT NULL, PRIMARY KEY(`platform`, `cache_key`, `position`), FOREIGN KEY(`platform`, `cache_key`) REFERENCES `platform_playlist_cache`(`platform`, `cache_key`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "itemKey",
+            "columnName": "item_key",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "album_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationMs",
+            "columnName": "duration_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "cover_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioId",
+            "columnName": "audio_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "uploaderMid",
+            "columnName": "uploader_mid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "added_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platform",
+            "cache_key",
+            "position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_platform_playlist_cache_track_item_id",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "cache_key",
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_track_item_id` ON `${TABLE_NAME}` (`platform`, `cache_key`, `item_id`)"
+          },
+          {
+            "name": "index_platform_playlist_cache_track_item_key",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "cache_key",
+              "item_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_track_item_key` ON `${TABLE_NAME}` (`platform`, `cache_key`, `item_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "platform_playlist_cache",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "platform",
+              "cache_key"
+            ],
+            "referencedColumns": [
+              "platform",
+              "cache_key"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "platform_playlist_cache_track_artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`platform` TEXT NOT NULL, `cache_key` TEXT NOT NULL, `track_position` INTEGER NOT NULL, `artist_position` INTEGER NOT NULL, `artist_id` INTEGER NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`platform`, `cache_key`, `track_position`, `artist_position`), FOREIGN KEY(`platform`, `cache_key`, `track_position`) REFERENCES `platform_playlist_cache_track`(`platform`, `cache_key`, `position`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cache_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackPosition",
+            "columnName": "track_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistPosition",
+            "columnName": "artist_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "platform",
+            "cache_key",
+            "track_position",
+            "artist_position"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_platform_playlist_cache_artist_track",
+            "unique": false,
+            "columnNames": [
+              "platform",
+              "cache_key",
+              "track_position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_platform_playlist_cache_artist_track` ON `${TABLE_NAME}` (`platform`, `cache_key`, `track_position`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "platform_playlist_cache_track",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "platform",
+              "cache_key",
+              "track_position"
+            ],
+            "referencedColumns": [
+              "platform",
+              "cache_key",
+              "position"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'eb0339978de00d8fa7d8768164c1a741')"
+    ]
+  }
+}

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -5,5 +5,10 @@
             android:authorities="moe.ouom.neriplayer.test.stagedmetadataprovider"
             android:exported="true"
             android:grantUriPermissions="true" />
+        <provider
+            android:name="moe.ouom.neriplayer.data.local.media.Issue339LyricsTestDocumentProvider"
+            android:authorities="moe.ouom.neriplayer.test.issue339lyrics"
+            android:exported="true"
+            android:grantUriPermissions="true" />
     </application>
 </manifest>

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportSafLyricsTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportSafLyricsTest.kt
@@ -1,0 +1,123 @@
+package moe.ouom.neriplayer.data.local.audioimport
+
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import moe.ouom.neriplayer.data.local.media.LocalMediaSupport
+import moe.ouom.neriplayer.data.local.media.Issue339LyricsTestDocumentProvider
+import moe.ouom.neriplayer.data.model.SongItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LocalAudioImportSafLyricsTest {
+    private val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun importExternalDocumentCopiesLyricsDirectorySidecars() = runBlocking {
+        val audioUri = DocumentsContract.buildDocumentUri(
+            "moe.ouom.neriplayer.test.issue339lyrics",
+            "opaque/audio-issue339"
+        )
+
+        val result = LocalAudioImportManager.importExternalSongs(targetContext, listOf(audioUri))
+
+        assertEquals(0, result.failedCount)
+        val importedFile = File(requireNotNull(result.songs.single().localFilePath))
+        try {
+            val details = LocalMediaSupport.inspect(targetContext, Uri.fromFile(importedFile))
+            assertEquals("[00:00.10]original from Lyrics", details.lyricContent)
+            assertEquals("[00:00.10]translated from Lyrics", details.translatedLyricContent)
+            assertEquals("[00:00.10]romanized from Lyrics", details.romanizedLyricContent)
+            assertNotNull(details.lyricPath)
+        } finally {
+            importedFile.delete()
+            File(importedFile.parentFile, "${importedFile.nameWithoutExtension}.lrc").delete()
+            File(importedFile.parentFile, "${importedFile.nameWithoutExtension}_trans.lrc").delete()
+            File(importedFile.parentFile, "${importedFile.nameWithoutExtension}_roma.lrc").delete()
+        }
+    }
+
+    @Test
+    fun scanFolderCarriesLyricsDirectorySidecarsIntoSongItem() = runBlocking {
+        val treeUri = DocumentsContract.buildTreeDocumentUri(
+            Issue339LyricsTestDocumentProvider.AUTHORITY,
+            Issue339LyricsTestDocumentProvider.ROOT_ID
+        )
+
+        val result = LocalAudioImportManager.scanFolderSongs(targetContext, treeUri)
+
+        assertEquals(0, result.failedCount)
+        val song = result.songs.single()
+        assertEquals(
+            "[00:00.10]original from Lyrics",
+            song.matchedLyric
+        )
+        assertEquals(
+            "[00:00.10]translated from Lyrics",
+            song.matchedTranslatedLyric
+        )
+        assertEquals(song.matchedLyric, song.originalLyric)
+        assertEquals(song.matchedTranslatedLyric, song.originalTranslatedLyric)
+    }
+
+    @Test
+    fun importExternalDocumentCopiesLocalMetadataSidecar() = runBlocking {
+        val audioUri = DocumentsContract.buildDocumentUri(
+            "moe.ouom.neriplayer.test.issue339lyrics",
+            "opaque/audio-issue339"
+        )
+        val sourceSong = SongItem(
+            id = 339L,
+            name = "Issue 339",
+            artist = "Artist",
+            album = "Local",
+            albumId = 0L,
+            durationMs = 1_000L,
+            coverUrl = null,
+            mediaUri = audioUri.toString(),
+            matchedLyric = "[00:01.00]saved original",
+            matchedTranslatedLyric = "[00:01.00]saved translation",
+            localFileName = Issue339LyricsTestDocumentProvider.AUDIO_NAME
+        )
+        assertEquals(
+            "SUCCESS",
+            LocalMediaSupport.writeEditableMetadata(
+                context = targetContext,
+                song = sourceSong,
+                writeCover = false,
+                writeLyrics = true
+            ).name
+        )
+
+        val result = LocalAudioImportManager.importExternalSongs(targetContext, listOf(audioUri))
+        val importedFile = File(requireNotNull(result.songs.single().localFilePath))
+        val metadata = File(importedFile.parentFile, importedFile.name + ".npmeta.json")
+        try {
+            assertEquals(0, result.failedCount)
+            assertTrue(metadata.isFile)
+            val details = LocalMediaSupport.inspect(targetContext, Uri.fromFile(importedFile))
+            assertEquals("[00:01.00]saved original", details.lyricContent)
+            assertEquals("[00:01.00]saved translation", details.translatedLyricContent)
+        } finally {
+            DocumentsContract.deleteDocument(
+                targetContext.contentResolver,
+                DocumentsContract.buildDocumentUri(
+                    "moe.ouom.neriplayer.test.issue339lyrics",
+                    "opaque/metadata-issue339"
+                )
+            )
+            metadata.delete()
+            importedFile.delete()
+            File(importedFile.parentFile, "${importedFile.nameWithoutExtension}.lrc").delete()
+            File(importedFile.parentFile, "${importedFile.nameWithoutExtension}_trans.lrc").delete()
+            File(importedFile.parentFile, "${importedFile.nameWithoutExtension}_roma.lrc").delete()
+        }
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabaseMigrationTest.kt
@@ -21,12 +21,12 @@ class NeriUserDataDatabaseMigrationTest {
     )
 
     @Test
-    fun migrateFromVersion1ToVersion14() {
+    fun migrateFromVersion1ToVersion15() {
         helper.createDatabase(TEST_DATABASE_NAME, 1).close()
 
         helper.runMigrationsAndValidate(
             TEST_DATABASE_NAME,
-            14,
+            15,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
             NeriUserDataDatabase.MIGRATION_2_3,
@@ -40,12 +40,13 @@ class NeriUserDataDatabaseMigrationTest {
             NeriUserDataDatabase.MIGRATION_10_11,
             NeriUserDataDatabase.MIGRATION_11_12,
             NeriUserDataDatabase.MIGRATION_12_13,
-            NeriUserDataDatabase.MIGRATION_13_14
+            NeriUserDataDatabase.MIGRATION_13_14,
+            NeriUserDataDatabase.MIGRATION_14_15
         ).close()
     }
 
     @Test
-    fun migrateFromVersion1ToVersion14KeepsExistingLocalPlaylistRows() {
+    fun migrateFromVersion1ToVersion15KeepsExistingLocalPlaylistRows() {
         helper.createDatabase(TEST_DATABASE_WITH_DATA_NAME, 1).apply {
             insertVersion1LocalPlaylistFixture()
             close()
@@ -53,7 +54,7 @@ class NeriUserDataDatabaseMigrationTest {
 
         val migrated = helper.runMigrationsAndValidate(
             TEST_DATABASE_WITH_DATA_NAME,
-            14,
+            15,
             true,
             NeriUserDataDatabase.MIGRATION_1_2,
             NeriUserDataDatabase.MIGRATION_2_3,
@@ -67,7 +68,8 @@ class NeriUserDataDatabaseMigrationTest {
             NeriUserDataDatabase.MIGRATION_10_11,
             NeriUserDataDatabase.MIGRATION_11_12,
             NeriUserDataDatabase.MIGRATION_12_13,
-            NeriUserDataDatabase.MIGRATION_13_14
+            NeriUserDataDatabase.MIGRATION_13_14,
+            NeriUserDataDatabase.MIGRATION_14_15
         )
 
         try {
@@ -109,6 +111,46 @@ class NeriUserDataDatabaseMigrationTest {
                 migrated.stringFor(
                     "SELECT value FROM migration_metadata " +
                         "WHERE key = 'local_playlist_cutover_state'"
+                )
+            )
+        } finally {
+            migrated.close()
+        }
+    }
+
+    @Test
+    fun migrateFromVersion14ToVersion15KeepsSnapshotMetadata() {
+        helper.createDatabase(TEST_DATABASE_VERSION_14_NAME, 14).apply {
+            execSQL(
+                """
+                INSERT INTO download_snapshot_metadata (
+                  root_key, audio_name, user_lyric_offset_ms, duration_ms
+                ) VALUES ('root', 'song.flac', 0, 180000)
+                """.trimIndent()
+            )
+            close()
+        }
+
+        val migrated = helper.runMigrationsAndValidate(
+            TEST_DATABASE_VERSION_14_NAME,
+            15,
+            true,
+            NeriUserDataDatabase.MIGRATION_14_15
+        )
+
+        try {
+            assertEquals(
+                1L,
+                migrated.longFor(
+                    "SELECT COUNT(*) FROM download_snapshot_metadata " +
+                        "WHERE root_key = 'root' AND audio_name = 'song.flac'"
+                )
+            )
+            assertEquals(
+                1L,
+                migrated.longFor(
+                    "SELECT COUNT(*) FROM pragma_table_info('download_snapshot_metadata') " +
+                        "WHERE name = 'romanized_lyric_path'"
                 )
             )
         } finally {
@@ -212,5 +254,6 @@ class NeriUserDataDatabaseMigrationTest {
     private companion object {
         const val TEST_DATABASE_NAME = "neri-user-data-migration-test"
         const val TEST_DATABASE_WITH_DATA_NAME = "neri-user-data-migration-with-data-test"
+        const val TEST_DATABASE_VERSION_14_NAME = "neri-user-data-migration-v14-test"
     }
 }

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/media/Issue339LyricsTestDocumentProvider.java
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/media/Issue339LyricsTestDocumentProvider.java
@@ -1,0 +1,248 @@
+package moe.ouom.neriplayer.data.local.media;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.ParcelFileDescriptor;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+import android.provider.OpenableColumns;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public final class Issue339LyricsTestDocumentProvider extends ContentProvider {
+    public static final String AUTHORITY = "moe.ouom.neriplayer.test.issue339lyrics";
+    public static final String ROOT_ID = "root-issue339";
+    public static final String MUSIC_ID = "folder-issue339";
+    public static final String AUDIO_ID = "audio-issue339";
+    public static final String LYRICS_ID = "lyrics-issue339";
+    public static final String ORIGINAL_ID = "original-issue339";
+    public static final String TRANSLATED_ID = "translated-issue339";
+    public static final String ROMANIZED_ID = "romanized-issue339";
+    public static final String AUDIO_NAME = "netease - 茶太 - だんご大家族.wav";
+    public static final String ORIGINAL_NAME = "netease - 茶太 - だんご大家族.lrc";
+    public static final String TRANSLATED_NAME = "netease - 茶太 - だんご大家族_trans.lrc";
+    public static final String ROMANIZED_NAME = "netease - 茶太 - だんご大家族_roma.lrc";
+
+    private static final long FIXTURE_LAST_MODIFIED = 1_700_000_000_000L;
+    private static final String[] DEFAULT_DOCUMENT_COLUMNS = {
+        DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+        DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+        DocumentsContract.Document.COLUMN_MIME_TYPE,
+        DocumentsContract.Document.COLUMN_FLAGS,
+        DocumentsContract.Document.COLUMN_SIZE,
+        DocumentsContract.Document.COLUMN_LAST_MODIFIED
+    };
+    private static final byte[] EMPTY_CONTENT = new byte[0];
+    private static final byte[] ORIGINAL_CONTENT =
+        "[00:00.10]original from Lyrics".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] TRANSLATED_CONTENT =
+        "[00:00.10]translated from Lyrics".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] ROMANIZED_CONTENT =
+        "[00:00.10]romanized from Lyrics".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] AUDIO_CONTENT = buildWaveContent();
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        return mimeTypeFor(documentId(uri));
+    }
+
+    @Override
+    public Cursor query(
+        Uri uri,
+        String[] projection,
+        String selection,
+        String[] selectionArgs,
+        String sortOrder
+    ) {
+        String[] columns = projection == null ? DEFAULT_DOCUMENT_COLUMNS : projection;
+        MatrixCursor cursor = new MatrixCursor(columns);
+        if (isChildDocumentsUri(uri)) {
+            for (String childId : childrenFor(documentId(uri))) {
+                cursor.addRow(documentRow(columns, childId));
+            }
+        } else {
+            cursor.addRow(documentRow(columns, documentId(uri)));
+        }
+        return cursor;
+    }
+
+    @Override
+    public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+        if (!mode.contains("r")) {
+            throw new FileNotFoundException("read-only test provider");
+        }
+        try {
+            ParcelFileDescriptor[] pipe = ParcelFileDescriptor.createPipe();
+            byte[] content = contentFor(documentId(uri));
+            Thread writer = new Thread(() -> writePipe(pipe[1], content), "issue339-lyrics-fixture");
+            writer.start();
+            return pipe[0];
+        } catch (IOException error) {
+            FileNotFoundException failure = new FileNotFoundException(
+                "Unable to open Issue #339 fixture: " + uri
+            );
+            failure.initCause(error);
+            throw failure;
+        }
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public Bundle call(String method, String arg, Bundle extras) {
+        if ("android:findDocumentPath".equals(method)) {
+            Bundle result = new Bundle();
+            result.putParcelable(
+                "result",
+                new DocumentsContract.Path(null, Arrays.asList(ROOT_ID, MUSIC_ID, AUDIO_ID))
+            );
+            return result;
+        }
+        return super.call(method, arg, extras);
+    }
+
+    private static void writePipe(ParcelFileDescriptor writeSide, byte[] content) {
+        try (OutputStream output = new ParcelFileDescriptor.AutoCloseOutputStream(writeSide)) {
+            output.write(content);
+        } catch (IOException ignored) {
+            // the client can stop reading while metadata probing is still in progress
+        }
+    }
+
+    private static Object[] documentRow(String[] columns, String documentId) {
+        Object[] row = new Object[columns.length];
+        for (int index = 0; index < columns.length; index++) {
+            String column = columns[index];
+            if (DocumentsContract.Document.COLUMN_DOCUMENT_ID.equals(column)) {
+                row[index] = documentId;
+            } else if (DocumentsContract.Document.COLUMN_DISPLAY_NAME.equals(column)
+                || OpenableColumns.DISPLAY_NAME.equals(column)) {
+                row[index] = displayNameFor(documentId);
+            } else if (DocumentsContract.Document.COLUMN_MIME_TYPE.equals(column)
+                || MediaStore.MediaColumns.MIME_TYPE.equals(column)) {
+                row[index] = mimeTypeFor(documentId);
+            } else if (DocumentsContract.Document.COLUMN_FLAGS.equals(column)) {
+                row[index] = 0;
+            } else if (DocumentsContract.Document.COLUMN_SIZE.equals(column)
+                || OpenableColumns.SIZE.equals(column)) {
+                row[index] = contentFor(documentId).length;
+            } else if (DocumentsContract.Document.COLUMN_LAST_MODIFIED.equals(column)
+                || MediaStore.MediaColumns.DATE_MODIFIED.equals(column)) {
+                row[index] = FIXTURE_LAST_MODIFIED / 1_000L;
+            }
+        }
+        return row;
+    }
+
+    private static List<String> childrenFor(String parentDocumentId) {
+        if (ROOT_ID.equals(parentDocumentId)) {
+            return Collections.singletonList(MUSIC_ID);
+        }
+        if (MUSIC_ID.equals(parentDocumentId)) {
+            return Arrays.asList(AUDIO_ID, LYRICS_ID);
+        }
+        if (LYRICS_ID.equals(parentDocumentId)) {
+            return Arrays.asList(ORIGINAL_ID, TRANSLATED_ID, ROMANIZED_ID);
+        }
+        return Collections.emptyList();
+    }
+
+    private static boolean isChildDocumentsUri(Uri uri) {
+        List<String> segments = uri.getPathSegments();
+        return !segments.isEmpty() && "children".equals(segments.get(segments.size() - 1));
+    }
+
+    private static String documentId(Uri uri) {
+        try {
+            return DocumentsContract.getDocumentId(uri);
+        } catch (IllegalArgumentException ignored) {
+            List<String> segments = uri.getPathSegments();
+            int childrenIndex = segments.indexOf("children");
+            if (childrenIndex > 0) {
+                return segments.get(childrenIndex - 1);
+            }
+            return segments.isEmpty() ? ROOT_ID : segments.get(segments.size() - 1);
+        }
+    }
+
+    private static String displayNameFor(String documentId) {
+        if (ROOT_ID.equals(documentId)) return "Issue 339";
+        if (MUSIC_ID.equals(documentId)) return "my";
+        if (AUDIO_ID.equals(documentId)) return AUDIO_NAME;
+        if (LYRICS_ID.equals(documentId)) return "Lyrics";
+        if (ORIGINAL_ID.equals(documentId)) return ORIGINAL_NAME;
+        if (TRANSLATED_ID.equals(documentId)) return TRANSLATED_NAME;
+        if (ROMANIZED_ID.equals(documentId)) return ROMANIZED_NAME;
+        return documentId;
+    }
+
+    private static String mimeTypeFor(String documentId) {
+        if (ROOT_ID.equals(documentId) || LYRICS_ID.equals(documentId)) {
+            return DocumentsContract.Document.MIME_TYPE_DIR;
+        }
+        if (AUDIO_ID.equals(documentId)) return "audio/wav";
+        return "text/plain";
+    }
+
+    private static byte[] contentFor(String documentId) {
+        if (AUDIO_ID.equals(documentId)) return AUDIO_CONTENT;
+        if (ORIGINAL_ID.equals(documentId)) return ORIGINAL_CONTENT;
+        if (TRANSLATED_ID.equals(documentId)) return TRANSLATED_CONTENT;
+        if (ROMANIZED_ID.equals(documentId)) return ROMANIZED_CONTENT;
+        return EMPTY_CONTENT;
+    }
+
+    private static byte[] buildWaveContent() {
+        int sampleRate = 8_000;
+        int sampleCount = sampleRate;
+        int dataSize = sampleCount * 2;
+        ByteBuffer bytes = ByteBuffer.allocate(44 + dataSize).order(ByteOrder.LITTLE_ENDIAN);
+        bytes.put(new byte[] { 82, 73, 70, 70 });
+        bytes.putInt(36 + dataSize);
+        bytes.put(new byte[] { 87, 65, 86, 69 });
+        bytes.put(new byte[] { 102, 109, 116, 32 });
+        bytes.putInt(16);
+        bytes.putShort((short) 1);
+        bytes.putShort((short) 1);
+        bytes.putInt(sampleRate);
+        bytes.putInt(sampleRate * 2);
+        bytes.putShort((short) 2);
+        bytes.putShort((short) 16);
+        bytes.put(new byte[] { 100, 97, 116, 97 });
+        bytes.putInt(dataSize);
+        for (int index = 0; index < sampleCount; index++) {
+            bytes.putShort((short) 0);
+        }
+        return bytes.array();
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/media/Issue339LyricsTestDocumentProvider.java
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/media/Issue339LyricsTestDocumentProvider.java
@@ -6,13 +6,14 @@ import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.provider.OpenableColumns;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.File;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -24,16 +25,19 @@ import java.util.List;
 public final class Issue339LyricsTestDocumentProvider extends ContentProvider {
     public static final String AUTHORITY = "moe.ouom.neriplayer.test.issue339lyrics";
     public static final String ROOT_ID = "root-issue339";
-    public static final String MUSIC_ID = "folder-issue339";
-    public static final String AUDIO_ID = "audio-issue339";
-    public static final String LYRICS_ID = "lyrics-issue339";
-    public static final String ORIGINAL_ID = "original-issue339";
-    public static final String TRANSLATED_ID = "translated-issue339";
-    public static final String ROMANIZED_ID = "romanized-issue339";
+    public static final String MUSIC_ID = "opaque/folder-issue339";
+    // document IDs are opaque provider values and may contain slash characters
+    public static final String AUDIO_ID = "opaque/audio-issue339";
+    public static final String LYRICS_ID = "opaque/lyrics-issue339";
+    public static final String ORIGINAL_ID = "opaque/original-issue339";
+    public static final String TRANSLATED_ID = "opaque/translated-issue339";
+    public static final String ROMANIZED_ID = "opaque/romanized-issue339";
+    public static final String METADATA_ID = "opaque/metadata-issue339";
     public static final String AUDIO_NAME = "netease - 茶太 - だんご大家族.wav";
     public static final String ORIGINAL_NAME = "netease - 茶太 - だんご大家族.lrc";
     public static final String TRANSLATED_NAME = "netease - 茶太 - だんご大家族_trans.lrc";
     public static final String ROMANIZED_NAME = "netease - 茶太 - だんご大家族_roma.lrc";
+    public static final String METADATA_NAME = AUDIO_NAME + ".npmeta.json";
 
     private static final long FIXTURE_LAST_MODIFIED = 1_700_000_000_000L;
     private static final String[] DEFAULT_DOCUMENT_COLUMNS = {
@@ -52,6 +56,10 @@ public final class Issue339LyricsTestDocumentProvider extends ContentProvider {
     private static final byte[] ROMANIZED_CONTENT =
         "[00:00.10]romanized from Lyrics".getBytes(StandardCharsets.UTF_8);
     private static final byte[] AUDIO_CONTENT = buildWaveContent();
+    private static final String METADATA_DIRECTORY_NAME = "issue339-metadata";
+    private static final String EXTRA_URI = "uri";
+    private static final int DIRECTORY_FLAGS =
+        DocumentsContract.Document.FLAG_DIR_SUPPORTS_CREATE;
 
     @Override
     public boolean onCreate() {
@@ -85,6 +93,23 @@ public final class Issue339LyricsTestDocumentProvider extends ContentProvider {
 
     @Override
     public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+        if (METADATA_ID.equals(documentId(uri))) {
+            try {
+                File file = metadataFile();
+                int flags = mode.contains("w")
+                    ? ParcelFileDescriptor.MODE_READ_WRITE
+                        | ParcelFileDescriptor.MODE_CREATE
+                        | ParcelFileDescriptor.MODE_TRUNCATE
+                    : ParcelFileDescriptor.MODE_READ_ONLY;
+                return ParcelFileDescriptor.open(file, flags);
+            } catch (IOException error) {
+                FileNotFoundException failure = new FileNotFoundException(
+                    "Unable to open Issue #339 metadata: " + uri
+                );
+                failure.initCause(error);
+                throw failure;
+            }
+        }
         if (!mode.contains("r")) {
             throw new FileNotFoundException("read-only test provider");
         }
@@ -110,6 +135,9 @@ public final class Issue339LyricsTestDocumentProvider extends ContentProvider {
 
     @Override
     public int delete(Uri uri, String selection, String[] selectionArgs) {
+        if (METADATA_ID.equals(documentId(uri))) {
+            return metadataFile().delete() ? 1 : 0;
+        }
         return 0;
     }
 
@@ -128,6 +156,32 @@ public final class Issue339LyricsTestDocumentProvider extends ContentProvider {
             );
             return result;
         }
+        if ("android:createDocument".equals(method)) {
+            Bundle result = new Bundle();
+            result.putParcelable(
+                EXTRA_URI,
+                DocumentsContract.buildDocumentUri(
+                    AUTHORITY,
+                    METADATA_ID
+                )
+            );
+            return result;
+        }
+        if ("android:deleteDocument".equals(method)) {
+            Uri target = null;
+            if (extras != null) {
+                Object rawTarget = Build.VERSION.SDK_INT >= 33
+                    ? extras.getParcelable(EXTRA_URI, Uri.class)
+                    : extras.get(EXTRA_URI);
+                if (rawTarget instanceof Uri) {
+                    target = (Uri) rawTarget;
+                }
+            }
+            if (target != null && METADATA_ID.equals(documentId(target))) {
+                metadataFile().delete();
+            }
+            return new Bundle();
+        }
         return super.call(method, arg, extras);
     }
 
@@ -139,7 +193,7 @@ public final class Issue339LyricsTestDocumentProvider extends ContentProvider {
         }
     }
 
-    private static Object[] documentRow(String[] columns, String documentId) {
+    private Object[] documentRow(String[] columns, String documentId) {
         Object[] row = new Object[columns.length];
         for (int index = 0; index < columns.length; index++) {
             String column = columns[index];
@@ -152,7 +206,7 @@ public final class Issue339LyricsTestDocumentProvider extends ContentProvider {
                 || MediaStore.MediaColumns.MIME_TYPE.equals(column)) {
                 row[index] = mimeTypeFor(documentId);
             } else if (DocumentsContract.Document.COLUMN_FLAGS.equals(column)) {
-                row[index] = 0;
+                row[index] = isDirectory(documentId) ? DIRECTORY_FLAGS : 0;
             } else if (DocumentsContract.Document.COLUMN_SIZE.equals(column)
                 || OpenableColumns.SIZE.equals(column)) {
                 row[index] = contentFor(documentId).length;
@@ -164,11 +218,14 @@ public final class Issue339LyricsTestDocumentProvider extends ContentProvider {
         return row;
     }
 
-    private static List<String> childrenFor(String parentDocumentId) {
+    private List<String> childrenFor(String parentDocumentId) {
         if (ROOT_ID.equals(parentDocumentId)) {
             return Collections.singletonList(MUSIC_ID);
         }
         if (MUSIC_ID.equals(parentDocumentId)) {
+            if (metadataFile().isFile()) {
+                return Arrays.asList(AUDIO_ID, LYRICS_ID, METADATA_ID);
+            }
             return Arrays.asList(AUDIO_ID, LYRICS_ID);
         }
         if (LYRICS_ID.equals(parentDocumentId)) {
@@ -203,23 +260,48 @@ public final class Issue339LyricsTestDocumentProvider extends ContentProvider {
         if (ORIGINAL_ID.equals(documentId)) return ORIGINAL_NAME;
         if (TRANSLATED_ID.equals(documentId)) return TRANSLATED_NAME;
         if (ROMANIZED_ID.equals(documentId)) return ROMANIZED_NAME;
+        if (METADATA_ID.equals(documentId)) return METADATA_NAME;
         return documentId;
     }
 
     private static String mimeTypeFor(String documentId) {
-        if (ROOT_ID.equals(documentId) || LYRICS_ID.equals(documentId)) {
+        if (ROOT_ID.equals(documentId) || MUSIC_ID.equals(documentId) ||
+            LYRICS_ID.equals(documentId)) {
             return DocumentsContract.Document.MIME_TYPE_DIR;
         }
         if (AUDIO_ID.equals(documentId)) return "audio/wav";
+        if (METADATA_ID.equals(documentId)) return "application/json";
         return "text/plain";
     }
 
-    private static byte[] contentFor(String documentId) {
+    private static boolean isDirectory(String documentId) {
+        return DocumentsContract.Document.MIME_TYPE_DIR.equals(mimeTypeFor(documentId));
+    }
+
+    private byte[] contentFor(String documentId) {
         if (AUDIO_ID.equals(documentId)) return AUDIO_CONTENT;
         if (ORIGINAL_ID.equals(documentId)) return ORIGINAL_CONTENT;
         if (TRANSLATED_ID.equals(documentId)) return TRANSLATED_CONTENT;
         if (ROMANIZED_ID.equals(documentId)) return ROMANIZED_CONTENT;
+        if (METADATA_ID.equals(documentId)) {
+            try {
+                return java.nio.file.Files.readAllBytes(metadataFile().toPath());
+            } catch (IOException ignored) {
+                return EMPTY_CONTENT;
+            }
+        }
         return EMPTY_CONTENT;
+    }
+
+    private File metadataFile() {
+        if (getContext() == null) {
+            throw new IllegalStateException("Provider context is unavailable");
+        }
+        File directory = new File(getContext().getCacheDir(), METADATA_DIRECTORY_NAME);
+        if (!directory.exists() && !directory.mkdirs()) {
+            throw new IllegalStateException("Unable to create metadata fixture directory");
+        }
+        return new File(directory, METADATA_NAME);
     }
 
     private static byte[] buildWaveContent() {

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportSafLyricsTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportSafLyricsTest.kt
@@ -4,8 +4,12 @@ import android.net.Uri
 import android.provider.DocumentsContract
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import moe.ouom.neriplayer.data.model.SongItem
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -60,6 +64,118 @@ class LocalMediaSupportSafLyricsTest {
             details.romanizedLyricContent
         )
         assertNotNull(details.lyricPath)
+    }
+
+    @Test
+    fun writeLyricsToLocalFileCreatesMetadataSidecar() = runBlocking {
+        val audio = File.createTempFile("issue339-local-", ".wav", targetContext.cacheDir)
+        val metadata = File(audio.parentFile, audio.name + ".npmeta.json")
+        audio.writeBytes(byteArrayOf(0))
+        try {
+            val song = SongItem(
+                id = 339L,
+                name = "Local song",
+                artist = "Artist",
+                album = "Local",
+                albumId = 0L,
+                durationMs = 1_000L,
+                coverUrl = null,
+                mediaUri = audio.toURI().toString(),
+                matchedLyric = "[00:01.00]local original",
+                matchedTranslatedLyric = "[00:01.00]local translation",
+                localFileName = audio.name,
+                localFilePath = audio.absolutePath
+            )
+            val outcome = LocalMediaSupport.writeEditableMetadata(
+                context = targetContext,
+                song = song,
+                writeCover = false,
+                writeLyrics = true
+            )
+
+            assertEquals("SUCCESS", outcome.name)
+            assertTrue(metadata.isFile)
+            val parsed = LocalMediaSupport.parseLocalMetadataSidecar(
+                metadata.absolutePath,
+                metadata.readText()
+            )
+            assertEquals("[00:01.00]local original", parsed?.lyric)
+            assertEquals("[00:01.00]local translation", parsed?.translatedLyric)
+        } finally {
+            metadata.delete()
+            audio.delete()
+        }
+    }
+
+    @Test
+    fun writeLyricsToSafDocumentCreatesMetadataSidecar() = runBlocking {
+        val audioUri = DocumentsContract.buildDocumentUri(
+            Issue339LyricsTestDocumentProvider.AUTHORITY,
+            Issue339LyricsTestDocumentProvider.AUDIO_ID
+        )
+        val song = SongItem(
+            id = 340L,
+            name = "SAF song",
+            artist = "Artist",
+            album = "Local",
+            albumId = 0L,
+            durationMs = 1_000L,
+            coverUrl = null,
+            mediaUri = audioUri.toString(),
+            matchedLyric = "[00:01.00]saf original",
+            matchedTranslatedLyric = "[00:01.00]saf translation",
+            localFileName = Issue339LyricsTestDocumentProvider.AUDIO_NAME
+        )
+        val outcome = LocalMediaSupport.writeEditableMetadata(
+            context = targetContext,
+            song = song,
+            writeCover = false,
+            writeLyrics = true
+        )
+        assertEquals("SUCCESS", outcome.name)
+
+        val metadataUri = findMetadataUri()
+        try {
+            assertNotNull(metadataUri)
+            val raw = LocalMediaSupport.readTextContent(targetContext, metadataUri.toString())
+            val parsed = LocalMediaSupport.parseLocalMetadataSidecar(metadataUri.toString(), raw.orEmpty())
+            assertEquals("[00:01.00]saf original", parsed?.lyric)
+            assertEquals("[00:01.00]saf translation", parsed?.translatedLyric)
+            val details = LocalMediaSupport.inspect(targetContext, audioUri)
+            assertEquals("[00:01.00]saf original", details.lyricContent)
+            assertEquals("[00:01.00]saf translation", details.translatedLyricContent)
+        } finally {
+            metadataUri?.let { DocumentsContract.deleteDocument(targetContext.contentResolver, it) }
+        }
+    }
+
+    private fun findMetadataUri(): Uri? {
+        val childrenUri = DocumentsContract.buildChildDocumentsUri(
+            Issue339LyricsTestDocumentProvider.AUTHORITY,
+            Issue339LyricsTestDocumentProvider.MUSIC_ID
+        )
+        return targetContext.contentResolver.query(
+            childrenUri,
+            arrayOf(
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME
+            ),
+            null,
+            null,
+            null
+        )?.use { cursor ->
+            val idIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+            val nameIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+            while (cursor.moveToNext()) {
+                if (cursor.getString(nameIndex) == Issue339LyricsTestDocumentProvider.METADATA_NAME) {
+                    return@use DocumentsContract.buildDocumentUri(
+                        Issue339LyricsTestDocumentProvider.AUTHORITY,
+                        cursor.getString(idIndex)
+                    )
+                }
+            }
+            null
+        }
     }
 
     private val treeUri = DocumentsContract.buildTreeDocumentUri(

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportSafLyricsTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportSafLyricsTest.kt
@@ -1,0 +1,45 @@
+package moe.ouom.neriplayer.data.local.media
+
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LocalMediaSupportSafLyricsTest {
+    private val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun inspectContentDocumentReadsLyricsDirectorySidecarsForOpaqueDocumentIds() {
+        val audioUri = DocumentsContract.buildDocumentUriUsingTree(
+            treeUri,
+            Issue339LyricsTestDocumentProvider.AUDIO_ID
+        )
+
+        val details = LocalMediaSupport.inspect(targetContext, audioUri)
+
+        assertEquals(
+            "[00:00.10]original from Lyrics",
+            details.lyricContent
+        )
+        assertEquals(
+            "[00:00.10]translated from Lyrics",
+            details.translatedLyricContent
+        )
+        assertEquals(
+            "[00:00.10]romanized from Lyrics",
+            details.romanizedLyricContent
+        )
+        assertNotNull(details.lyricPath)
+        assertEquals("content", Uri.parse(details.lyricPath).scheme)
+    }
+
+    private val treeUri = DocumentsContract.buildTreeDocumentUri(
+        Issue339LyricsTestDocumentProvider.AUTHORITY,
+        Issue339LyricsTestDocumentProvider.ROOT_ID
+    )
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportSafLyricsTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportSafLyricsTest.kt
@@ -38,6 +38,30 @@ class LocalMediaSupportSafLyricsTest {
         assertEquals("content", Uri.parse(details.lyricPath).scheme)
     }
 
+    @Test
+    fun inspectPlainDocumentReadsLyricsDirectorySidecars() {
+        val audioUri = DocumentsContract.buildDocumentUri(
+            Issue339LyricsTestDocumentProvider.AUTHORITY,
+            Issue339LyricsTestDocumentProvider.AUDIO_ID
+        )
+
+        val details = LocalMediaSupport.inspect(targetContext, audioUri)
+
+        assertEquals(
+            "[00:00.10]original from Lyrics",
+            details.lyricContent
+        )
+        assertEquals(
+            "[00:00.10]translated from Lyrics",
+            details.translatedLyricContent
+        )
+        assertEquals(
+            "[00:00.10]romanized from Lyrics",
+            details.romanizedLyricContent
+        )
+        assertNotNull(details.lyricPath)
+    }
+
     private val treeUri = DocumentsContract.buildTreeDocumentUri(
         Issue339LyricsTestDocumentProvider.AUTHORITY,
         Issue339LyricsTestDocumentProvider.ROOT_ID

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/DownloadCompatibilityAliases.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/DownloadCompatibilityAliases.kt
@@ -356,6 +356,16 @@ internal object ManagedDownloadArtifactPlanner {
         snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
     ): String? = ManagedDownloadArtifactPlannerDelegate.indexedLyricText(context, audio, songId, translated, snapshot)
 
+    fun indexedRomanizedLyricReference(
+        audio: ManagedDownloadStorage.StoredEntry,
+        songId: Long?,
+        snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
+    ): String? = ManagedDownloadArtifactPlannerDelegate.indexedRomanizedLyricReference(
+        audio = audio,
+        songId = songId,
+        snapshot = snapshot
+    )
+
     fun indexedCoverReference(
         audio: ManagedDownloadStorage.StoredEntry,
         snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/GlobalDownloadManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/GlobalDownloadManager.kt
@@ -1041,7 +1041,8 @@ object GlobalDownloadManager {
             ManagedDownloadStorage.metadataReferenceForAudio(storedAudio),
             sidecarReferences?.coverReference,
             sidecarReferences?.lyricReference,
-            sidecarReferences?.translatedLyricReference
+            sidecarReferences?.translatedLyricReference,
+            sidecarReferences?.romanizedLyricReference
         )
         runCatching {
             removeManagedDownloadArtifacts(
@@ -1074,7 +1075,8 @@ object GlobalDownloadManager {
         val references = listOfNotNull(
             sidecarReferences?.coverReference,
             sidecarReferences?.lyricReference,
-            sidecarReferences?.translatedLyricReference
+            sidecarReferences?.translatedLyricReference,
+            sidecarReferences?.romanizedLyricReference
         )
         if (references.isEmpty()) {
             return
@@ -1785,7 +1787,8 @@ object GlobalDownloadManager {
             resolvedStoredAudio?.let(ManagedDownloadStorage::metadataReferenceForAudio),
             sidecarReferences?.coverReference,
             sidecarReferences?.lyricReference,
-            sidecarReferences?.translatedLyricReference
+            sidecarReferences?.translatedLyricReference,
+            sidecarReferences?.romanizedLyricReference
         )
 
         NPLogger.d(

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorage.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorage.kt
@@ -407,6 +407,12 @@ internal object ManagedDownloadStorage {
         LYRIC
     }
 
+    internal enum class LyricKind {
+        ORIGINAL,
+        TRANSLATED,
+        ROMANIZED
+    }
+
     data class DownloadedAudioMetadata(
         val stableKey: String? = null,
         val songId: Long? = null,
@@ -435,6 +441,7 @@ internal object ManagedDownloadStorage {
         val coverPath: String? = null,
         val lyricPath: String? = null,
         val translatedLyricPath: String? = null,
+        val romanizedLyricPath: String? = null,
         val durationMs: Long = 0L,
         val downloadFinalized: Boolean? = null
     )
@@ -1494,6 +1501,17 @@ internal object ManagedDownloadStorage {
         return overwriteLyric(context, fileNameByName, content)
     }
 
+    internal fun writeRomanizedLyrics(
+        context: Context,
+        songId: Long,
+        baseName: String,
+        content: String
+    ): String? {
+        val fileName = ManagedDownloadLyricStore.romanizedLyricFileName(baseName)
+        NPLogger.d(TAG, "写入音译歌词文件: fileName=$fileName, songId=$songId")
+        return overwriteLyric(context, fileName, content)
+    }
+
     fun readLyrics(context: Context, song: SongItem, translated: Boolean): String? {
         val snapshot = buildDownloadLibrarySnapshotBlocking(context)
         val resolvedAudio = findAudioEntry(snapshot, song)
@@ -1516,6 +1534,39 @@ internal object ManagedDownloadStorage {
             return readTextInternal(context, reference)
         }
         return ManagedDownloadLyricStore.fallbackEmbeddedLyric(resolvedMetadata, translated)
+    }
+
+    fun readRomanizedLyrics(context: Context, song: SongItem): String? {
+        val snapshot = buildDownloadLibrarySnapshotBlocking(context)
+        val resolvedAudio = findAudioEntry(snapshot, song)
+        val resolvedMetadata = resolvedAudio?.let { snapshot.metadataByAudioName[it.name] }
+        val reference = ManagedDownloadLyricStore.resolveManagedRomanizedLyricReference(
+            context = context,
+            snapshot = snapshot,
+            song = song,
+            resolvedAudio = resolvedAudio,
+            resolvedMetadata = resolvedMetadata,
+            fileNameTemplate = settings.fileNameTemplate,
+            exists = ::existsInternal
+        )
+        if (reference != null) {
+            return readTextInternal(context, reference)
+        }
+        return null
+    }
+
+    internal fun findRomanizedLyricLocation(
+        context: Context,
+        songId: Long,
+        candidateBaseNames: List<String>
+    ): String? {
+        val snapshot = resolveSnapshotForIndexedLookup(context)
+            ?: buildDownloadLibrarySnapshotBlocking(context)
+        return ManagedDownloadLyricStore.findRomanizedLyricLocation(
+            snapshot = snapshot,
+            songId = songId,
+            candidateBaseNames = candidateBaseNames
+        )
     }
 
     fun toPlayableUri(reference: String?): String? {
@@ -1618,6 +1669,22 @@ internal object ManagedDownloadStorage {
             songId = songId,
             candidateBaseNames = candidateBaseNames,
             translated = translated
+        )
+    }
+
+    internal fun buildLyricCandidateNames(
+        songId: Long?,
+        candidateBaseNames: List<String>,
+        kind: LyricKind
+    ): List<String> {
+        return ManagedDownloadStorageNaming.buildLyricCandidateNames(
+            songId = songId,
+            candidateBaseNames = candidateBaseNames,
+            kind = when (kind) {
+                LyricKind.ORIGINAL -> ManagedDownloadStorageNaming.LyricKind.ORIGINAL
+                LyricKind.TRANSLATED -> ManagedDownloadStorageNaming.LyricKind.TRANSLATED
+                LyricKind.ROMANIZED -> ManagedDownloadStorageNaming.LyricKind.ROMANIZED
+            }
         )
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/cleanup/ManagedDownloadArtifactPlanner.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/cleanup/ManagedDownloadArtifactPlanner.kt
@@ -9,6 +9,7 @@ import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
 import moe.ouom.neriplayer.core.download.catalog.resolveDownloadedSongPlaybackReference
 import moe.ouom.neriplayer.core.download.naming.candidateManagedDownloadBaseNames
 import moe.ouom.neriplayer.core.download.naming.sanitizeManagedDownloadFileName
+import moe.ouom.neriplayer.core.download.storage.naming.ManagedDownloadStorageNaming
 
 internal object ManagedDownloadArtifactPlanner {
     fun collectArtifactReferences(
@@ -26,6 +27,7 @@ internal object ManagedDownloadArtifactPlanner {
         val lyricReferences = buildList {
             trustedMetadataReference(metadata?.lyricPath, snapshot)?.let(::add)
             trustedMetadataReference(metadata?.translatedLyricPath, snapshot)?.let(::add)
+            trustedMetadataReference(metadata?.romanizedLyricPath, snapshot)?.let(::add)
             addAll(
                 allIndexedLyricReferences(
                     candidateBaseNames = candidateBaseNames,
@@ -39,6 +41,14 @@ internal object ManagedDownloadArtifactPlanner {
                     candidateBaseNames = candidateBaseNames,
                     songId = resolvedSongId,
                     translated = true,
+                    snapshot = snapshot
+                )
+            )
+            addAll(
+                allIndexedLyricReferences(
+                    candidateBaseNames = candidateBaseNames,
+                    songId = resolvedSongId,
+                    kind = ManagedDownloadStorageNaming.LyricKind.ROMANIZED,
                     snapshot = snapshot
                 )
             )
@@ -96,6 +106,19 @@ internal object ManagedDownloadArtifactPlanner {
             translated = translated,
             snapshot = snapshot
         )
+    }
+
+    fun indexedRomanizedLyricReference(
+        audio: ManagedDownloadStorage.StoredEntry,
+        songId: Long?,
+        snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
+    ): String? {
+        return allIndexedLyricReferences(
+            candidateBaseNames = candidateManagedDownloadBaseNames(audio.nameWithoutExtension),
+            songId = songId,
+            kind = ManagedDownloadStorageNaming.LyricKind.ROMANIZED,
+            snapshot = snapshot
+        ).firstOrNull()
     }
 
     suspend fun indexedLyricText(
@@ -172,10 +195,32 @@ internal object ManagedDownloadArtifactPlanner {
         translated: Boolean,
         snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
     ): List<String> {
+        return allIndexedLyricReferences(
+            candidateBaseNames = candidateBaseNames,
+            songId = songId,
+            kind = if (translated) {
+                ManagedDownloadStorageNaming.LyricKind.TRANSLATED
+            } else {
+                ManagedDownloadStorageNaming.LyricKind.ORIGINAL
+            },
+            snapshot = snapshot
+        )
+    }
+
+    private fun allIndexedLyricReferences(
+        candidateBaseNames: List<String>,
+        songId: Long?,
+        kind: ManagedDownloadStorageNaming.LyricKind,
+        snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot
+    ): List<String> {
         val candidates = ManagedDownloadStorage.buildLyricCandidateNames(
             songId = songId,
             candidateBaseNames = candidateBaseNames,
-            translated = translated
+            kind = when (kind) {
+                ManagedDownloadStorageNaming.LyricKind.ORIGINAL -> ManagedDownloadStorage.LyricKind.ORIGINAL
+                ManagedDownloadStorageNaming.LyricKind.TRANSLATED -> ManagedDownloadStorage.LyricKind.TRANSLATED
+                ManagedDownloadStorageNaming.LyricKind.ROMANIZED -> ManagedDownloadStorage.LyricKind.ROMANIZED
+            }
         )
         return candidates
             .mapNotNull { candidate -> snapshot.lyricEntriesByName[candidate]?.reference }
@@ -287,7 +332,8 @@ internal object ManagedDownloadArtifactPlanner {
                 listOfNotNull(
                     metadata.coverPath,
                     metadata.lyricPath,
-                    metadata.translatedLyricPath
+                    metadata.translatedLyricPath,
+                    metadata.romanizedLyricPath
                 ).contains(reference)
         }
     }

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/cleanup/ManagedDownloadUnfinalizedCleanupPlanner.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/cleanup/ManagedDownloadUnfinalizedCleanupPlanner.kt
@@ -61,7 +61,12 @@ internal object ManagedDownloadUnfinalizedCleanupPlanner {
         metadata: ManagedDownloadStorage.DownloadedAudioMetadata,
         managedSidecarReferences: Set<String>
     ): List<String> {
-        return listOf(metadata.coverPath, metadata.lyricPath, metadata.translatedLyricPath)
+        return listOf(
+            metadata.coverPath,
+            metadata.lyricPath,
+            metadata.translatedLyricPath,
+            metadata.romanizedLyricPath
+        )
             .mapNotNull { reference -> reference?.takeIf(String::isNotBlank) }
             .filter(managedSidecarReferences::contains)
     }

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/metadata/DownloadedAudioMetadataStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/metadata/DownloadedAudioMetadataStore.kt
@@ -37,6 +37,7 @@ internal class DownloadedAudioMetadataStore(
             coverReference = sidecars.coverReference,
             lyricReference = sidecars.lyricReference,
             translatedLyricReference = sidecars.translatedLyricReference,
+            romanizedLyricReference = sidecars.romanizedLyricReference,
             downloadFinalized = downloadFinalized
         )
 
@@ -48,7 +49,7 @@ internal class DownloadedAudioMetadataStore(
             if (result.getOrDefault(false)) {
                 NPLogger.d(
                     loggerTag,
-                    "保存下载 metadata: file=${audio.name}, stableKey=${identity.stableKey()}, finalized=$downloadFinalized, lyricPath=${sidecars.lyricReference}, translatedLyricPath=${sidecars.translatedLyricReference}, coverPath=${sidecars.coverReference}"
+                    "保存下载 metadata: file=${audio.name}, stableKey=${identity.stableKey()}, finalized=$downloadFinalized, lyricPath=${sidecars.lyricReference}, translatedLyricPath=${sidecars.translatedLyricReference}, romanizedLyricPath=${sidecars.romanizedLyricReference}, coverPath=${sidecars.coverReference}"
                 )
                 return true
             }
@@ -90,7 +91,8 @@ internal class DownloadedAudioMetadataStore(
             return DownloadedMetadataSidecarReferences(
                 coverReference = sidecarReferences?.coverReference,
                 lyricReference = sidecarReferences?.lyricReference,
-                translatedLyricReference = sidecarReferences?.translatedLyricReference
+                translatedLyricReference = sidecarReferences?.translatedLyricReference,
+                romanizedLyricReference = sidecarReferences?.romanizedLyricReference
             )
         }
 
@@ -117,6 +119,12 @@ internal class DownloadedAudioMetadataStore(
                     songId = song.id,
                     candidateBaseNames = candidateBaseNames,
                     translated = true
+                ),
+            romanizedLyricReference = sidecarReferences?.romanizedLyricReference
+                ?: ManagedDownloadStorage.findRomanizedLyricLocation(
+                    context = context,
+                    songId = song.id,
+                    candidateBaseNames = candidateBaseNames
                 )
         )
     }
@@ -126,6 +134,7 @@ internal class DownloadedAudioMetadataStore(
         coverReference: String?,
         lyricReference: String?,
         translatedLyricReference: String?,
+        romanizedLyricReference: String?,
         downloadFinalized: Boolean
     ): JSONObject {
         val identity = song.identity()
@@ -157,6 +166,7 @@ internal class DownloadedAudioMetadataStore(
             put("coverPath", coverReference)
             put("lyricPath", lyricReference)
             put("translatedLyricPath", translatedLyricReference)
+            put("romanizedLyricPath", romanizedLyricReference)
             put("durationMs", song.durationMs)
             put("downloadFinalized", downloadFinalized)
         }
@@ -165,7 +175,8 @@ internal class DownloadedAudioMetadataStore(
     private data class DownloadedMetadataSidecarReferences(
         val coverReference: String?,
         val lyricReference: String?,
-        val translatedLyricReference: String?
+        val translatedLyricReference: String?,
+        val romanizedLyricReference: String?
     )
 }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/ManagedDownloadStorageJsonCodec.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/ManagedDownloadStorageJsonCodec.kt
@@ -196,6 +196,7 @@ internal object ManagedDownloadStorageJsonCodec {
             put("coverPath", coverPath)
             put("lyricPath", lyricPath)
             put("translatedLyricPath", translatedLyricPath)
+            put("romanizedLyricPath", romanizedLyricPath)
             put("durationMs", durationMs)
             put("downloadFinalized", downloadFinalized)
         }
@@ -371,6 +372,7 @@ internal object ManagedDownloadStorageJsonCodec {
             coverPath = optString("coverPath").takeIf(String::isNotBlank),
             lyricPath = optString("lyricPath").takeIf(String::isNotBlank),
             translatedLyricPath = optString("translatedLyricPath").takeIf(String::isNotBlank),
+            romanizedLyricPath = optString("romanizedLyricPath").takeIf(String::isNotBlank),
             durationMs = optLong("durationMs"),
             downloadFinalized = optOptionalBoolean("downloadFinalized")
         )

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/lookup/ManagedDownloadManagedAudioPolicy.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/lookup/ManagedDownloadManagedAudioPolicy.kt
@@ -29,12 +29,17 @@ internal object ManagedDownloadManagedAudioPolicy {
         return ManagedDownloadStorageNaming.buildLyricCandidateNames(
             songId = null,
             candidateBaseNames = candidateBaseNames,
-            translated = false
+            kind = ManagedDownloadStorageNaming.LyricKind.ORIGINAL
         ).any(lyricEntryNames::contains) ||
             ManagedDownloadStorageNaming.buildLyricCandidateNames(
                 songId = null,
                 candidateBaseNames = candidateBaseNames,
-                translated = true
+                kind = ManagedDownloadStorageNaming.LyricKind.TRANSLATED
+            ).any(lyricEntryNames::contains) ||
+            ManagedDownloadStorageNaming.buildLyricCandidateNames(
+                songId = null,
+                candidateBaseNames = candidateBaseNames,
+                kind = ManagedDownloadStorageNaming.LyricKind.ROMANIZED
             ).any(lyricEntryNames::contains)
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/lookup/ManagedDownloadStorageLookup.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/lookup/ManagedDownloadStorageLookup.kt
@@ -21,6 +21,12 @@ internal object ManagedDownloadStorageLookup {
     ): ManagedDownloadAudioLookupResult? {
         val identity = song.identity()
         val stableKey = identity.stableKey()
+        val localReferences = listOfNotNull(song.localFilePath, song.mediaUri)
+            .filter { it.startsWith("/" ) || it.startsWith("content://", ignoreCase = true) }
+            .distinct()
+        localReferences.firstNotNullOfOrNull { reference ->
+            snapshot.audioEntriesByLookupKey[reference]
+        }?.let { return ManagedDownloadAudioLookupResult(it, "localReference") }
         val remoteTrackKey = ManagedDownloadSnapshotIndex.buildRemoteTrackKey(
             song.channelId,
             song.audioId,

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/metadata/ManagedDownloadMetadataCodec.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/metadata/ManagedDownloadMetadataCodec.kt
@@ -17,6 +17,7 @@ internal object ManagedDownloadMetadataCodec {
         rewriteMetadataReferenceField(root, "coverPath", referenceMap)
         rewriteMetadataReferenceField(root, "lyricPath", referenceMap)
         rewriteMetadataReferenceField(root, "translatedLyricPath", referenceMap)
+        rewriteMetadataReferenceField(root, "romanizedLyricPath", referenceMap)
         rewriteMetadataReferenceField(root, "coverUrl", referenceMap)
         rewriteMetadataReferenceField(root, "originalCoverUrl", referenceMap)
         rewriteMetadataReferenceField(root, "mediaUri", referenceMap)

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/migration/ManagedDownloadMigrationEntryCollector.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/migration/ManagedDownloadMigrationEntryCollector.kt
@@ -88,12 +88,17 @@ internal object ManagedDownloadMigrationEntryCollector {
                 ManagedDownloadStorageNaming.buildLyricCandidateNames(
                     songId = songId,
                     candidateBaseNames = candidateBaseNames,
-                    translated = false
+                    kind = ManagedDownloadStorageNaming.LyricKind.ORIGINAL
                 ).forEach(::add)
                 ManagedDownloadStorageNaming.buildLyricCandidateNames(
                     songId = songId,
                     candidateBaseNames = candidateBaseNames,
-                    translated = true
+                    kind = ManagedDownloadStorageNaming.LyricKind.TRANSLATED
+                ).forEach(::add)
+                ManagedDownloadStorageNaming.buildLyricCandidateNames(
+                    songId = songId,
+                    candidateBaseNames = candidateBaseNames,
+                    kind = ManagedDownloadStorageNaming.LyricKind.ROMANIZED
                 ).forEach(::add)
             }
         }

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/naming/ManagedDownloadStorageNaming.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/naming/ManagedDownloadStorageNaming.kt
@@ -3,6 +3,12 @@ package moe.ouom.neriplayer.core.download.storage.naming
 import moe.ouom.neriplayer.core.download.storage.imageExtensions
 
 internal object ManagedDownloadStorageNaming {
+    internal enum class LyricKind {
+        ORIGINAL,
+        TRANSLATED,
+        ROMANIZED
+    }
+
     fun buildSidecarCandidateNames(candidateBaseNames: List<String>): List<String> {
         return buildList {
             candidateBaseNames.forEach { baseName ->
@@ -23,14 +29,32 @@ internal object ManagedDownloadStorageNaming {
         candidateBaseNames: List<String>,
         translated: Boolean
     ): List<String> {
+        return buildLyricCandidateNames(
+            songId = songId,
+            candidateBaseNames = candidateBaseNames,
+            kind = if (translated) LyricKind.TRANSLATED else LyricKind.ORIGINAL
+        )
+    }
+
+    fun buildLyricCandidateNames(
+        songId: Long?,
+        candidateBaseNames: List<String>,
+        kind: LyricKind
+    ): List<String> {
         val names = linkedSetOf<String>()
         fun addLyricNames(baseName: String) {
-            if (translated) {
-                names += "${baseName}_trans.lrc"
-                names += "${baseName}_trans.lrc.txt"
-            } else {
-                names += "$baseName.lrc"
-                names += "$baseName.lrc.txt"
+            val prefixes = when (kind) {
+                LyricKind.ORIGINAL -> listOf(baseName)
+                LyricKind.TRANSLATED -> listOf("${baseName}_trans")
+                LyricKind.ROMANIZED -> listOf(
+                    "${baseName}_roma",
+                    "${baseName}_romalrc",
+                    "${baseName}_romanized"
+                )
+            }
+            prefixes.forEach { prefix ->
+                names += "$prefix.lrc"
+                names += "$prefix.lrc.txt"
             }
         }
 

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/sidecar/ManagedDownloadLyricStore.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/sidecar/ManagedDownloadLyricStore.kt
@@ -12,6 +12,8 @@ internal object ManagedDownloadLyricStore {
         return if (translated) "${baseName}_trans.lrc" else "$baseName.lrc"
     }
 
+    fun romanizedLyricFileName(baseName: String): String = "${baseName}_roma.lrc"
+
     fun findLyricLocation(
         snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot,
         songId: Long,
@@ -23,6 +25,45 @@ internal object ManagedDownloadLyricStore {
             songId = songId.takeIf { it > 0L },
             candidateBaseNames = candidateBaseNames,
             translated = translated
+        )
+    }
+
+    fun findRomanizedLyricLocation(
+        snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot,
+        songId: Long,
+        candidateBaseNames: List<String>
+    ): String? {
+        return findIndexedLyricReference(
+            snapshot = snapshot,
+            songId = songId.takeIf { it > 0L },
+            candidateBaseNames = candidateBaseNames,
+            kind = ManagedDownloadStorageNaming.LyricKind.ROMANIZED
+        )
+    }
+
+    fun resolveManagedRomanizedLyricReference(
+        context: Context,
+        snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot,
+        song: SongItem,
+        resolvedAudio: ManagedDownloadStorage.StoredEntry?,
+        resolvedMetadata: ManagedDownloadStorage.DownloadedAudioMetadata?,
+        fileNameTemplate: String?,
+        exists: (Context, String?) -> Boolean
+    ): String? {
+        resolvedMetadata?.romanizedLyricPath
+            ?.takeIf { exists(context, it) }
+            ?.let { return it }
+        resolvedAudio?.let { audio ->
+            findRomanizedLyricLocation(
+                snapshot = snapshot,
+                songId = resolvedMetadata?.songId ?: song.id,
+                candidateBaseNames = candidateManagedDownloadBaseNames(audio.nameWithoutExtension)
+            )?.let { return it }
+        }
+        return findRomanizedLyricLocation(
+            snapshot = snapshot,
+            songId = song.id,
+            candidateBaseNames = candidateManagedDownloadBaseNames(song, fileNameTemplate)
         )
     }
 
@@ -50,7 +91,11 @@ internal object ManagedDownloadLyricStore {
                 snapshot = snapshot,
                 songId = resolvedMetadata?.songId ?: song.id.takeIf { it > 0L },
                 candidateBaseNames = candidateManagedDownloadBaseNames(audio.nameWithoutExtension),
-                translated = translated
+                kind = if (translated) {
+                    ManagedDownloadStorageNaming.LyricKind.TRANSLATED
+                } else {
+                    ManagedDownloadStorageNaming.LyricKind.ORIGINAL
+                }
             )?.let { return it }
         }
 
@@ -58,7 +103,11 @@ internal object ManagedDownloadLyricStore {
             snapshot = snapshot,
             songId = song.id.takeIf { it > 0L },
             candidateBaseNames = candidateManagedDownloadBaseNames(song, fileNameTemplate),
-            translated = translated
+            kind = if (translated) {
+                ManagedDownloadStorageNaming.LyricKind.TRANSLATED
+            } else {
+                ManagedDownloadStorageNaming.LyricKind.ORIGINAL
+            }
         )
     }
 
@@ -90,11 +139,29 @@ internal object ManagedDownloadLyricStore {
         candidateBaseNames: List<String>,
         translated: Boolean
     ): String? {
+        return findIndexedLyricReference(
+            snapshot = snapshot,
+            songId = songId,
+            candidateBaseNames = candidateBaseNames,
+            kind = if (translated) {
+                ManagedDownloadStorageNaming.LyricKind.TRANSLATED
+            } else {
+                ManagedDownloadStorageNaming.LyricKind.ORIGINAL
+            }
+        )
+    }
+
+    private fun findIndexedLyricReference(
+        snapshot: ManagedDownloadStorage.DownloadLibrarySnapshot,
+        songId: Long?,
+        candidateBaseNames: List<String>,
+        kind: ManagedDownloadStorageNaming.LyricKind
+    ): String? {
         return ManagedDownloadStorageLookup.findIndexedEntryByNames(
             names = ManagedDownloadStorageNaming.buildLyricCandidateNames(
                 songId = songId,
                 candidateBaseNames = candidateBaseNames,
-                translated = translated
+                kind = kind
             ),
             entriesByName = snapshot.lyricEntriesByName
         )?.reference

--- a/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomMapper.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/download/storage/snapshot/ManagedDownloadSnapshotRoomMapper.kt
@@ -72,6 +72,7 @@ internal object ManagedDownloadSnapshotRoomMapper {
                     coverPath = metadata.coverPath,
                     lyricPath = metadata.lyricPath,
                     translatedLyricPath = metadata.translatedLyricPath,
+                    romanizedLyricPath = metadata.romanizedLyricPath,
                     durationMs = metadata.durationMs,
                     downloadFinalized = metadata.downloadFinalized
                 )
@@ -159,6 +160,7 @@ internal object ManagedDownloadSnapshotRoomMapper {
             coverPath = coverPath,
             lyricPath = lyricPath,
             translatedLyricPath = translatedLyricPath,
+            romanizedLyricPath = romanizedLyricPath,
             durationMs = durationMs,
             downloadFinalized = downloadFinalized
         )

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/download/AudioDownloadManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/download/AudioDownloadManager.kt
@@ -379,23 +379,28 @@ object AudioDownloadManager {
         val coverReference: String? = null,
         val lyricReference: String? = null,
         val translatedLyricReference: String? = null,
+        val romanizedLyricReference: String? = null,
         val createdCover: Boolean = false,
         val createdLyric: Boolean = false,
-        val createdTranslatedLyric: Boolean = false
+        val createdTranslatedLyric: Boolean = false,
+        val createdRomanizedLyric: Boolean = false
     ) {
         val isEmpty: Boolean
             get() = coverReference.isNullOrBlank() &&
                 lyricReference.isNullOrBlank() &&
-                translatedLyricReference.isNullOrBlank()
+                translatedLyricReference.isNullOrBlank() &&
+                romanizedLyricReference.isNullOrBlank()
 
         fun retainCreatedOnly(): DownloadedSidecarReferences {
             return DownloadedSidecarReferences(
                 coverReference = coverReference.takeIf { createdCover },
                 lyricReference = lyricReference.takeIf { createdLyric },
                 translatedLyricReference = translatedLyricReference.takeIf { createdTranslatedLyric },
+                romanizedLyricReference = romanizedLyricReference.takeIf { createdRomanizedLyric },
                 createdCover = createdCover && !coverReference.isNullOrBlank(),
                 createdLyric = createdLyric && !lyricReference.isNullOrBlank(),
-                createdTranslatedLyric = createdTranslatedLyric && !translatedLyricReference.isNullOrBlank()
+                createdTranslatedLyric = createdTranslatedLyric && !translatedLyricReference.isNullOrBlank(),
+                createdRomanizedLyric = createdRomanizedLyric && !romanizedLyricReference.isNullOrBlank()
             )
         }
     }
@@ -996,6 +1001,14 @@ object AudioDownloadManager {
                 existingCreated = existing?.createdTranslatedLyric ?: false,
                 incomingReference = incoming?.translatedLyricReference,
                 incomingCreated = incoming?.createdTranslatedLyric ?: false
+            ),
+            romanizedLyricReference = incoming?.romanizedLyricReference
+                ?: existing?.romanizedLyricReference,
+            createdRomanizedLyric = mergeSidecarCreatedFlag(
+                existingReference = existing?.romanizedLyricReference,
+                existingCreated = existing?.createdRomanizedLyric ?: false,
+                incomingReference = incoming?.romanizedLyricReference,
+                incomingCreated = incoming?.createdRomanizedLyric ?: false
             )
         )
     }
@@ -1605,7 +1618,8 @@ object AudioDownloadManager {
             DownloadedSidecarReferences(
                 coverReference = coverReference,
                 lyricReference = lyricReferences.lyricReference,
-                translatedLyricReference = lyricReferences.translatedLyricReference
+                translatedLyricReference = lyricReferences.translatedLyricReference,
+                romanizedLyricReference = lyricReferences.romanizedLyricReference
             )
         } else {
             coroutineScope {
@@ -1638,7 +1652,8 @@ object AudioDownloadManager {
                 DownloadedSidecarReferences(
                     coverReference = coverReference,
                     lyricReference = lyricReferences.lyricReference,
-                    translatedLyricReference = lyricReferences.translatedLyricReference
+                    translatedLyricReference = lyricReferences.translatedLyricReference,
+                    romanizedLyricReference = lyricReferences.romanizedLyricReference
                 )
             }
         }
@@ -2423,6 +2438,13 @@ object AudioDownloadManager {
         return rawLyric == null
     }
 
+    internal fun shouldFetchRomanizedLyricForDownload(
+        shouldFetchPrimaryLyric: Boolean,
+        shouldFetchTranslatedLyric: Boolean
+    ): Boolean {
+        return shouldFetchPrimaryLyric || shouldFetchTranslatedLyric
+    }
+
     /** 下载歌词文件 */
     private suspend fun downloadLyrics(
         context: Context,
@@ -2435,6 +2457,7 @@ object AudioDownloadManager {
     ): DownloadedSidecarReferences {
         var lyricReference: String? = null
         var translatedLyricReference: String? = null
+        var romanizedLyricReference: String? = null
         try {
             ensureSongDownloadNotCancelled(
                 songKey = songKey,
@@ -2445,9 +2468,14 @@ object AudioDownloadManager {
             )
             var lyricText = resolveLocalLyricForDownload(song.matchedLyric)
             var translatedText = resolveLocalLyricForDownload(song.matchedTranslatedLyric)
+            var romanizedText: String? = null
             val shouldFetchPrimaryLyric = shouldFetchRemoteLyricForDownload(song.matchedLyric)
             val shouldFetchTranslatedLyric =
                 shouldFetchRemoteLyricForDownload(song.matchedTranslatedLyric)
+            val shouldFetchRomanizedLyric = shouldFetchRomanizedLyricForDownload(
+                shouldFetchPrimaryLyric = shouldFetchPrimaryLyric,
+                shouldFetchTranslatedLyric = shouldFetchTranslatedLyric
+            )
             if (lyricText != null) {
                 NPLogger.d(TAG, context.getString(R.string.download_lyrics_matched, song.name))
             }
@@ -2465,13 +2493,17 @@ object AudioDownloadManager {
                     val downloaded = downloadNeteaseLyrics(
                         song = song,
                         shouldFetchPrimaryLyric = shouldFetchPrimaryLyric && lyricText == null,
-                        shouldFetchTranslatedLyric = shouldFetchTranslatedLyric && translatedText == null
+                        shouldFetchTranslatedLyric = shouldFetchTranslatedLyric && translatedText == null,
+                        shouldFetchRomanizedLyric = shouldFetchRomanizedLyric && romanizedText == null
                     )
                     if (lyricText == null && shouldFetchPrimaryLyric) {
                         lyricText = downloaded.lyricText
                     }
                     if (translatedText == null && shouldFetchTranslatedLyric) {
                         translatedText = downloaded.translatedText
+                    }
+                    if (romanizedText == null && shouldFetchRomanizedLyric) {
+                        romanizedText = downloaded.romanizedText
                     }
                 }
             }
@@ -2528,6 +2560,24 @@ object AudioDownloadManager {
                     NPLogger.d(TAG, "翻译歌词写入完成: song=${song.name}, reference=$reference")
                 }
             }
+            romanizedText?.takeIf { it.isNotBlank() }?.let { lyric ->
+                romanizedLyricReference = ManagedDownloadStorage.writeRomanizedLyrics(
+                    context = context,
+                    songId = song.id,
+                    baseName = baseName,
+                    content = lyric
+                )
+                romanizedLyricReference?.let { reference ->
+                    rememberPartialSidecarReferences(
+                        songKey,
+                        DownloadedSidecarReferences(
+                            romanizedLyricReference = reference,
+                            createdRomanizedLyric = true
+                        )
+                    )
+                    NPLogger.d(TAG, "音译歌词写入完成: song=${song.name}, reference=$reference")
+                }
+            }
         } catch (cancellation: java.util.concurrent.CancellationException) {
             NPLogger.d(TAG, "歌词整理阶段收到取消: ${song.name}")
             throw cancellation
@@ -2537,8 +2587,10 @@ object AudioDownloadManager {
         return DownloadedSidecarReferences(
             lyricReference = lyricReference,
             translatedLyricReference = translatedLyricReference,
+            romanizedLyricReference = romanizedLyricReference,
             createdLyric = !lyricReference.isNullOrBlank(),
-            createdTranslatedLyric = !translatedLyricReference.isNullOrBlank()
+            createdTranslatedLyric = !translatedLyricReference.isNullOrBlank(),
+            createdRomanizedLyric = !romanizedLyricReference.isNullOrBlank()
         )
     }
 
@@ -2591,21 +2643,31 @@ object AudioDownloadManager {
     private fun downloadNeteaseLyrics(
         song: SongItem,
         shouldFetchPrimaryLyric: Boolean = true,
-        shouldFetchTranslatedLyric: Boolean = true
+        shouldFetchTranslatedLyric: Boolean = true,
+        shouldFetchRomanizedLyric: Boolean = true
     ): DownloadedLyrics {
-        if (!shouldFetchPrimaryLyric && !shouldFetchTranslatedLyric) {
+        if (!shouldFetchPrimaryLyric && !shouldFetchTranslatedLyric && !shouldFetchRomanizedLyric) {
             return DownloadedLyrics()
         }
 
-        if (!shouldFetchPrimaryLyric) {
+        if (!shouldFetchPrimaryLyric && !shouldFetchRomanizedLyric) {
             try {
                 val lyrics = AppContainer.neteaseClient.getLyricNew(song.id)
                 val root = JSONObject(lyrics)
                 if (root.optInt("code") == 200) {
                     val tlyric: String = root.optJSONObject("tlyric")?.optString("lyric").orEmpty()
+                    val romalrc = root.optJSONObject("romalrc")?.optString("lyric").orEmpty()
                     if (shouldFetchTranslatedLyric && tlyric.isNotBlank()) {
                         NPLogger.d(TAG, "翻译歌词保存: ${song.name}")
-                        return DownloadedLyrics(translatedText = tlyric)
+                        return DownloadedLyrics(
+                            translatedText = tlyric,
+                            romanizedText = romalrc.takeIf {
+                                shouldFetchRomanizedLyric && it.isNotBlank()
+                            }
+                        )
+                    }
+                    if (shouldFetchRomanizedLyric && romalrc.isNotBlank()) {
+                        return DownloadedLyrics(romanizedText = romalrc)
                     }
                 }
             } catch (e: Exception) {
@@ -2622,6 +2684,7 @@ object AudioDownloadManager {
             val yrc: String = root.optJSONObject("yrc")?.optString("lyric") ?: ""
             val lrc: String = root.optJSONObject("lrc")?.optString("lyric") ?: ""
             val translated: String = root.optJSONObject("tlyric")?.optString("lyric") ?: ""
+            val romanized: String = root.optJSONObject("romalrc")?.optString("lyric") ?: ""
             val preferredLyric = if (shouldFetchPrimaryLyric) {
                 yrc.takeIf { it.isNotBlank() } ?: lrc.takeIf { it.isNotBlank() }
             } else {
@@ -2640,6 +2703,9 @@ object AudioDownloadManager {
                 lyricText = preferredLyric,
                 translatedText = translated.takeIf {
                     shouldFetchTranslatedLyric && it.isNotBlank()
+                },
+                romanizedText = romanized.takeIf {
+                    shouldFetchRomanizedLyric && it.isNotBlank()
                 }
             )
         } catch (e: Exception) {
@@ -2768,6 +2834,10 @@ object AudioDownloadManager {
 
     fun getTranslatedLyricContent(context: Context, song: SongItem): String? {
         return ManagedDownloadStorage.readLyrics(context, song, translated = true)
+    }
+
+    fun getRomanizedLyricContent(context: Context, song: SongItem): String? {
+        return ManagedDownloadStorage.readRomanizedLyrics(context, song)
     }
 
     // 解析网易云直链
@@ -2942,7 +3012,8 @@ object AudioDownloadManager {
 
     private data class DownloadedLyrics(
         val lyricText: String? = null,
-        val translatedText: String? = null
+        val translatedText: String? = null,
+        val romanizedText: String? = null
     )
 
     private fun ensureHttps(url: String): String = if (url.startsWith("http://")) url.replaceFirst("http://", "https://") else url

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/download/AudioDownloadManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/download/AudioDownloadManager.kt
@@ -2561,6 +2561,13 @@ object AudioDownloadManager {
                 }
             }
             romanizedText?.takeIf { it.isNotBlank() }?.let { lyric ->
+                ensureSongDownloadNotCancelled(
+                    songKey = songKey,
+                    stage = "lyrics_romanized_write",
+                    batchSessionId = batchSessionId,
+                    attemptId = attemptId,
+                    requireActiveAttempt = requireActiveAttempt
+                )
                 romanizedLyricReference = ManagedDownloadStorage.writeRomanizedLyrics(
                     context = context,
                     songId = song.id,

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProvider.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProvider.kt
@@ -42,6 +42,7 @@ import moe.ouom.neriplayer.core.api.search.MusicPlatform
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicClient
 import moe.ouom.neriplayer.core.player.download.AudioDownloadManager
 import moe.ouom.neriplayer.data.local.media.LocalMediaSupport
+import moe.ouom.neriplayer.data.local.media.LocalMediaDetails
 import moe.ouom.neriplayer.data.local.media.isLocalSong
 import moe.ouom.neriplayer.data.model.stableKey
 import moe.ouom.neriplayer.data.platform.youtube.extractYouTubeMusicVideoId
@@ -100,6 +101,14 @@ internal fun resolveLocalLyricOverrideState(rawLyric: String?): LocalLyricOverri
         rawLyric.isBlank() -> LocalLyricOverrideState.CLEARED
         else -> LocalLyricOverrideState.PRESENT
     }
+}
+
+internal fun resolveLocalFirstLyricText(
+    localLyric: String?,
+    storedLyric: String?,
+    downloadedLyric: String?
+): String? {
+    return localLyric ?: storedLyric ?: downloadedLyric
 }
 
 internal fun hasCollapsedLyricEntryTimeline(entries: List<LyricEntry>): Boolean {
@@ -367,46 +376,18 @@ internal object PlayerLyricsProvider {
         return convertPlainLyricsToEntries(rawLyric, durationMs)
     }
 
-    private fun loadOnDemandLocalLyrics(
+    private fun inspectLocalLyricDetails(
         application: Application,
         song: SongItem
-    ): List<LyricEntry>? {
+    ): LocalMediaDetails? {
         if (!song.isLocalSong()) {
             return null
         }
-
-        val localLyric = runCatching {
-            LocalMediaSupport.inspect(application, song)?.lyricContent
-        }.onFailure {
-            NPLogger.w("NERI-PlayerManager", "本地歌词懒加载失败: ${it.message}")
-        }.getOrNull()
-
-        return parseLocalLyricOverride(
-            rawLyric = localLyric,
-            durationMs = song.durationMs,
-            logPrefix = "本地歌词解析失败"
-        )
-    }
-
-    private fun loadOnDemandLocalTranslatedLyrics(
-        application: Application,
-        song: SongItem
-    ): List<LyricEntry>? {
-        if (!song.isLocalSong()) {
-            return null
-        }
-
-        val localTranslatedLyric = runCatching {
-            LocalMediaSupport.inspect(application, song)?.translatedLyricContent
-        }.onFailure {
-            NPLogger.w("NERI-PlayerManager", "本地翻译歌词懒加载失败: ${it.message}")
-        }.getOrNull()
-
-        return parseLocalLyricOverride(
-            rawLyric = localTranslatedLyric,
-            durationMs = song.durationMs,
-            logPrefix = "本地翻译歌词解析失败"
-        )
+        return runCatching { LocalMediaSupport.inspect(application, song) }
+            .onFailure {
+                NPLogger.w("NERI-PlayerManager", "本地歌词旁车读取失败: ${it.message}")
+            }
+            .getOrNull()
     }
 
     suspend fun getNeteaseLyrics(
@@ -500,26 +481,38 @@ internal object PlayerLyricsProvider {
     ): List<LyricEntry> {
         return withContext(Dispatchers.IO) {
             val isYouTubeMusicTrack = isYouTubeMusicSong(song)
+            val localDetails = inspectLocalLyricDetails(application, song)
+            val localTranslatedLyric = localDetails?.translatedLyricContent
             val storedTranslatedLyric = resolveStoredLyricText(
                 currentLyric = song.matchedTranslatedLyric,
                 legacyLyric = song.originalTranslatedLyric
+            )
+            val downloadedTranslatedLyric = AudioDownloadManager.getTranslatedLyricContent(application, song)
+            val selectedTranslatedLyric = resolveLocalFirstLyricText(
+                localLyric = localTranslatedLyric,
+                storedLyric = storedTranslatedLyric,
+                downloadedLyric = downloadedTranslatedLyric
             )
             val deferredStoredTranslation = if (isYouTubeMusicTrack) {
                 storedTranslatedLyric?.let(::extractPlainLyricsFromCollapsedTimedLyrics)
             } else {
                 null
             }
-            if (deferredStoredTranslation == null) {
+            if (localTranslatedLyric != null) {
                 parseLocalLyricOverride(
-                    rawLyric = storedTranslatedLyric,
+                    rawLyric = localTranslatedLyric,
+                    durationMs = song.durationMs,
+                    logPrefix = "本地翻译歌词解析失败"
+                )?.let { return@withContext it }
+            } else if (deferredStoredTranslation == null) {
+                parseLocalLyricOverride(
+                    rawLyric = selectedTranslatedLyric,
                     durationMs = song.durationMs,
                     logPrefix = "本地翻译歌词解析失败"
                 )?.let { return@withContext it }
             } else {
                 NPLogger.w("NERI-PlayerManager", "已忽略 YouTube 全零翻译时间轴: ${song.name}")
             }
-
-            val downloadedTranslatedLyric = AudioDownloadManager.getTranslatedLyricContent(application, song)
             val deferredDownloadedTranslation = if (isYouTubeMusicTrack) {
                 downloadedTranslatedLyric?.let(::extractPlainLyricsFromCollapsedTimedLyrics)
             } else {
@@ -533,13 +526,6 @@ internal object PlayerLyricsProvider {
                 )?.let { return@withContext it }
             } else {
                 NPLogger.w("NERI-PlayerManager", "已忽略下载的 YouTube 全零翻译时间轴: ${song.name}")
-            }
-
-            loadOnDemandLocalTranslatedLyrics(application, song)?.let { entries ->
-                if (entries.isEmpty()) {
-                    return@withContext emptyList()
-                }
-                return@withContext entries
             }
 
             if (isYouTubeMusicTrack) {
@@ -593,11 +579,28 @@ internal object PlayerLyricsProvider {
 
     suspend fun getRomanizedLyrics(
         song: SongItem,
+        application: Application,
         neteaseClient: NeteaseClient,
         neteaseLyricsCache: LruCache<Long, NeteaseLyricsCacheEntry>,
         biliSourceTag: String
     ): List<LyricEntry> {
         return withContext(Dispatchers.IO) {
+            val localRomanizedLyric = inspectLocalLyricDetails(application, song)
+                ?.romanizedLyricContent
+            localRomanizedLyric?.let { rawLyric ->
+                parseLocalLyricOverride(
+                    rawLyric = rawLyric,
+                    durationMs = song.durationMs,
+                    logPrefix = "本地音译歌词读取失败"
+                )?.let { return@withContext it }
+            }
+            AudioDownloadManager.getRomanizedLyricContent(application, song)?.let { rawLyric ->
+                parseLocalLyricOverride(
+                    rawLyric = rawLyric,
+                    durationMs = song.durationMs,
+                    logPrefix = "本地音译歌词读取失败"
+                )?.let { return@withContext it }
+            }
             if (isYouTubeMusicSong(song)) {
                 return@withContext emptyList()
             }
@@ -647,16 +650,23 @@ internal object PlayerLyricsProvider {
     ): List<LyricEntry> {
         return withContext(Dispatchers.IO) {
             val isYouTubeMusicTrack = isYouTubeMusicSong(song)
+            val localLyric = inspectLocalLyricDetails(application, song)?.lyricContent
             val storedLyric = resolveStoredLyricText(
                 currentLyric = song.matchedLyric,
                 legacyLyric = song.originalLyric
             )
+            val downloadedLyric = AudioDownloadManager.getLyricContent(application, song)
+            val selectedLyric = resolveLocalFirstLyricText(
+                localLyric = localLyric,
+                storedLyric = storedLyric,
+                downloadedLyric = downloadedLyric
+            )
             var deferredCollapsedLyrics: String? = null
-            when (resolveLocalLyricOverrideState(storedLyric)) {
+            when (resolveLocalLyricOverrideState(selectedLyric)) {
                 LocalLyricOverrideState.CLEARED -> return@withContext emptyList()
                 LocalLyricOverrideState.PRESENT -> {
                     val recoveredPlainLyrics = if (isYouTubeMusicTrack) {
-                        extractPlainLyricsFromCollapsedTimedLyrics(storedLyric!!)
+                        extractPlainLyricsFromCollapsedTimedLyrics(selectedLyric!!)
                     } else {
                         null
                     }
@@ -665,7 +675,7 @@ internal object PlayerLyricsProvider {
                         NPLogger.w("NERI-PlayerManager", "已暂缓 YouTube 全零歌词时间轴: ${song.name}")
                     } else {
                         parseLocalLyricOverride(
-                            rawLyric = storedLyric,
+                            rawLyric = selectedLyric,
                             durationMs = song.durationMs,
                             logPrefix = "匹配歌词解析失败"
                         )?.let { entries ->
@@ -675,8 +685,6 @@ internal object PlayerLyricsProvider {
                 }
                 LocalLyricOverrideState.ABSENT -> Unit
             }
-
-            val downloadedLyric = AudioDownloadManager.getLyricContent(application, song)
             val recoveredDownloadedPlainLyrics = if (isYouTubeMusicTrack) {
                 downloadedLyric?.let(::extractPlainLyricsFromCollapsedTimedLyrics)
             } else {
@@ -697,13 +705,6 @@ internal object PlayerLyricsProvider {
                     return@withContext entries
                 }
             }
-            loadOnDemandLocalLyrics(application, song)?.let { entries ->
-                if (entries.isEmpty()) {
-                    return@withContext emptyList()
-                }
-                return@withContext entries
-            }
-
             if (isYouTubeMusicTrack) {
                 return@withContext getYouTubeMusicLyrics(
                     song = song,

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -949,6 +949,7 @@ internal suspend fun PlayerManager.getTranslatedLyricsImpl(song: SongItem): List
 internal suspend fun PlayerManager.getRomanizedLyricsImpl(song: SongItem): List<LyricEntry> {
     return PlayerLyricsProvider.getRomanizedLyrics(
         song = song,
+        application = application,
         neteaseClient = neteaseClient,
         neteaseLyricsCache = neteaseLyricsCache,
         biliSourceTag = BILI_SOURCE_TAG

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManager.kt
@@ -76,7 +76,11 @@ internal data class QuickImportedSongSeed(
     val durationMs: Long?,
     val localFile: File? = null,
     val nearbyCoverUri: String? = null,
-    val sourceStableKey: String? = null
+    val sourceStableKey: String? = null,
+    val matchedLyric: String? = null,
+    val matchedTranslatedLyric: String? = null,
+    val originalLyric: String? = null,
+    val originalTranslatedLyric: String? = null
 )
 
 private data class QuickImportedAudioInfo(
@@ -250,7 +254,7 @@ object LocalAudioImportManager {
         val scanStartedAt = SystemClock.elapsedRealtime()
         NPLogger.d(TAG, "scanFolderSongs start: uri=$folderUri")
         val root = DocumentFile.fromTreeUri(context, folderUri)
-        if (root == null || !root.canRead()) {
+        if (root == null) {
             NPLogger.w(TAG, "scanFolderSongs skipped unreadable folder: $folderUri")
             return@withContext LocalAudioImportResult(
                 songs = emptyList(),
@@ -508,6 +512,10 @@ object LocalAudioImportManager {
             originalName = resolvedTitle,
             originalArtist = resolvedArtist,
             originalCoverUrl = seed.nearbyCoverUri,
+            matchedLyric = seed.matchedLyric,
+            matchedTranslatedLyric = seed.matchedTranslatedLyric,
+            originalLyric = seed.originalLyric,
+            originalTranslatedLyric = seed.originalTranslatedLyric,
             localFileName = resolvedDisplayName.ifBlank { null },
             localFilePath = seed.localFile?.absolutePath,
             channelId = "local",
@@ -735,7 +743,11 @@ object LocalAudioImportManager {
                 durationMs = details.durationMs,
                 localFile = details.filePath?.let(::File)?.takeIf(File::exists),
                 nearbyCoverUri = details.coverUri,
-                sourceStableKey = details.sourceStableKey
+                sourceStableKey = details.sourceStableKey,
+                matchedLyric = details.lyricContent,
+                matchedTranslatedLyric = details.translatedLyricContent,
+                originalLyric = details.lyricContent,
+                originalTranslatedLyric = details.translatedLyricContent
             ),
             unknownArtistLabel = context.getString(R.string.music_unknown_artist)
         )
@@ -873,6 +885,11 @@ object LocalAudioImportManager {
         } else {
             null
         }
+        val lyrics = runCatching {
+            LocalMediaSupport.inspectLyricsForScan(context, uri)
+        }.onFailure {
+            NPLogger.w(TAG, "quick local lyrics inspection failed for $uri: ${it.message}")
+        }.getOrNull()
 
         return buildQuickImportedSong(
             seed = QuickImportedSongSeed(
@@ -883,7 +900,11 @@ object LocalAudioImportManager {
                 album = queryInfo.album,
                 durationMs = queryInfo.durationMs,
                 localFile = resolvedFile,
-                nearbyCoverUri = nearbyCoverUri
+                nearbyCoverUri = nearbyCoverUri,
+                matchedLyric = lyrics?.lyric,
+                matchedTranslatedLyric = lyrics?.translatedLyric,
+                originalLyric = lyrics?.lyric,
+                originalTranslatedLyric = lyrics?.translatedLyric
             ),
             unknownArtistLabel = context.getString(R.string.music_unknown_artist)
         )
@@ -989,6 +1010,12 @@ object LocalAudioImportManager {
         resolveSourceFile(context, uri)?.let { sourceFile ->
             copyNearbySidecars(sourceFile, targetFile)
         }
+        LocalMediaSupport.copyNearbyLyricSidecars(
+            context = context,
+            sourceUri = uri,
+            sourceDisplayName = displayName ?: targetFile.name,
+            targetFile = targetFile
+        )
 
         return Uri.fromFile(targetFile)
     }

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManager.kt
@@ -135,19 +135,18 @@ internal fun buildNearbySidecarCopyPlans(
             extensions = lyricExtensions
         )
 
-        fun addSelectedLyricSidecar(source: File?, translated: Boolean) {
+        fun addSelectedLyricSidecar(source: File?) {
             source ?: return
-            val sourcePrefix = if (translated) "${sourceBase}_trans" else sourceBase
-            val targetPrefix = if (translated) "${targetBase}_trans" else targetBase
             val suffix = source.name
-                .removePrefix(sourcePrefix)
-                .takeIf { it.startsWith('.') }
+                .removePrefix(sourceBase)
+                .takeIf { it.startsWith('.') || it.startsWith('_') }
                 ?: return
-            addIfExists(source, File(targetDir, "$targetPrefix$suffix"))
+            addIfExists(source, File(targetDir, "$targetBase$suffix"))
         }
 
-        addSelectedLyricSidecar(nearbyLyricFiles.original, translated = false)
-        addSelectedLyricSidecar(nearbyLyricFiles.translated, translated = true)
+        addSelectedLyricSidecar(nearbyLyricFiles.original)
+        addSelectedLyricSidecar(nearbyLyricFiles.translated)
+        addSelectedLyricSidecar(nearbyLyricFiles.romanized)
 
         imageExtensions.forEach { extension ->
             addIfExists(File(sourceDir, "$sourceBase.$extension"), File(targetDir, "$targetBase.$extension"))

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/NeriUserDataDatabase.kt
@@ -94,7 +94,7 @@ import moe.ouom.neriplayer.data.local.database.entity.PlatformPlaylistCacheTrack
         PlatformPlaylistCacheTrackEntity::class,
         PlatformPlaylistCacheTrackArtistEntity::class
     ],
-    version = 14,
+    version = 15,
     exportSchema = true
 )
 internal abstract class NeriUserDataDatabase : RoomDatabase() {
@@ -161,7 +161,8 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
                 MIGRATION_10_11,
                 MIGRATION_11_12,
                 MIGRATION_12_13,
-                MIGRATION_13_14
+                MIGRATION_13_14,
+                MIGRATION_14_15
             ).build()
         }
 
@@ -993,6 +994,15 @@ internal abstract class NeriUserDataDatabase : RoomDatabase() {
         val MIGRATION_13_14: Migration = object : Migration(13, 14) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 createPlatformPlaylistCacheTables(db)
+            }
+        }
+
+        val MIGRATION_14_15: Migration = object : Migration(14, 15) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE `download_snapshot_metadata` " +
+                        "ADD COLUMN `romanized_lyric_path` TEXT"
+                )
             }
         }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/DownloadSnapshotEntities.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/database/entity/DownloadSnapshotEntities.kt
@@ -124,6 +124,8 @@ internal data class DownloadSnapshotMetadataEntity(
     val lyricPath: String?,
     @ColumnInfo(name = "translated_lyric_path")
     val translatedLyricPath: String?,
+    @ColumnInfo(name = "romanized_lyric_path")
+    val romanizedLyricPath: String?,
     @ColumnInfo(name = "duration_ms")
     val durationMs: Long,
     @ColumnInfo(name = "download_finalized")

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
@@ -37,6 +37,7 @@ import android.os.Environment
 import android.os.ParcelFileDescriptor
 import android.provider.MediaStore
 import android.provider.OpenableColumns
+import android.provider.DocumentsContract
 import android.system.Os
 import androidx.core.content.FileProvider
 import com.kyant.taglib.Picture
@@ -131,12 +132,20 @@ data class LocalMediaDetails(
     val originalArtist: String?,
     val embeddedCover: Boolean,
     val sourceStableKey: String? = null,
-    val translatedLyricContent: String? = null
+    val translatedLyricContent: String? = null,
+    val romanizedLyricContent: String? = null
 )
 
 internal data class NearbyLyricFiles(
     val original: File?,
-    val translated: File?
+    val translated: File?,
+    val romanized: File? = null
+)
+
+internal data class NearbyLyricReferences(
+    val original: String?,
+    val translated: String?,
+    val romanized: String?
 )
 
 internal enum class EditableCoverMutation {
@@ -1252,10 +1261,29 @@ object LocalMediaSupport {
         )
         val nearbyCover = findNearbyCover(file)
         val nearbyLyricFiles = findNearbyLyricFiles(file)
-        val nearbyLyricContent = readNearbyLyricContent(nearbyLyricFiles.original, "lyric")
+        val nearbyLyricReferences = findNearbyLyricReferences(
+            context = context,
+            uri = uri,
+            file = file,
+            displayName = displayName
+        )
+        val nearbyLyricContent = readNearbyLyricContent(
+            context = context,
+            reference = nearbyLyricReferences.original
+                ?: nearbyLyricFiles.original?.absolutePath,
+            label = "lyric"
+        )
         val nearbyTranslatedLyricContent = readNearbyLyricContent(
-            nearbyLyricFiles.translated,
-            "translated lyric"
+            context = context,
+            reference = nearbyLyricReferences.translated
+                ?: nearbyLyricFiles.translated?.absolutePath,
+            label = "translated lyric"
+        )
+        val nearbyRomanizedLyricContent = readNearbyLyricContent(
+            context = context,
+            reference = nearbyLyricReferences.romanized
+                ?: nearbyLyricFiles.romanized?.absolutePath,
+            label = "romanized lyric"
         )
         val hasEffectiveExternalLyric = !nearbyLyricContent.isNullOrBlank()
         val effectiveLyricContent = resolveEffectiveLocalLyricContent(
@@ -1266,6 +1294,8 @@ object LocalMediaSupport {
             sidecarContent = nearbyTranslatedLyricContent,
             embeddedContent = tagLibMetadata?.translatedLyrics
         )
+        val effectiveRomanizedLyricContent = nearbyRomanizedLyricContent
+            ?.takeIf(String::isNotBlank)
 
         val retriever = MediaMetadataRetriever()
         return try {
@@ -1398,13 +1428,15 @@ object LocalMediaSupport {
                     else -> null
                 },
                 lyricContent = effectiveLyricContent,
-                lyricPath = nearbyLyricFiles.original?.absolutePath?.takeIf { hasEffectiveExternalLyric },
+                lyricPath = nearbyLyricReferences.original
+                    ?: nearbyLyricFiles.original?.absolutePath?.takeIf { hasEffectiveExternalLyric },
                 lyricSource = when {
                     hasEffectiveExternalLyric -> context.getString(R.string.local_song_lyric_external)
                     !effectiveLyricContent.isNullOrBlank() -> context.getString(R.string.local_song_lyric_embedded)
                     else -> null
                 },
                 translatedLyricContent = effectiveTranslatedLyricContent,
+                romanizedLyricContent = effectiveRomanizedLyricContent,
                 originalTitle = title,
                 originalArtist = tagLibMetadata?.artist ?: containerMetadata?.artist ?: queried.artist ?: artist,
                 embeddedCover = embeddedCover || tagLibCoverUri != null,
@@ -1464,13 +1496,15 @@ object LocalMediaSupport {
                     else -> null
                 },
                 lyricContent = effectiveLyricContent,
-                lyricPath = nearbyLyricFiles.original?.absolutePath?.takeIf { hasEffectiveExternalLyric },
+                lyricPath = nearbyLyricReferences.original
+                    ?: nearbyLyricFiles.original?.absolutePath?.takeIf { hasEffectiveExternalLyric },
                 lyricSource = when {
                     hasEffectiveExternalLyric -> context.getString(R.string.local_song_lyric_external)
                     !effectiveLyricContent.isNullOrBlank() -> context.getString(R.string.local_song_lyric_embedded)
                     else -> null
                 },
                 translatedLyricContent = effectiveTranslatedLyricContent,
+                romanizedLyricContent = effectiveRomanizedLyricContent,
                 originalTitle = title,
                 originalArtist = tagLibMetadata?.artist
                     ?: containerMetadata?.artist?.takeIf { it.isNotBlank() }
@@ -1570,7 +1604,8 @@ object LocalMediaSupport {
             lyricSource = null,
             originalTitle = selectedMetadata.title,
             originalArtist = selectedMetadata.artist,
-            embeddedCover = false
+            embeddedCover = false,
+            romanizedLyricContent = null
         )
     }
 
@@ -3029,8 +3064,8 @@ object LocalMediaSupport {
         file: File?,
         extensions: List<String> = lyricExtensions
     ): NearbyLyricFiles {
-        val actualFile = file ?: return NearbyLyricFiles(null, null)
-        val parent = actualFile.parentFile ?: return NearbyLyricFiles(null, null)
+        val actualFile = file ?: return NearbyLyricFiles(null, null, null)
+        val parent = actualFile.parentFile ?: return NearbyLyricFiles(null, null, null)
         val baseName = actualFile.nameWithoutExtension
         val searchDirectories = listOf(parent, File(parent, "Lyrics"))
             .filter(File::isDirectory)
@@ -3040,7 +3075,7 @@ object LocalMediaSupport {
                 searchDirectories = searchDirectories,
                 fileNames = lyricSidecarNames(
                     baseName = baseName,
-                    translated = false,
+                    kind = LyricKind.ORIGINAL,
                     extensions = extensions
                 )
             ),
@@ -3048,21 +3083,186 @@ object LocalMediaSupport {
                 searchDirectories = searchDirectories,
                 fileNames = lyricSidecarNames(
                     baseName = baseName,
-                    translated = true,
+                    kind = LyricKind.TRANSLATED,
+                    extensions = extensions
+                )
+            ),
+            romanized = findFirstLyricSidecar(
+                searchDirectories = searchDirectories,
+                fileNames = lyricSidecarNames(
+                    baseName = baseName,
+                    kind = LyricKind.ROMANIZED,
                     extensions = extensions
                 )
             )
         )
     }
 
-    private fun readNearbyLyricContent(file: File?, label: String): String? {
-        return file?.let {
-            readTextFile(it)
+    private fun readNearbyLyricContent(
+        context: Context,
+        reference: String?,
+        label: String
+    ): String? {
+        return reference?.let {
+            readTextContent(context, it)
                 ?: run {
-                    NPLogger.w(TAG, "read $label failed for ${it.absolutePath}")
+                    NPLogger.w(TAG, "read $label failed for $it")
                     null
                 }
         }
+    }
+
+    private fun findNearbyLyricReferences(
+        context: Context,
+        uri: Uri,
+        file: File?,
+        displayName: String
+    ): NearbyLyricReferences {
+        val localFiles = findNearbyLyricFiles(file)
+        if (!uri.scheme.equals("content", ignoreCase = true)) {
+            return NearbyLyricReferences(
+                original = localFiles.original?.absolutePath,
+                translated = localFiles.translated?.absolutePath,
+                romanized = localFiles.romanized?.absolutePath
+            )
+        }
+
+        val treeDocumentId = runCatching {
+            DocumentsContract.getTreeDocumentId(uri)
+        }.getOrNull()
+        val documentId = runCatching {
+            DocumentsContract.getDocumentId(uri)
+        }.getOrNull()
+        val treeUri = runCatching {
+            val authority = uri.authority ?: return@runCatching null
+            DocumentsContract.buildTreeDocumentUri(
+                authority,
+                DocumentsContract.getTreeDocumentId(uri)
+            )
+        }.getOrNull() ?: uri
+        val slashDelimitedParentId = documentId
+            ?.substringBeforeLast('/', missingDelimiterValue = "")
+            ?.takeIf { it.isNotBlank() && it != documentId }
+        val documentUri = if (treeDocumentId != null && documentId != null) {
+            DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId)
+        } else {
+            uri
+        }
+        val parentDocumentId = slashDelimitedParentId
+            ?: findDocumentParentId(context, documentUri)
+            ?: treeDocumentId
+        val parentChildren = queryDocumentChildren(context, treeUri, parentDocumentId)
+        val audioBaseName = displayName.substringBeforeLast('.', displayName)
+        val directReferences = resolveDocumentLyricReferences(
+            children = parentChildren,
+            baseName = audioBaseName
+        )
+        val lyricsDirectory = parentChildren.firstOrNull {
+            it.isDirectory && it.displayName.equals("Lyrics", ignoreCase = true)
+        }
+        val nestedReferences = resolveDocumentLyricReferences(
+            children = lyricsDirectory?.let {
+                queryDocumentChildren(context, treeUri, it.documentId)
+            }.orEmpty(),
+            baseName = audioBaseName
+        )
+        return NearbyLyricReferences(
+            original = directReferences.original ?: nestedReferences.original
+                ?: localFiles.original?.absolutePath,
+            translated = directReferences.translated ?: nestedReferences.translated
+                ?: localFiles.translated?.absolutePath,
+            romanized = directReferences.romanized ?: nestedReferences.romanized
+                ?: localFiles.romanized?.absolutePath
+        )
+    }
+
+    private fun findDocumentParentId(context: Context, documentUri: Uri): String? {
+        return runCatching {
+            DocumentsContract.findDocumentPath(context.contentResolver, documentUri)
+                ?.path
+                ?.dropLast(1)
+                ?.lastOrNull()
+                ?.takeIf(String::isNotBlank)
+        }.getOrNull()
+    }
+
+    private fun resolveDocumentLyricReferences(
+        children: Collection<DocumentChild>,
+        baseName: String
+    ): NearbyLyricReferences {
+        fun find(kind: LyricKind): String? {
+            val names = lyricSidecarNames(baseName, kind, lyricExtensions)
+            return names.firstNotNullOfOrNull { expectedName ->
+                children.firstOrNull { child ->
+                    !child.isDirectory && child.displayName == expectedName
+                }?.uri
+            }
+        }
+        return NearbyLyricReferences(
+            original = find(LyricKind.ORIGINAL),
+            translated = find(LyricKind.TRANSLATED),
+            romanized = find(LyricKind.ROMANIZED)
+        )
+    }
+
+    private data class DocumentChild(
+        val documentId: String,
+        val displayName: String,
+        val isDirectory: Boolean,
+        val uri: String
+    )
+
+    private fun queryDocumentChildren(
+        context: Context,
+        treeUri: Uri,
+        parentDocumentId: String?
+    ): List<DocumentChild> {
+        val resolvedParentId = parentDocumentId?.takeIf { it.isNotBlank() } ?: return emptyList()
+        val childrenUri = runCatching {
+            DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, resolvedParentId)
+        }.getOrNull() ?: return emptyList()
+        return runCatching {
+            context.contentResolver.query(
+                childrenUri,
+                arrayOf(
+                    DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                    DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                    DocumentsContract.Document.COLUMN_MIME_TYPE
+                ),
+                null,
+                null,
+                null
+            )?.use { cursor ->
+                val idIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+                val nameIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+                val mimeIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_MIME_TYPE)
+                if (idIndex < 0 || nameIndex < 0 || mimeIndex < 0) {
+                    return@use emptyList()
+                }
+                buildList {
+                    while (cursor.moveToNext()) {
+                        val childId = cursor.getString(idIndex)?.takeIf { it.isNotBlank() }
+                            ?: continue
+                        val childName = cursor.getString(nameIndex)?.takeIf { it.isNotBlank() }
+                            ?: continue
+                        val mimeType = cursor.getString(mimeIndex).orEmpty()
+                        add(
+                            DocumentChild(
+                                documentId = childId,
+                                displayName = childName,
+                                isDirectory = mimeType == DocumentsContract.Document.MIME_TYPE_DIR,
+                                uri = DocumentsContract.buildDocumentUriUsingTree(
+                                    treeUri,
+                                    childId
+                                ).toString()
+                            )
+                        )
+                    }
+                }
+            }.orEmpty()
+        }.onFailure {
+            NPLogger.w(TAG, "query document lyric children failed for $treeUri: ${it.message}")
+        }.getOrDefault(emptyList())
     }
 
     internal fun resolveEffectiveLocalLyricContent(
@@ -3084,18 +3284,34 @@ object LocalMediaSupport {
 
     private fun lyricSidecarNames(
         baseName: String,
-        translated: Boolean,
+        kind: LyricKind,
         extensions: List<String>
     ): List<String> {
-        val prefix = if (translated) "${baseName}_trans" else baseName
+        val prefixes = when (kind) {
+            LyricKind.ORIGINAL -> listOf(baseName)
+            LyricKind.TRANSLATED -> listOf("${baseName}_trans")
+            LyricKind.ROMANIZED -> listOf(
+                "${baseName}_roma",
+                "${baseName}_romalrc",
+                "${baseName}_romanized"
+            )
+        }
         return buildList {
-            extensions.forEach { extension ->
-                add("$prefix.$extension")
-            }
-            if ("lrc" in extensions) {
-                add("$prefix.lrc.txt")
+            prefixes.forEach { prefix ->
+                extensions.forEach { extension ->
+                    add("$prefix.$extension")
+                }
+                if ("lrc" in extensions) {
+                    add("$prefix.lrc.txt")
+                }
             }
         }
+    }
+
+    private enum class LyricKind {
+        ORIGINAL,
+        TRANSLATED,
+        ROMANIZED
     }
 
     internal fun findNearbyCover(file: File?): File? {

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
@@ -1428,8 +1428,11 @@ object LocalMediaSupport {
                     else -> null
                 },
                 lyricContent = effectiveLyricContent,
-                lyricPath = nearbyLyricReferences.original
-                    ?: nearbyLyricFiles.original?.absolutePath?.takeIf { hasEffectiveExternalLyric },
+                lyricPath = resolveEffectiveLocalLyricPath(
+                    reference = nearbyLyricReferences.original
+                        ?: nearbyLyricFiles.original?.absolutePath,
+                    content = nearbyLyricContent
+                ),
                 lyricSource = when {
                     hasEffectiveExternalLyric -> context.getString(R.string.local_song_lyric_external)
                     !effectiveLyricContent.isNullOrBlank() -> context.getString(R.string.local_song_lyric_embedded)
@@ -1496,8 +1499,11 @@ object LocalMediaSupport {
                     else -> null
                 },
                 lyricContent = effectiveLyricContent,
-                lyricPath = nearbyLyricReferences.original
-                    ?: nearbyLyricFiles.original?.absolutePath?.takeIf { hasEffectiveExternalLyric },
+                lyricPath = resolveEffectiveLocalLyricPath(
+                    reference = nearbyLyricReferences.original
+                        ?: nearbyLyricFiles.original?.absolutePath,
+                    content = nearbyLyricContent
+                ),
                 lyricSource = when {
                     hasEffectiveExternalLyric -> context.getString(R.string.local_song_lyric_external)
                     !effectiveLyricContent.isNullOrBlank() -> context.getString(R.string.local_song_lyric_embedded)
@@ -2413,7 +2419,7 @@ object LocalMediaSupport {
         audioExtension: String?
     ): Array<Picture> {
         if (usesRolelessEditableCoverPictures(audioExtension)) {
-            return replacementPicture?.let(::arrayOf) ?: emptyArray()
+            return replacementPicture?.let { arrayOf<Picture>(it) } ?: emptyArray<Picture>()
         }
         val retainedPictures = existingPictures.filterNot(::isFrontCoverPicture)
         return if (replacementPicture == null) {
@@ -3135,15 +3141,14 @@ object LocalMediaSupport {
         }.getOrNull()
         val treeUri = runCatching {
             val authority = uri.authority ?: return@runCatching null
-            DocumentsContract.buildTreeDocumentUri(
-                authority,
-                DocumentsContract.getTreeDocumentId(uri)
-            )
-        }.getOrNull() ?: uri
+            treeDocumentId?.let { documentId ->
+                DocumentsContract.buildTreeDocumentUri(authority, documentId)
+            }
+        }.getOrNull()
         val slashDelimitedParentId = documentId
             ?.substringBeforeLast('/', missingDelimiterValue = "")
             ?.takeIf { it.isNotBlank() && it != documentId }
-        val documentUri = if (treeDocumentId != null && documentId != null) {
+        val documentUri = if (treeUri != null && documentId != null) {
             DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId)
         } else {
             uri
@@ -3151,7 +3156,11 @@ object LocalMediaSupport {
         val parentDocumentId = slashDelimitedParentId
             ?: findDocumentParentId(context, documentUri)
             ?: treeDocumentId
-        val parentChildren = queryDocumentChildren(context, treeUri, parentDocumentId)
+        val parentChildren = queryDocumentChildren(
+            context = context,
+            baseUri = treeUri ?: uri,
+            parentDocumentId = parentDocumentId
+        )
         val audioBaseName = displayName.substringBeforeLast('.', displayName)
         val directReferences = resolveDocumentLyricReferences(
             children = parentChildren,
@@ -3162,7 +3171,11 @@ object LocalMediaSupport {
         }
         val nestedReferences = resolveDocumentLyricReferences(
             children = lyricsDirectory?.let {
-                queryDocumentChildren(context, treeUri, it.documentId)
+                queryDocumentChildren(
+                    context = context,
+                    baseUri = treeUri ?: uri,
+                    parentDocumentId = it.documentId
+                )
             }.orEmpty(),
             baseName = audioBaseName
         )
@@ -3214,12 +3227,19 @@ object LocalMediaSupport {
 
     private fun queryDocumentChildren(
         context: Context,
-        treeUri: Uri,
+        baseUri: Uri,
         parentDocumentId: String?
     ): List<DocumentChild> {
         val resolvedParentId = parentDocumentId?.takeIf { it.isNotBlank() } ?: return emptyList()
         val childrenUri = runCatching {
-            DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, resolvedParentId)
+            if (DocumentsContract.isTreeUri(baseUri)) {
+                DocumentsContract.buildChildDocumentsUriUsingTree(baseUri, resolvedParentId)
+            } else {
+                DocumentsContract.buildChildDocumentsUri(
+                    baseUri.authority ?: return@runCatching null,
+                    resolvedParentId
+                )
+            }
         }.getOrNull() ?: return emptyList()
         return runCatching {
             context.contentResolver.query(
@@ -3251,18 +3271,26 @@ object LocalMediaSupport {
                                 documentId = childId,
                                 displayName = childName,
                                 isDirectory = mimeType == DocumentsContract.Document.MIME_TYPE_DIR,
-                                uri = DocumentsContract.buildDocumentUriUsingTree(
-                                    treeUri,
-                                    childId
-                                ).toString()
+                                uri = buildDocumentReferenceUri(baseUri, childId).toString()
                             )
                         )
                     }
                 }
             }.orEmpty()
         }.onFailure {
-            NPLogger.w(TAG, "query document lyric children failed for $treeUri: ${it.message}")
+            NPLogger.w(TAG, "query document lyric children failed for $baseUri: ${it.message}")
         }.getOrDefault(emptyList())
+    }
+
+    private fun buildDocumentReferenceUri(baseUri: Uri, documentId: String): Uri {
+        return if (DocumentsContract.isTreeUri(baseUri)) {
+            DocumentsContract.buildDocumentUriUsingTree(baseUri, documentId)
+        } else {
+            DocumentsContract.buildDocumentUri(
+                baseUri.authority ?: error("Document URI has no authority: $baseUri"),
+                documentId
+            )
+        }
     }
 
     internal fun resolveEffectiveLocalLyricContent(
@@ -3271,6 +3299,13 @@ object LocalMediaSupport {
     ): String? {
         return sidecarContent?.takeIf(String::isNotBlank)
             ?: embeddedContent?.takeIf(String::isNotBlank)
+    }
+
+    internal fun resolveEffectiveLocalLyricPath(
+        reference: String?,
+        content: String?
+    ): String? {
+        return reference?.takeIf { !content.isNullOrBlank() }
     }
 
     private fun findFirstLyricSidecar(

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
@@ -61,6 +61,7 @@ import moe.ouom.neriplayer.util.network.isFileInsideDirectory
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.io.RandomAccessFile
@@ -94,6 +95,7 @@ private val MP4_SUPPORTED_COVER_MIME_TYPES = setOf(
 )
 private val EDITABLE_COVER_JPEG_QUALITIES = intArrayOf(95, 90, 85, 80, 75, 70, 65, 60)
 private const val STAGED_METADATA_WRITE_DIRECTORY = "staged_metadata_writes"
+private const val LOCAL_METADATA_SUFFIX = ".npmeta.json"
 private val STAGED_CONTENT_REWRITE_EXTENSIONS = setOf(
     "aac", "aif", "aiff", "ape", "flac", "m4a", "m4b", "mp3", "mp4",
     "ogg", "opus", "tta", "wav", "wv"
@@ -146,6 +148,40 @@ internal data class NearbyLyricReferences(
     val original: String?,
     val translated: String?,
     val romanized: String?
+)
+
+internal data class LocalLyricsScanMetadata(
+    val lyric: String?,
+    val translatedLyric: String?,
+    val romanizedLyric: String?
+)
+
+internal data class LocalMetadataSidecar(
+    val reference: String,
+    val hasLyricOverride: Boolean,
+    val hasTranslatedLyricOverride: Boolean,
+    val hasRomanizedLyricOverride: Boolean,
+    val matchedLyric: String?,
+    val matchedTranslatedLyric: String?,
+    val originalLyric: String?,
+    val originalTranslatedLyric: String?,
+    val matchedRomanizedLyric: String?,
+    val originalRomanizedLyric: String?
+) {
+    val lyric: String?
+        get() = matchedLyric ?: originalLyric
+
+    val translatedLyric: String?
+        get() = matchedTranslatedLyric ?: originalTranslatedLyric
+
+    val romanizedLyric: String?
+        get() = matchedRomanizedLyric ?: originalRomanizedLyric
+}
+
+private data class LocalDocumentNavigation(
+    val baseUri: Uri,
+    val treeUri: Uri?,
+    val parentDocumentId: String?
 )
 
 internal enum class EditableCoverMutation {
@@ -536,12 +572,37 @@ object LocalMediaSupport {
             } else {
                 directOutcome
             }
-            if (outcome == LocalMediaMetadataWriteOutcome.SUCCESS) {
-                return@withContext outcome
+            val sidecarWritten = if (writeLyrics) {
+                writeLocalLyricsMetadata(
+                    context = context,
+                    sourceUri = sourceUri,
+                    file = runCatching { resolveLocalFile(context, sourceUri) }.getOrNull(),
+                    displayName = song.localFileName
+                        ?.takeIf(String::isNotBlank)
+                        ?: sourceUri.lastPathSegment.orEmpty(),
+                    song = song
+                )
+            } else {
+                true
+            }
+            val finalOutcome = when {
+                !writeLyrics -> outcome
+                !sidecarWritten -> LocalMediaMetadataWriteOutcome.FAILED
+                outcome == LocalMediaMetadataWriteOutcome.SUCCESS -> {
+                    LocalMediaMetadataWriteOutcome.SUCCESS
+                }
+                !writeCover -> LocalMediaMetadataWriteOutcome.SUCCESS
+                else -> outcome
+            }
+            if (!sidecarWritten) {
+                NPLogger.w(TAG, "write local lyrics metadata sidecar failed for $sourceUri")
+            }
+            if (finalOutcome == LocalMediaMetadataWriteOutcome.SUCCESS) {
+                return@withContext finalOutcome
             }
             fallbackOutcome = selectEditableMetadataWriteFallback(
                 current = fallbackOutcome,
-                candidate = outcome
+                candidate = finalOutcome
             )
         }
         fallbackOutcome
@@ -1083,6 +1144,66 @@ object LocalMediaSupport {
             ?: queried.album?.takeIf { it.isNotBlank() }
         val usesFallbackAlbum = album == null
         val nearbyCover = findNearbyCover(file)
+        val localMetadata = readLocalMetadataSidecar(
+            context = context,
+            sourceUri = uri,
+            file = file,
+            displayName = resolved.displayName
+        )
+        val nearbyLyricFiles = findNearbyLyricFiles(file)
+        val nearbyLyricReferences = findNearbyLyricReferences(
+            context = context,
+            uri = uri,
+            file = file,
+            displayName = resolved.displayName
+        )
+        val nearbyLyricContent = readNearbyLyricContent(
+            context = context,
+            reference = nearbyLyricReferences.original
+                ?: nearbyLyricFiles.original?.absolutePath,
+            label = "scan lyric"
+        )
+        val nearbyTranslatedLyricContent = readNearbyLyricContent(
+            context = context,
+            reference = nearbyLyricReferences.translated
+                ?: nearbyLyricFiles.translated?.absolutePath,
+            label = "scan translated lyric"
+        )
+        val nearbyRomanizedLyricContent = readNearbyLyricContent(
+            context = context,
+            reference = nearbyLyricReferences.romanized
+                ?: nearbyLyricFiles.romanized?.absolutePath,
+            label = "scan romanized lyric"
+        )
+        val effectiveLyricContent = if (localMetadata?.hasLyricOverride == true) {
+            localMetadata.lyric
+        } else {
+            resolveEffectiveLocalLyricContent(
+                sidecarContent = nearbyLyricContent,
+                embeddedContent = tagLibMetadata?.lyrics
+            )
+        }
+        val effectiveTranslatedLyricContent = if (
+            localMetadata?.hasTranslatedLyricOverride == true
+        ) {
+            localMetadata.translatedLyric
+        } else {
+            resolveEffectiveLocalLyricContent(
+                sidecarContent = nearbyTranslatedLyricContent,
+                embeddedContent = tagLibMetadata?.translatedLyrics
+            )
+        }
+        val effectiveRomanizedLyricContent = if (
+            localMetadata?.hasRomanizedLyricOverride == true
+        ) {
+            localMetadata.romanizedLyric
+        } else {
+            nearbyRomanizedLyricContent?.takeIf(String::isNotBlank)
+        }
+        val lyricReference = localMetadata?.reference
+            ?.takeIf { localMetadata.hasLyricOverride }
+            ?: nearbyLyricReferences.original
+            ?: nearbyLyricFiles.original?.absolutePath
 
         return LocalMediaDetails(
             sourceUri = uri,
@@ -1112,16 +1233,93 @@ object LocalMediaSupport {
             coverSource = nearbyCover?.let {
                 context.getString(R.string.local_song_cover_external)
             },
-            lyricContent = null,
-            lyricPath = null,
-            lyricSource = null,
+            lyricContent = effectiveLyricContent,
+            lyricPath = resolveEffectiveLocalLyricPath(
+                reference = lyricReference,
+                content = effectiveLyricContent
+            ),
+            lyricSource = when {
+                localMetadata?.hasLyricOverride != true &&
+                    !nearbyLyricContent.isNullOrBlank() -> {
+                    context.getString(R.string.local_song_lyric_external)
+                }
+                !effectiveLyricContent.isNullOrBlank() -> {
+                    context.getString(R.string.local_song_lyric_embedded)
+                }
+                else -> null
+            },
             originalTitle = title,
             originalArtist = tagLibMetadata?.artist
                 ?: containerMetadata?.artist?.takeIf { it.isNotBlank() }
                 ?: queried.artist?.takeIf { it.isNotBlank() }
                 ?: artist,
             embeddedCover = false,
-            sourceStableKey = tagLibMetadata?.sourceStableKey
+            sourceStableKey = tagLibMetadata?.sourceStableKey,
+            translatedLyricContent = effectiveTranslatedLyricContent,
+            romanizedLyricContent = effectiveRomanizedLyricContent
+        )
+    }
+
+    internal fun inspectLyricsForScan(
+        context: Context,
+        uri: Uri
+    ): LocalLyricsScanMetadata {
+        val resolved = resolveInspectableLocalMedia(
+            context = context,
+            uri = uri,
+            allowDescriptorFallback = true
+        )
+        val localMetadata = readLocalMetadataSidecar(
+            context = context,
+            sourceUri = uri,
+            file = resolved.file,
+            displayName = resolved.displayName
+        )
+        val nearbyFiles = findNearbyLyricFiles(resolved.file)
+        val nearbyReferences = findNearbyLyricReferences(
+            context = context,
+            uri = uri,
+            file = resolved.file,
+            displayName = resolved.displayName
+        )
+        fun read(reference: String?, fallback: File?, label: String): String? {
+            return readNearbyLyricContent(
+                context = context,
+                reference = reference ?: fallback?.absolutePath,
+                label = label
+            )
+        }
+        val nearbyLyric = read(
+            nearbyReferences.original,
+            nearbyFiles.original,
+            "quick scan lyric"
+        )
+        val nearbyTranslatedLyric = read(
+            nearbyReferences.translated,
+            nearbyFiles.translated,
+            "quick scan translated lyric"
+        )
+        val nearbyRomanizedLyric = read(
+            nearbyReferences.romanized,
+            nearbyFiles.romanized,
+            "quick scan romanized lyric"
+        )
+        return LocalLyricsScanMetadata(
+            lyric = if (localMetadata?.hasLyricOverride == true) {
+                localMetadata.lyric
+            } else {
+                nearbyLyric
+            },
+            translatedLyric = if (localMetadata?.hasTranslatedLyricOverride == true) {
+                localMetadata.translatedLyric
+            } else {
+                nearbyTranslatedLyric
+            },
+            romanizedLyric = if (localMetadata?.hasRomanizedLyricOverride == true) {
+                localMetadata.romanizedLyric
+            } else {
+                nearbyRomanizedLyric
+            }
         )
     }
 
@@ -1162,6 +1360,12 @@ object LocalMediaSupport {
             ?: queried.album?.takeIf { it.isNotBlank() }
         val usesFallbackAlbum = album == null
         val resolvedAlbum = album ?: context.getString(R.string.local_files)
+        val localMetadata = readLocalMetadataSidecar(
+            context = context,
+            sourceUri = uri,
+            file = file,
+            displayName = resolved.displayName
+        )
 
         return LocalMediaDetails(
             sourceUri = uri,
@@ -1202,7 +1406,7 @@ object LocalMediaSupport {
             filePath = file?.absolutePath ?: queried.filePath,
             coverUri = null,
             coverSource = null,
-            lyricContent = null,
+            lyricContent = localMetadata?.lyric,
             lyricPath = null,
             lyricSource = null,
             originalTitle = title,
@@ -1212,7 +1416,9 @@ object LocalMediaSupport {
                 ?: queried.artist?.takeIf { it.isNotBlank() }
                 ?: artist,
             embeddedCover = false,
-            sourceStableKey = tagLibMetadata?.sourceStableKey
+            sourceStableKey = tagLibMetadata?.sourceStableKey,
+            translatedLyricContent = localMetadata?.translatedLyric,
+            romanizedLyricContent = localMetadata?.romanizedLyric
         )
     }
 
@@ -1285,17 +1491,39 @@ object LocalMediaSupport {
                 ?: nearbyLyricFiles.romanized?.absolutePath,
             label = "romanized lyric"
         )
-        val hasEffectiveExternalLyric = !nearbyLyricContent.isNullOrBlank()
-        val effectiveLyricContent = resolveEffectiveLocalLyricContent(
-            sidecarContent = nearbyLyricContent,
-            embeddedContent = tagLibMetadata?.lyrics
+        val localMetadata = readLocalMetadataSidecar(
+            context = context,
+            sourceUri = uri,
+            file = file,
+            displayName = displayName
         )
-        val effectiveTranslatedLyricContent = resolveEffectiveLocalLyricContent(
-            sidecarContent = nearbyTranslatedLyricContent,
-            embeddedContent = tagLibMetadata?.translatedLyrics
-        )
-        val effectiveRomanizedLyricContent = nearbyRomanizedLyricContent
-            ?.takeIf(String::isNotBlank)
+        val hasEffectiveExternalLyric =
+            localMetadata?.hasLyricOverride != true && !nearbyLyricContent.isNullOrBlank()
+        val effectiveLyricContent = if (localMetadata?.hasLyricOverride == true) {
+            localMetadata.lyric
+        } else {
+            resolveEffectiveLocalLyricContent(
+                sidecarContent = nearbyLyricContent,
+                embeddedContent = tagLibMetadata?.lyrics
+            )
+        }
+        val effectiveTranslatedLyricContent = if (
+            localMetadata?.hasTranslatedLyricOverride == true
+        ) {
+            localMetadata.translatedLyric
+        } else {
+            resolveEffectiveLocalLyricContent(
+                sidecarContent = nearbyTranslatedLyricContent,
+                embeddedContent = tagLibMetadata?.translatedLyrics
+            )
+        }
+        val effectiveRomanizedLyricContent = if (
+            localMetadata?.hasRomanizedLyricOverride == true
+        ) {
+            localMetadata.romanizedLyric
+        } else {
+            nearbyRomanizedLyricContent?.takeIf(String::isNotBlank)
+        }
 
         val retriever = MediaMetadataRetriever()
         return try {
@@ -1429,9 +1657,11 @@ object LocalMediaSupport {
                 },
                 lyricContent = effectiveLyricContent,
                 lyricPath = resolveEffectiveLocalLyricPath(
-                    reference = nearbyLyricReferences.original
+                    reference = localMetadata?.reference
+                        ?.takeIf { localMetadata.hasLyricOverride }
+                        ?: nearbyLyricReferences.original
                         ?: nearbyLyricFiles.original?.absolutePath,
-                    content = nearbyLyricContent
+                    content = effectiveLyricContent
                 ),
                 lyricSource = when {
                     hasEffectiveExternalLyric -> context.getString(R.string.local_song_lyric_external)
@@ -1500,9 +1730,11 @@ object LocalMediaSupport {
                 },
                 lyricContent = effectiveLyricContent,
                 lyricPath = resolveEffectiveLocalLyricPath(
-                    reference = nearbyLyricReferences.original
+                    reference = localMetadata?.reference
+                        ?.takeIf { localMetadata.hasLyricOverride }
+                        ?: nearbyLyricReferences.original
                         ?: nearbyLyricFiles.original?.absolutePath,
-                    content = nearbyLyricContent
+                    content = effectiveLyricContent
                 ),
                 lyricSource = when {
                     hasEffectiveExternalLyric -> context.getString(R.string.local_song_lyric_external)
@@ -1778,6 +2010,242 @@ object LocalMediaSupport {
             ?: return null
 
         return decodeTextBytes(bytes)
+    }
+
+    private fun readLocalMetadataSidecar(
+        context: Context,
+        sourceUri: Uri,
+        file: File?,
+        displayName: String
+    ): LocalMetadataSidecar? {
+        val reference = resolveLocalMetadataReference(
+            context = context,
+            sourceUri = sourceUri,
+            file = file,
+            displayName = displayName
+        ) ?: return null
+        val raw = readTextContent(context, reference) ?: return null
+        return parseLocalMetadataSidecar(reference, raw)
+    }
+
+    internal fun parseLocalMetadataSidecar(
+        reference: String,
+        raw: String
+    ): LocalMetadataSidecar? {
+        return runCatching {
+            val root = JSONObject(raw)
+            LocalMetadataSidecar(
+                reference = reference,
+                hasLyricOverride = root.has("matchedLyric") || root.has("originalLyric"),
+                hasTranslatedLyricOverride = root.has("matchedTranslatedLyric") ||
+                    root.has("originalTranslatedLyric"),
+                hasRomanizedLyricOverride = root.has("matchedRomanizedLyric") ||
+                    root.has("originalRomanizedLyric"),
+                matchedLyric = root.optPresentLocalMetadataString("matchedLyric"),
+                matchedTranslatedLyric = root.optPresentLocalMetadataString(
+                    "matchedTranslatedLyric"
+                ),
+                originalLyric = root.optPresentLocalMetadataString("originalLyric"),
+                originalTranslatedLyric = root.optPresentLocalMetadataString(
+                    "originalTranslatedLyric"
+                ),
+                matchedRomanizedLyric = root.optPresentLocalMetadataString(
+                    "matchedRomanizedLyric"
+                ),
+                originalRomanizedLyric = root.optPresentLocalMetadataString(
+                    "originalRomanizedLyric"
+                )
+            )
+        }.onFailure {
+            NPLogger.w(TAG, "parse local metadata sidecar failed for $reference: ${it.message}")
+        }.getOrNull()
+    }
+
+    internal fun buildLocalLyricsMetadataJson(
+        existingRaw: String?,
+        song: SongItem
+    ): String {
+        val root = existingRaw
+            ?.takeIf(String::isNotBlank)
+            ?.let { runCatching { JSONObject(it) }.getOrNull() }
+            ?: JSONObject()
+        song.matchedLyric?.let { root.put("matchedLyric", it) }
+        song.originalLyric?.let { root.put("originalLyric", it) }
+        song.matchedTranslatedLyric?.let { root.put("matchedTranslatedLyric", it) }
+        song.originalTranslatedLyric?.let { root.put("originalTranslatedLyric", it) }
+        return root.toString()
+    }
+
+    private fun writeLocalLyricsMetadata(
+        context: Context,
+        sourceUri: Uri,
+        file: File?,
+        displayName: String,
+        song: SongItem
+    ): Boolean {
+        val metadataReference = resolveLocalMetadataReference(
+            context = context,
+            sourceUri = sourceUri,
+            file = file,
+            displayName = displayName
+        )
+        val targetReference = metadataReference ?: createLocalMetadataReference(
+            context = context,
+            sourceUri = sourceUri,
+            file = file,
+            displayName = displayName
+        ) ?: return false
+        val existingRaw = readTextContent(context, targetReference)
+        val existingParsed = existingRaw?.let {
+            parseLocalMetadataSidecar(targetReference, it)
+        }
+        val updatedRaw = buildLocalLyricsMetadataJson(existingRaw, song)
+        if (!writeLocalMetadataReference(context, targetReference, file, updatedRaw)) {
+            return false
+        }
+        val stored = readTextContent(context, targetReference) ?: return false
+        val parsed = parseLocalMetadataSidecar(targetReference, stored) ?: return false
+        val expectedLyric = song.matchedLyric ?: song.originalLyric ?: existingParsed?.lyric
+        val expectedTranslatedLyric = song.matchedTranslatedLyric
+            ?: song.originalTranslatedLyric
+            ?: existingParsed?.translatedLyric
+        val shouldHaveLyricOverride = song.matchedLyric != null ||
+            song.originalLyric != null || existingParsed?.hasLyricOverride == true
+        val shouldHaveTranslatedLyricOverride = song.matchedTranslatedLyric != null ||
+            song.originalTranslatedLyric != null || existingParsed?.hasTranslatedLyricOverride == true
+        return (!shouldHaveLyricOverride || parsed.hasLyricOverride) &&
+            parsed.lyric == expectedLyric &&
+            (!shouldHaveTranslatedLyricOverride || parsed.hasTranslatedLyricOverride) &&
+            parsed.translatedLyric == expectedTranslatedLyric
+    }
+
+    private fun resolveLocalMetadataReference(
+        context: Context,
+        sourceUri: Uri,
+        file: File?,
+        displayName: String
+    ): String? {
+        file?.let { localFile ->
+            val target = File(localFile.parentFile ?: return@let, localFile.name + LOCAL_METADATA_SUFFIX)
+            if (target.isFile) return target.absolutePath
+        }
+        val navigation = resolveLocalDocumentNavigation(context, sourceUri) ?: return null
+        val parentChildren = queryDocumentChildren(
+            context = context,
+            baseUri = navigation.treeUri ?: navigation.baseUri,
+            parentDocumentId = navigation.parentDocumentId
+        )
+        val metadataName = displayName + LOCAL_METADATA_SUFFIX
+        return parentChildren.firstOrNull { child ->
+            !child.isDirectory && child.displayName == metadataName
+        }?.uri
+            ?: file?.let { localFile ->
+                localFile.parentFile
+                    ?.let { parent -> File(parent, localFile.name + LOCAL_METADATA_SUFFIX) }
+                    ?.takeIf(File::isFile)
+                    ?.absolutePath
+            }
+    }
+
+    private fun createLocalMetadataReference(
+        context: Context,
+        sourceUri: Uri,
+        file: File?,
+        displayName: String
+    ): String? {
+        if (file != null && !sourceUri.authority.equals("com.android.providers.media.documents", true)) {
+            return File(
+                file.parentFile ?: return null,
+                file.name + LOCAL_METADATA_SUFFIX
+            ).absolutePath
+        }
+        val navigation = resolveLocalDocumentNavigation(context, sourceUri) ?: return null
+        val parentId = navigation.parentDocumentId ?: return null
+        val parentUri = buildDocumentReferenceUri(
+            navigation.treeUri ?: navigation.baseUri,
+            parentId
+        )
+        return runCatching {
+            DocumentsContract.createDocument(
+                context.contentResolver,
+                parentUri,
+                "application/json",
+                displayName + LOCAL_METADATA_SUFFIX
+            )?.toString()
+        }.onFailure {
+            NPLogger.w(TAG, "create local metadata sidecar failed for $sourceUri: ${it.message}")
+        }.getOrNull() ?: file?.let { localFile ->
+            localFile.parentFile
+                ?.let { parent -> File(parent, localFile.name + LOCAL_METADATA_SUFFIX) }
+                ?.absolutePath
+        }
+    }
+
+    private fun writeLocalMetadataReference(
+        context: Context,
+        reference: String,
+        file: File?,
+        content: String
+    ): Boolean {
+        if (file != null && reference.startsWith("/")) {
+            val target = File(reference)
+            val parent = target.parentFile ?: return false
+            if (!parent.exists() && !parent.mkdirs()) return false
+            val temp = runCatching {
+                File.createTempFile(".${target.name}.", ".tmp", parent)
+            }.getOrNull() ?: return false
+            return runCatching {
+                temp.writeText(content, Charsets.UTF_8)
+                if (!temp.renameTo(target)) {
+                    temp.copyTo(target, overwrite = true)
+                    temp.delete()
+                }
+                true
+            }.onFailure {
+                temp.delete()
+                NPLogger.w(TAG, "write local metadata sidecar failed for $reference: ${it.message}")
+            }.getOrDefault(false)
+        }
+        return runCatching {
+            context.contentResolver.openOutputStream(reference.toUri(), "wt")
+                ?.use { output -> output.write(content.toByteArray(Charsets.UTF_8)) }
+                ?: return@runCatching false
+            true
+        }.onFailure {
+            NPLogger.w(TAG, "write local metadata sidecar failed for $reference: ${it.message}")
+        }.getOrDefault(false)
+    }
+
+    private fun resolveLocalDocumentNavigation(
+        context: Context,
+        uri: Uri
+    ): LocalDocumentNavigation? {
+        if (!uri.scheme.equals("content", ignoreCase = true)) return null
+        val treeDocumentId = runCatching { DocumentsContract.getTreeDocumentId(uri) }.getOrNull()
+        val documentId = runCatching { DocumentsContract.getDocumentId(uri) }.getOrNull()
+        val treeUri = runCatching {
+            val authority = uri.authority ?: return@runCatching null
+            treeDocumentId?.let { DocumentsContract.buildTreeDocumentUri(authority, it) }
+        }.getOrNull()
+        val documentUri = if (treeUri != null && documentId != null) {
+            DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId)
+        } else {
+            uri
+        }
+        val providerParentId = findDocumentParentId(context, documentUri)
+        val slashDelimitedParentId = documentId
+            ?.substringBeforeLast('/', missingDelimiterValue = "")
+            ?.takeIf { it.isNotBlank() && it != documentId }
+        return LocalDocumentNavigation(
+            baseUri = uri,
+            treeUri = treeUri,
+            parentDocumentId = providerParentId ?: slashDelimitedParentId ?: treeDocumentId
+        )
+    }
+
+    private fun JSONObject.optPresentLocalMetadataString(fieldName: String): String? {
+        if (!has(fieldName) || isNull(fieldName)) return null
+        return optString(fieldName)
     }
 
     private fun readLimitedTextFile(file: File): ByteArray {
@@ -3104,6 +3572,73 @@ object LocalMediaSupport {
         )
     }
 
+    internal fun copyNearbyLyricSidecars(
+        context: Context,
+        sourceUri: Uri,
+        sourceDisplayName: String,
+        targetFile: File
+    ) {
+        if (!sourceUri.scheme.equals("content", ignoreCase = true)) {
+            return
+        }
+        val references = findNearbyLyricReferences(
+            context = context,
+            uri = sourceUri,
+            file = null,
+            displayName = sourceDisplayName
+        )
+        val targetLyricFiles = findNearbyLyricFiles(targetFile)
+        val metadataReference = resolveLocalMetadataReference(
+            context = context,
+            sourceUri = sourceUri,
+            file = null,
+            displayName = sourceDisplayName
+        )
+        if (metadataReference != null) {
+            copyLyricReference(
+                context = context,
+                reference = metadataReference,
+                target = File(targetFile.parentFile ?: return, targetFile.name + LOCAL_METADATA_SUFFIX)
+            )
+        }
+        listOf(
+            Triple(references.original, targetLyricFiles.original, ""),
+            Triple(references.translated, targetLyricFiles.translated, "_trans"),
+            Triple(references.romanized, targetLyricFiles.romanized, "_roma")
+        ).forEach { (reference, existingTarget, suffix) ->
+            if (reference == null || existingTarget != null) {
+                return@forEach
+            }
+            copyLyricReference(
+                context = context,
+                reference = reference,
+                target = File(
+                    targetFile.parentFile ?: return@forEach,
+                    "${targetFile.nameWithoutExtension}$suffix.lrc"
+                )
+            )
+        }
+    }
+
+    private fun copyLyricReference(
+        context: Context,
+        reference: String,
+        target: File
+    ) {
+        if (target.exists()) return
+        runCatching {
+            context.contentResolver.openInputStream(reference.toUri())?.use { input ->
+                target.parentFile?.mkdirs()
+                FileOutputStream(target).use { output ->
+                    input.copyTo(output)
+                }
+            } ?: error("unable to open lyric sidecar: $reference")
+        }.onFailure {
+            NPLogger.w(TAG, "copy lyric sidecar failed for $reference: ${it.message}")
+            target.delete()
+        }
+    }
+
     private fun readNearbyLyricContent(
         context: Context,
         reference: String?,
@@ -3145,16 +3680,17 @@ object LocalMediaSupport {
                 DocumentsContract.buildTreeDocumentUri(authority, documentId)
             }
         }.getOrNull()
-        val slashDelimitedParentId = documentId
-            ?.substringBeforeLast('/', missingDelimiterValue = "")
-            ?.takeIf { it.isNotBlank() && it != documentId }
         val documentUri = if (treeUri != null && documentId != null) {
             DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId)
         } else {
             uri
         }
-        val parentDocumentId = slashDelimitedParentId
-            ?: findDocumentParentId(context, documentUri)
+        val providerParentId = findDocumentParentId(context, documentUri)
+        val slashDelimitedParentId = documentId
+            ?.substringBeforeLast('/', missingDelimiterValue = "")
+            ?.takeIf { it.isNotBlank() && it != documentId }
+        val parentDocumentId = providerParentId
+            ?: slashDelimitedParentId
             ?: treeDocumentId
         val parentChildren = queryDocumentChildren(
             context = context,

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
@@ -222,6 +222,8 @@ import moe.ouom.neriplayer.core.download.GlobalDownloadManager
 import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
 import moe.ouom.neriplayer.core.download.shouldHideRemoteDownloadAction
 import moe.ouom.neriplayer.core.player.PlayerManager
+import moe.ouom.neriplayer.core.player.download.AudioDownloadManager
+import moe.ouom.neriplayer.core.player.metadata.resolveLocalFirstLyricText
 import moe.ouom.neriplayer.core.player.playback.BiliVideoSkipPlaybackController
 import moe.ouom.neriplayer.core.player.model.PlaybackAudioInfo
 import moe.ouom.neriplayer.core.player.model.PlaybackAudioSource
@@ -1766,8 +1768,8 @@ fun NowPlayingScreen(
     val localPlaylistsReady by PlayerManager.localPlaylistsReadyFlow.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val composeResources = LocalResources.current
-    val coverDownloadPresenceVersion by GlobalDownloadManager.downloadPresenceVersion.collectAsStateWithLifecycle()
-    val currentCoverUrl = remember(currentSong, context, coverDownloadPresenceVersion) {
+    val downloadPresenceVersion by GlobalDownloadManager.downloadPresenceVersion.collectAsStateWithLifecycle()
+    val currentCoverUrl = remember(currentSong, context, downloadPresenceVersion) {
         currentSong?.displayCoverUrl(context)
     }
     val coverPreviewOnTapEnabled = shouldOpenNowPlayingCoverPreviewOnTap(currentSong)
@@ -2064,6 +2066,7 @@ fun NowPlayingScreen(
         currentSong?.album,
         currentSong?.mediaUri,
         currentSong?.localFilePath,
+        downloadPresenceVersion,
         currentMediaUrl
     ) {
         val song = currentSong
@@ -2083,6 +2086,36 @@ fun NowPlayingScreen(
             val localRawLyrics = localDetails?.lyricContent
             val localRawTranslatedLyrics = localDetails?.translatedLyricContent
             val localRawPhoneticLyrics = localDetails?.romanizedLyricContent
+            val downloadedRawLyrics = song?.let { downloadedSong ->
+                runCatching {
+                    AudioDownloadManager.getLyricContent(context, downloadedSong)
+                }.onFailure { error ->
+                    NPLogger.w(
+                        "NowPlayingLyrics",
+                        "下载原文歌词读取失败: ${error.message}"
+                    )
+                }.getOrNull()
+            }
+            val downloadedRawTranslatedLyrics = song?.let { downloadedSong ->
+                runCatching {
+                    AudioDownloadManager.getTranslatedLyricContent(context, downloadedSong)
+                }.onFailure { error ->
+                    NPLogger.w(
+                        "NowPlayingLyrics",
+                        "下载翻译歌词读取失败: ${error.message}"
+                    )
+                }.getOrNull()
+            }
+            val downloadedRawPhoneticLyrics = song?.let { downloadedSong ->
+                runCatching {
+                    AudioDownloadManager.getRomanizedLyricContent(context, downloadedSong)
+                }.onFailure { error ->
+                    NPLogger.w(
+                        "NowPlayingLyrics",
+                        "下载音译歌词读取失败: ${error.message}"
+                    )
+                }.getOrNull()
+            }
             val storedRawLyrics = resolveStoredLyricText(
                 currentLyric = song?.matchedLyric,
                 legacyLyric = song?.originalLyric
@@ -2093,26 +2126,47 @@ fun NowPlayingScreen(
             )
             val preferredSongId = resolvePreferredNeteaseLyricSongId(song)
             val preferredNeteaseLyric = runCatching {
-                if (localRawLyrics == null && storedRawLyrics == null && preferredSongId != null) {
+                if (
+                    localRawLyrics == null &&
+                    storedRawLyrics == null &&
+                    downloadedRawLyrics == null &&
+                    preferredSongId != null
+                ) {
                     PlayerManager.getPreferredNeteaseLyricContent(preferredSongId)
                 } else {
                     ""
                 }
             }.getOrNull().orEmpty()
             val rawNeteasePhoneticLyric = runCatching {
-                if (localRawPhoneticLyrics == null && preferredSongId != null) {
+                if (
+                    localRawPhoneticLyrics == null &&
+                    downloadedRawPhoneticLyrics == null &&
+                    preferredSongId != null
+                ) {
                     PlayerManager.getPreferredNeteaseRomanizedLyricContent(preferredSongId)
                 } else {
                     ""
                 }
             }.getOrNull().orEmpty()
             val effectiveRawLyrics = resolvePreferredLyricContent(
-                matchedLyric = localRawLyrics ?: song?.matchedLyric,
+                matchedLyric = resolveLocalFirstLyricText(
+                    localLyric = localRawLyrics,
+                    storedLyric = storedRawLyrics,
+                    downloadedLyric = downloadedRawLyrics
+                ),
                 preferredNeteaseLyric = preferredNeteaseLyric,
-                legacyLyric = song?.originalLyric
+                legacyLyric = null
             )
-            val effectiveRawTranslatedLyrics = localRawTranslatedLyrics
-                ?: storedRawTranslatedLyrics
+            val effectiveRawTranslatedLyrics = resolveLocalFirstLyricText(
+                localLyric = localRawTranslatedLyrics,
+                storedLyric = storedRawTranslatedLyrics,
+                downloadedLyric = downloadedRawTranslatedLyrics
+            )
+            val effectiveRawPhoneticLyrics = resolveLocalFirstLyricText(
+                localLyric = localRawPhoneticLyrics,
+                storedLyric = null,
+                downloadedLyric = downloadedRawPhoneticLyrics
+            ) ?: rawNeteasePhoneticLyric.takeIf { it.isNotBlank() }
             val bypassStoredRawLyrics = shouldBypassCollapsedStoredLyric(effectiveRawLyrics)
             val bypassStoredTranslatedLyrics = shouldBypassCollapsedStoredLyric(
                 effectiveRawTranslatedLyrics
@@ -2183,6 +2237,9 @@ fun NowPlayingScreen(
                     localRawPhoneticLyrics != null && song != null -> {
                         PlayerManager.getRomanizedLyrics(song)
                     }
+                    downloadedRawPhoneticLyrics != null -> {
+                        parseNeteaseLyricsAuto(downloadedRawPhoneticLyrics)
+                    }
                     rawNeteasePhoneticLyric.isNotBlank() -> {
                         parseNeteaseLyricsAuto(rawNeteasePhoneticLyric)
                     }
@@ -2199,8 +2256,7 @@ fun NowPlayingScreen(
                 rawTranslatedLyrics = effectiveRawTranslatedLyrics.takeUnless {
                     bypassStoredTranslatedLyrics
                 },
-                rawPhoneticLyrics = localRawPhoneticLyrics
-                    ?: rawNeteasePhoneticLyric.takeIf { it.isNotBlank() },
+                rawPhoneticLyrics = effectiveRawPhoneticLyrics,
                 lyrics = resolvedLyrics,
                 translatedLyrics = resolvedTranslatedLyrics,
                 phoneticLyrics = resolvedPhoneticLyrics,
@@ -4696,9 +4752,57 @@ fun EditSongInfoSheet(
                     coroutineScope.launch {
                         try {
                             val loadedLyricsResult: Pair<String, String> = withContext(Dispatchers.IO) {
+                                val localDetails = if (actualSong.isLocalSong()) {
+                                    runCatching { LocalMediaSupport.inspect(context, actualSong) }
+                                        .onFailure { error ->
+                                            NPLogger.w(
+                                                "NowPlayingLyrics",
+                                                "编辑器读取本地歌词旁车失败: ${error.message}"
+                                            )
+                                        }
+                                        .getOrNull()
+                                } else {
+                                    null
+                                }
+                                val localRawLyrics = localDetails?.lyricContent
+                                val localRawTranslatedLyrics = localDetails?.translatedLyricContent
+                                val storedRawLyrics = resolveStoredLyricText(
+                                    currentLyric = actualSong.matchedLyric,
+                                    legacyLyric = actualSong.originalLyric
+                                )
+                                val storedRawTranslatedLyrics = resolveStoredLyricText(
+                                    currentLyric = actualSong.matchedTranslatedLyric,
+                                    legacyLyric = actualSong.originalTranslatedLyric
+                                )
+                                val downloadedRawLyrics = runCatching {
+                                    AudioDownloadManager.getLyricContent(context, actualSong)
+                                }.onFailure { error ->
+                                    NPLogger.w(
+                                        "NowPlayingLyrics",
+                                        "编辑器读取下载原文歌词失败: ${error.message}"
+                                    )
+                                }.getOrNull()
+                                val downloadedRawTranslatedLyrics = runCatching {
+                                    AudioDownloadManager.getTranslatedLyricContent(context, actualSong)
+                                }.onFailure { error ->
+                                    NPLogger.w(
+                                        "NowPlayingLyrics",
+                                        "编辑器读取下载翻译歌词失败: ${error.message}"
+                                    )
+                                }.getOrNull()
+                                val selectedRawLyrics = resolveLocalFirstLyricText(
+                                    localLyric = localRawLyrics,
+                                    storedLyric = storedRawLyrics,
+                                    downloadedLyric = downloadedRawLyrics
+                                )
+                                val selectedRawTranslatedLyrics = resolveLocalFirstLyricText(
+                                    localLyric = localRawTranslatedLyrics,
+                                    storedLyric = storedRawTranslatedLyrics,
+                                    downloadedLyric = downloadedRawTranslatedLyrics
+                                )
                                 val rawNeteaseLyric = runCatching {
                                     val preferredSongId = resolvePreferredNeteaseLyricSongId(actualSong)
-                                    if (preferredSongId != null) {
+                                    if (selectedRawLyrics == null && preferredSongId != null) {
                                         PlayerManager.getPreferredNeteaseLyricContent(preferredSongId)
                                     } else {
                                         null
@@ -4716,19 +4820,16 @@ fun EditSongInfoSheet(
                                     }
                                 }
                                 val lyrics = resolveLyricsEditorInitialText(
-                                    matchedLyric = actualSong.matchedLyric,
+                                    matchedLyric = selectedRawLyrics,
                                     preferredNeteaseLyric = rawNeteaseLyric,
                                     displayedLyricsText = displayedLyricsText,
                                     displayedHasWordTimedEntries = displayedLyricsSnapshot.hasWordTimedEntries(),
                                     fallbackLyricsText = fallbackLyricsText,
-                                    legacyLyric = actualSong.originalLyric
+                                    legacyLyric = null
                                 )
 
                                 val translatedLyrics = try {
-                                    resolveStoredLyricText(
-                                        currentLyric = actualSong.matchedTranslatedLyric,
-                                        legacyLyric = actualSong.originalTranslatedLyric
-                                    ) ?: run {
+                                    selectedRawTranslatedLyrics ?: run {
                                         val translatedEntries =
                                             if (displayedTranslatedLyricsSnapshot.isNotEmpty()) {
                                                 displayedTranslatedLyricsSnapshot
@@ -4758,7 +4859,7 @@ fun EditSongInfoSheet(
                         } catch (e: CancellationException) {
                             throw e
                         } catch (e: Exception) {
-                            e.printStackTrace()
+                            NPLogger.e("NowPlayingScreen", "歌词编辑器初始化失败", e)
                             lyricsEditorSeed = resolveLyricsEditorSeed(song = actualSong)
                         }
                     }

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
@@ -229,6 +229,7 @@ import moe.ouom.neriplayer.core.player.model.forSource
 import moe.ouom.neriplayer.core.player.model.PlaybackQualityOption
 import moe.ouom.neriplayer.core.player.model.PlayerQueueDisplayItem
 import moe.ouom.neriplayer.data.local.media.isLocalSong
+import moe.ouom.neriplayer.data.local.media.LocalMediaSupport
 import moe.ouom.neriplayer.data.model.isSyncableRemoteSong
 import moe.ouom.neriplayer.data.local.media.CustomSongCoverStorage
 import moe.ouom.neriplayer.data.local.playlist.LocalPlaylistRepository
@@ -1886,17 +1887,24 @@ fun NowPlayingScreen(
     var showVolumeSheet by remember { mutableStateOf(false) }
     val volumeSheetState = rememberModalBottomSheetState()
 
-    var lyrics by remember(currentSong?.id) { mutableStateOf<List<LyricEntry>>(emptyList()) }
-    var translatedLyrics by remember(currentSong?.id) { mutableStateOf<List<LyricEntry>>(emptyList()) }
-    var rawLyricsText by remember(currentSong?.id) { mutableStateOf<String?>(null) }
-    var rawTranslatedLyricsText by remember(currentSong?.id) { mutableStateOf<String?>(null) }
-    var rawPhoneticLyricsText by remember(currentSong?.id) { mutableStateOf<String?>(null) }
-    var remotePhoneticLyrics by remember(currentSong?.id) { mutableStateOf<List<LyricEntry>>(emptyList()) }
-    var plainLyrics by remember(currentSong?.id) { mutableStateOf<List<LyricEntry>>(emptyList()) }
-    var plainTranslatedLyrics by remember(currentSong?.id) {
+    val currentLyricSourceKey = Triple(
+        currentSong?.id,
+        currentSong?.mediaUri,
+        currentSong?.localFilePath
+    )
+    var lyrics by remember(currentLyricSourceKey) { mutableStateOf<List<LyricEntry>>(emptyList()) }
+    var translatedLyrics by remember(currentLyricSourceKey) { mutableStateOf<List<LyricEntry>>(emptyList()) }
+    var rawLyricsText by remember(currentLyricSourceKey) { mutableStateOf<String?>(null) }
+    var rawTranslatedLyricsText by remember(currentLyricSourceKey) { mutableStateOf<String?>(null) }
+    var rawPhoneticLyricsText by remember(currentLyricSourceKey) { mutableStateOf<String?>(null) }
+    var remotePhoneticLyrics by remember(currentLyricSourceKey) {
         mutableStateOf<List<LyricEntry>>(emptyList())
     }
-    var embeddedPhoneticLyrics by remember(currentSong?.id) {
+    var plainLyrics by remember(currentLyricSourceKey) { mutableStateOf<List<LyricEntry>>(emptyList()) }
+    var plainTranslatedLyrics by remember(currentLyricSourceKey) {
+        mutableStateOf<List<LyricEntry>>(emptyList())
+    }
+    var embeddedPhoneticLyrics by remember(currentLyricSourceKey) {
         mutableStateOf<List<LyricEntry>>(emptyList())
     }
     val nowPlayingViewModel: NowPlayingViewModel = viewModel()
@@ -2054,10 +2062,27 @@ fun NowPlayingScreen(
         currentSong?.matchedSongId,
         currentSong?.matchedLyricSource,
         currentSong?.album,
+        currentSong?.mediaUri,
+        currentSong?.localFilePath,
         currentMediaUrl
     ) {
         val song = currentSong
         val loadedLyricsState = withContext(Dispatchers.IO) {
+            val localDetails = if (song?.isLocalSong() == true) {
+                runCatching { LocalMediaSupport.inspect(context, song) }
+                    .onFailure { error ->
+                        NPLogger.w(
+                            "NowPlayingLyrics",
+                            "本地歌词旁车读取失败: ${error.message}"
+                        )
+                    }
+                    .getOrNull()
+            } else {
+                null
+            }
+            val localRawLyrics = localDetails?.lyricContent
+            val localRawTranslatedLyrics = localDetails?.translatedLyricContent
+            val localRawPhoneticLyrics = localDetails?.romanizedLyricContent
             val storedRawLyrics = resolveStoredLyricText(
                 currentLyric = song?.matchedLyric,
                 legacyLyric = song?.originalLyric
@@ -2068,33 +2093,38 @@ fun NowPlayingScreen(
             )
             val preferredSongId = resolvePreferredNeteaseLyricSongId(song)
             val preferredNeteaseLyric = runCatching {
-                if (storedRawLyrics == null && preferredSongId != null) {
+                if (localRawLyrics == null && storedRawLyrics == null && preferredSongId != null) {
                     PlayerManager.getPreferredNeteaseLyricContent(preferredSongId)
                 } else {
                     ""
                 }
             }.getOrNull().orEmpty()
             val rawNeteasePhoneticLyric = runCatching {
-                if (preferredSongId != null) {
+                if (localRawPhoneticLyrics == null && preferredSongId != null) {
                     PlayerManager.getPreferredNeteaseRomanizedLyricContent(preferredSongId)
                 } else {
                     ""
                 }
             }.getOrNull().orEmpty()
             val effectiveRawLyrics = resolvePreferredLyricContent(
-                matchedLyric = song?.matchedLyric,
+                matchedLyric = localRawLyrics ?: song?.matchedLyric,
                 preferredNeteaseLyric = preferredNeteaseLyric,
                 legacyLyric = song?.originalLyric
             )
+            val effectiveRawTranslatedLyrics = localRawTranslatedLyrics
+                ?: storedRawTranslatedLyrics
             val bypassStoredRawLyrics = shouldBypassCollapsedStoredLyric(effectiveRawLyrics)
             val bypassStoredTranslatedLyrics = shouldBypassCollapsedStoredLyric(
-                storedRawTranslatedLyrics
+                effectiveRawTranslatedLyrics
             )
             val shouldDelayOnlineLyrics =
                 song != null &&
                     extractYouTubeMusicVideoId(song.mediaUri) != null &&
                     currentMediaUrl.isNullOrBlank()
             val resolvedLyrics = when {
+                localRawLyrics != null && song != null -> {
+                    PlayerManager.getLyrics(song)
+                }
                 bypassStoredRawLyrics && song != null -> {
                     PlayerManager.getLyrics(song)
                 }
@@ -2126,15 +2156,18 @@ fun NowPlayingScreen(
 
             val resolvedTranslatedLyrics = try {
                 when {
-                    storedRawTranslatedLyrics != null -> {
-                        if (storedRawTranslatedLyrics.isBlank()) {
+                    localRawTranslatedLyrics != null && song != null -> {
+                        PlayerManager.getTranslatedLyrics(song)
+                    }
+                    effectiveRawTranslatedLyrics != null -> {
+                        if (effectiveRawTranslatedLyrics.isBlank()) {
                             emptyList()
                         } else if (bypassStoredTranslatedLyrics && song != null) {
                             PlayerManager.getTranslatedLyrics(song)
                         } else if (bypassStoredTranslatedLyrics) {
                             emptyList()
                         } else {
-                            parseNeteaseLyricsAuto(storedRawTranslatedLyrics)
+                            parseNeteaseLyricsAuto(effectiveRawTranslatedLyrics)
                         }
                     }
                     song != null -> {
@@ -2147,6 +2180,9 @@ fun NowPlayingScreen(
             }
             val resolvedPhoneticLyrics = try {
                 when {
+                    localRawPhoneticLyrics != null && song != null -> {
+                        PlayerManager.getRomanizedLyrics(song)
+                    }
                     rawNeteasePhoneticLyric.isNotBlank() -> {
                         parseNeteaseLyricsAuto(rawNeteasePhoneticLyric)
                     }
@@ -2160,10 +2196,11 @@ fun NowPlayingScreen(
             }
             LoadedLyricsState(
                 rawLyrics = effectiveRawLyrics.takeUnless { bypassStoredRawLyrics },
-                rawTranslatedLyrics = storedRawTranslatedLyrics.takeUnless {
+                rawTranslatedLyrics = effectiveRawTranslatedLyrics.takeUnless {
                     bypassStoredTranslatedLyrics
                 },
-                rawPhoneticLyrics = rawNeteasePhoneticLyric.takeIf { it.isNotBlank() },
+                rawPhoneticLyrics = localRawPhoneticLyrics
+                    ?: rawNeteasePhoneticLyric.takeIf { it.isNotBlank() },
                 lyrics = resolvedLyrics,
                 translatedLyrics = resolvedTranslatedLyrics,
                 phoneticLyrics = resolvedPhoneticLyrics,

--- a/app/src/test/java/moe/ouom/neriplayer/core/download/GlobalDownloadManagerDeleteReferenceTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/download/GlobalDownloadManagerDeleteReferenceTest.kt
@@ -78,6 +78,52 @@ class GlobalDownloadManagerDeleteReferenceTest {
     }
 
     @Test
+    fun `artifact planner keeps romanized lyric owned by other download`() {
+        val sharedRomanizedReference = "content://downloads/lyrics/shared_roma.lrc"
+        val currentAudio = ManagedDownloadStorage.StoredEntry(
+            name = "artist - current.mp3",
+            reference = "content://downloads/audio/current.mp3",
+            mediaUri = "content://downloads/audio/current.mp3",
+            localFilePath = null,
+            sizeBytes = 1024L,
+            lastModifiedMs = 1L
+        )
+        val currentMetadataReference = ManagedDownloadStorage.metadataReferenceForAudio(currentAudio)
+            ?: error("missing current metadata reference")
+        val currentMetadata = ManagedDownloadStorage.StoredEntry(
+            name = "${currentAudio.name}.npmeta.json",
+            reference = currentMetadataReference,
+            mediaUri = currentMetadataReference,
+            localFilePath = null,
+            sizeBytes = 128L,
+            lastModifiedMs = 1L
+        )
+        val snapshot = ManagedDownloadStorage.emptyDownloadLibrarySnapshot().copy(
+            metadataEntriesByAudioName = mapOf(currentAudio.name to currentMetadata),
+            metadataByAudioName = mapOf(
+                "artist - other.mp3" to ManagedDownloadStorage.DownloadedAudioMetadata(
+                    romanizedLyricPath = sharedRomanizedReference
+                )
+            ),
+            knownReferences = setOf(
+                currentAudio.reference,
+                currentMetadataReference,
+                sharedRomanizedReference
+            )
+        )
+
+        val references = ManagedDownloadArtifactPlanner.collectArtifactReferences(
+            snapshot = snapshot,
+            storedAudio = currentAudio,
+            songId = 1L,
+            candidateBaseNames = listOf("artist - current"),
+            explicitReferences = listOf(sharedRomanizedReference)
+        )
+
+        assertEquals(setOf(currentAudio.reference, currentMetadataReference), references)
+    }
+
+    @Test
     fun `download deletion result retains songs whose required audio was not deleted`() {
         val deletedSong = downloadedSong(id = 1L, name = "deleted")
         val retainedSong = downloadedSong(id = 2L, name = "retained")

--- a/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorageLookupTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorageLookupTest.kt
@@ -1,6 +1,8 @@
 package moe.ouom.neriplayer.core.download
 
 import moe.ouom.neriplayer.core.download.storage.lookup.ManagedDownloadStorageLookup
+import moe.ouom.neriplayer.core.download.storage.snapshot.ManagedDownloadSnapshotIndex
+import moe.ouom.neriplayer.data.model.SongItem
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -29,6 +31,47 @@ class ManagedDownloadStorageLookupTest {
                 baseNames = listOf("Artist - Song")
             )
         )
+    }
+
+    @Test
+    fun `local SAF playback reference wins over retained remote identity`() {
+        val localMediaUri =
+            "content://com.android.externalstorage.documents/tree/primary%3AMusic%2Fmy/" +
+                "document/primary%3AMusic%2Fmy%2Fnetease%20-%20%E8%8C%B6%E5%A4%AA%20-%20" +
+                "%E3%81%A0%E3%82%93%E3%81%94%E5%A4%A7%E5%AE%B6%E6%97%8F.flac"
+        val expected = storedEntry(
+            name = "netease - 茶太 - だんご大家族.flac",
+            reference = localMediaUri,
+            mediaUri = localMediaUri
+        )
+        val snapshot = ManagedDownloadSnapshotIndex.compose(
+            audioEntries = listOf(expected),
+            metadataEntries = emptyList(),
+            metadataByAudioName = emptyMap(),
+            coverEntries = emptyList(),
+            lyricEntries = emptyList()
+        )
+        val song = SongItem(
+            id = 5_364_584_910_320_485_668L,
+            name = "だんご大家族",
+            artist = "茶太",
+            album = "Neteaseメグメル/だんご大家族",
+            albumId = 0L,
+            durationMs = 0L,
+            coverUrl = null,
+            mediaUri = localMediaUri,
+            channelId = "netease",
+            audioId = "5364584910320485668"
+        )
+
+        val result = ManagedDownloadStorageLookup.findAudioEntry(
+            snapshot = snapshot,
+            song = song,
+            fileNameTemplate = null
+        )
+
+        assertEquals(expected, result?.entry)
+        assertEquals("localReference", result?.hitType)
     }
 
     private fun storedEntry(

--- a/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorageMigrationCompatTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorageMigrationCompatTest.kt
@@ -86,6 +86,19 @@ class ManagedDownloadStorageMigrationCompatTest {
     }
 
     @Test
+    fun `shouldTreatAudioAsManaged keeps romanized lyric sidecar audio in custom directory`() {
+        assertTrue(
+            ManagedDownloadStorage.shouldTreatAudioAsManaged(
+                audioName = "Artist - Song.mp3",
+                metadataAudioNames = emptySet(),
+                coverEntryNames = emptySet(),
+                lyricEntryNames = setOf("Artist - Song_roma.lrc"),
+                allowMetadataLessAudio = false
+            )
+        )
+    }
+
+    @Test
     fun `shouldTreatAudioAsManaged skips foreign audio in custom directory`() {
         assertFalse(
             ManagedDownloadStorage.shouldTreatAudioAsManaged(
@@ -111,6 +124,31 @@ class ManagedDownloadStorageMigrationCompatTest {
                 songId = 42L,
                 candidateBaseNames = listOf("Artist - Song"),
                 translated = false
+            )
+        )
+    }
+
+    @Test
+    fun `buildLyricCandidateNames recognizes romanized lyric compatibility names`() {
+        assertEquals(
+            listOf(
+                "42_roma.lrc",
+                "42_roma.lrc.txt",
+                "42_romalrc.lrc",
+                "42_romalrc.lrc.txt",
+                "42_romanized.lrc",
+                "42_romanized.lrc.txt",
+                "Artist - Song_roma.lrc",
+                "Artist - Song_roma.lrc.txt",
+                "Artist - Song_romalrc.lrc",
+                "Artist - Song_romalrc.lrc.txt",
+                "Artist - Song_romanized.lrc",
+                "Artist - Song_romanized.lrc.txt"
+            ),
+            ManagedDownloadStorage.buildLyricCandidateNames(
+                songId = 42L,
+                candidateBaseNames = listOf("Artist - Song"),
+                kind = ManagedDownloadStorage.LyricKind.ROMANIZED
             )
         )
     }

--- a/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorageSnapshotCacheTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadStorageSnapshotCacheTest.kt
@@ -78,6 +78,7 @@ class ManagedDownloadStorageSnapshotCacheTest {
             coverPath = coverEntry.reference,
             lyricPath = lyricEntry.reference,
             translatedLyricPath = "/music/Lyrics/Artist - Song_trans.lrc",
+            romanizedLyricPath = "/music/Lyrics/Artist - Song_roma.lrc",
             durationMs = 5000L,
             downloadFinalized = false
         )
@@ -150,6 +151,7 @@ class ManagedDownloadStorageSnapshotCacheTest {
             mediaUri = "https://example.com/room.flac",
             channelId = "netease",
             audioId = "44",
+            romanizedLyricPath = "/music/Lyrics/Artist - Room Song_roma.lrc",
             durationMs = 240_000L,
             downloadFinalized = true
         )
@@ -182,6 +184,10 @@ class ManagedDownloadStorageSnapshotCacheTest {
 
         assertEquals(snapshot.audioEntries, restored.audioEntries)
         assertEquals(metadata, restored.metadataByAudioName[audioEntry.name])
+        assertEquals(
+            "/music/Lyrics/Artist - Room Song_roma.lrc",
+            restored.metadataByAudioName[audioEntry.name]?.romanizedLyricPath
+        )
         assertEquals(listOf(audioEntry), restored.audioEntriesByStableKey["room-stable"])
         assertEquals(listOf(audioEntry), restored.audioEntriesByRemoteTrackKey["netease|44|"])
         assertTrue(restored.knownReferences.contains(metadataEntry.reference))
@@ -282,6 +288,7 @@ class ManagedDownloadStorageSnapshotCacheTest {
             put("coverPath", "old-cover")
             put("lyricPath", "old-lyric")
             put("translatedLyricPath", "old-translated")
+            put("romanizedLyricPath", "old-romanized")
         }.toString()
 
         val rewritten = ManagedDownloadStorage.rewriteManagedMetadataReferences(
@@ -289,7 +296,8 @@ class ManagedDownloadStorageSnapshotCacheTest {
             referenceMap = mapOf(
                 "old-cover" to "new-cover",
                 "old-lyric" to "new-lyric",
-                "old-translated" to "new-translated"
+                "old-translated" to "new-translated",
+                "old-romanized" to "new-romanized"
             )
         )
         val root = JSONObject(rewritten)
@@ -297,6 +305,7 @@ class ManagedDownloadStorageSnapshotCacheTest {
         assertEquals("new-cover", root.getString("coverPath"))
         assertEquals("new-lyric", root.getString("lyricPath"))
         assertEquals("new-translated", root.getString("translatedLyricPath"))
+        assertEquals("new-romanized", root.getString("romanizedLyricPath"))
     }
 
     @Test

--- a/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadUnfinalizedCleanupPlannerTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/download/ManagedDownloadUnfinalizedCleanupPlannerTest.kt
@@ -1,0 +1,86 @@
+package moe.ouom.neriplayer.core.download
+
+import moe.ouom.neriplayer.core.download.cleanup.ManagedDownloadParsedMetadataEntry
+import moe.ouom.neriplayer.core.download.cleanup.ManagedDownloadUnfinalizedCleanupPlanner
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ManagedDownloadUnfinalizedCleanupPlannerTest {
+
+    @Test
+    fun `unfinalized cleanup deletes its unshared romanized lyric`() {
+        val metadataReference = "content://downloads/audio/pending.mp3.npmeta.json"
+        val audioReference = "content://downloads/audio/pending.mp3"
+        val romanizedReference = "content://downloads/lyrics/pending_roma.lrc"
+
+        val references = ManagedDownloadUnfinalizedCleanupPlanner.planReferencesToDelete(
+            rootEntries = listOf(
+                entry("pending.mp3.npmeta.json", metadataReference),
+                entry("pending.mp3", audioReference, sizeBytes = 0L)
+            ),
+            parsedMetadataEntries = listOf(
+                ManagedDownloadParsedMetadataEntry(
+                    entry("pending.mp3.npmeta.json", metadataReference),
+                    ManagedDownloadStorage.DownloadedAudioMetadata(
+                        downloadFinalized = false,
+                        romanizedLyricPath = romanizedReference
+                    )
+                )
+            ),
+            managedSidecarReferences = setOf(romanizedReference)
+        )
+
+        assertTrue(references.contains(romanizedReference))
+    }
+
+    @Test
+    fun `unfinalized cleanup preserves romanized lyric shared by finalized download`() {
+        val pendingMetadataReference = "content://downloads/audio/pending.mp3.npmeta.json"
+        val pendingAudioReference = "content://downloads/audio/pending.mp3"
+        val completedMetadataReference = "content://downloads/audio/completed.mp3.npmeta.json"
+        val sharedRomanizedReference = "content://downloads/lyrics/shared_roma.lrc"
+
+        val references = ManagedDownloadUnfinalizedCleanupPlanner.planReferencesToDelete(
+            rootEntries = listOf(
+                entry("pending.mp3.npmeta.json", pendingMetadataReference),
+                entry("pending.mp3", pendingAudioReference, sizeBytes = 0L),
+                entry("completed.mp3.npmeta.json", completedMetadataReference)
+            ),
+            parsedMetadataEntries = listOf(
+                ManagedDownloadParsedMetadataEntry(
+                    entry("pending.mp3.npmeta.json", pendingMetadataReference),
+                    ManagedDownloadStorage.DownloadedAudioMetadata(
+                        downloadFinalized = false,
+                        romanizedLyricPath = sharedRomanizedReference
+                    )
+                ),
+                ManagedDownloadParsedMetadataEntry(
+                    entry("completed.mp3.npmeta.json", completedMetadataReference),
+                    ManagedDownloadStorage.DownloadedAudioMetadata(
+                        downloadFinalized = true,
+                        romanizedLyricPath = sharedRomanizedReference
+                    )
+                )
+            ),
+            managedSidecarReferences = setOf(sharedRomanizedReference)
+        )
+
+        assertFalse(references.contains(sharedRomanizedReference))
+    }
+
+    private fun entry(
+        name: String,
+        reference: String,
+        sizeBytes: Long = 1L
+    ): ManagedDownloadStorage.StoredEntry {
+        return ManagedDownloadStorage.StoredEntry(
+            name = name,
+            reference = reference,
+            mediaUri = reference,
+            localFilePath = null,
+            sizeBytes = sizeBytes,
+            lastModifiedMs = 1L
+        )
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/download/AudioDownloadManagerSidecarReferenceTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/download/AudioDownloadManagerSidecarReferenceTest.kt
@@ -78,6 +78,24 @@ class AudioDownloadManagerSidecarReferenceTest {
     }
 
     @Test
+    fun `retainCreatedOnly keeps only created romanized lyric`() {
+        val created = AudioDownloadManager.DownloadedSidecarReferences(
+            romanizedLyricReference = "content://lyrics/song_roma.lrc",
+            createdRomanizedLyric = true
+        )
+        val existing = AudioDownloadManager.DownloadedSidecarReferences(
+            romanizedLyricReference = "content://library/song_roma.lrc",
+            createdRomanizedLyric = false
+        )
+
+        assertEquals(created, created.retainCreatedOnly())
+        assertEquals(
+            AudioDownloadManager.DownloadedSidecarReferences(),
+            existing.retainCreatedOnly()
+        )
+    }
+
+    @Test
     fun `mergeDownloadedSidecarReferences uses incoming ownership when reference changes`() {
         val existing = AudioDownloadManager.DownloadedSidecarReferences(
             coverReference = "content://covers/old.jpg",

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/download/AudioDownloadManagerTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/download/AudioDownloadManagerTest.kt
@@ -61,6 +61,28 @@ class AudioDownloadManagerTest {
     }
 
     @Test
+    fun `romanized lyric download only piggybacks on an existing lyric request`() {
+        assertFalse(
+            AudioDownloadManager.shouldFetchRomanizedLyricForDownload(
+                shouldFetchPrimaryLyric = false,
+                shouldFetchTranslatedLyric = false
+            )
+        )
+        assertTrue(
+            AudioDownloadManager.shouldFetchRomanizedLyricForDownload(
+                shouldFetchPrimaryLyric = true,
+                shouldFetchTranslatedLyric = false
+            )
+        )
+        assertTrue(
+            AudioDownloadManager.shouldFetchRomanizedLyricForDownload(
+                shouldFetchPrimaryLyric = false,
+                shouldFetchTranslatedLyric = true
+            )
+        )
+    }
+
+    @Test
     fun `resolveLocalLyricForDownload keeps explicit lyrics and preserves cleared state separately`() {
         assertEquals(null, AudioDownloadManager.resolveLocalLyricForDownload(null))
         assertEquals(null, AudioDownloadManager.resolveLocalLyricForDownload(""))

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProviderTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProviderTest.kt
@@ -49,6 +49,14 @@ class PlayerLyricsProviderTest {
                 downloadedLyric = "[00:01.00]downloaded"
             )
         )
+        assertEquals(
+            "[00:01.00]stored",
+            resolveLocalFirstLyricText(
+                localLyric = null,
+                storedLyric = "[00:01.00]stored",
+                downloadedLyric = "[00:01.00]downloaded"
+            )
+        )
     }
 
     @Test

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProviderTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProviderTest.kt
@@ -24,6 +24,34 @@ class PlayerLyricsProviderTest {
     }
 
     @Test
+    fun `resolveLocalFirstLyricText keeps local blank override ahead of stored and downloaded text`() {
+        assertEquals(
+            "[00:01.00]local",
+            resolveLocalFirstLyricText(
+                localLyric = "[00:01.00]local",
+                storedLyric = "[00:01.00]stored",
+                downloadedLyric = "[00:01.00]downloaded"
+            )
+        )
+        assertEquals(
+            "",
+            resolveLocalFirstLyricText(
+                localLyric = "",
+                storedLyric = "[00:01.00]stored",
+                downloadedLyric = "[00:01.00]downloaded"
+            )
+        )
+        assertEquals(
+            "[00:01.00]downloaded",
+            resolveLocalFirstLyricText(
+                localLyric = null,
+                storedLyric = null,
+                downloadedLyric = "[00:01.00]downloaded"
+            )
+        )
+    }
+
+    @Test
     fun `isTransientHttp2StreamReset detects cancel and refused stream failures`() {
         assertTrue(IOException("stream was reset: CANCEL").isTransientHttp2StreamReset())
 

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
@@ -124,6 +124,23 @@ class LocalAudioImportManagerTest {
     }
 
     @Test
+    fun `copyNearbySidecars preserves romanized lyric sidecar`() {
+        val sourceDir = tempFolder.newFolder("source-romanized-lyrics")
+        val sourceAudio = File(sourceDir, "song.flac").apply { writeText("audio") }
+        File(File(sourceDir, "Lyrics").apply { mkdirs() }, "song_roma.lrc")
+            .writeText("romanized")
+
+        val targetDir = tempFolder.newFolder("imports-romanized-lyrics")
+        val targetAudio = File(targetDir, "imported_song.flac").apply { writeText("audio") }
+
+        LocalAudioImportManager.copyNearbySidecars(sourceAudio, targetAudio)
+
+        val copiedRomanized = File(targetDir, "imported_song_roma.lrc")
+        assertTrue(copiedRomanized.exists())
+        assertEquals("romanized", copiedRomanized.readText())
+    }
+
+    @Test
     fun `copyNearbySidecars preserves source directory lyric selection priority`() {
         val sourceDir = tempFolder.newFolder("source-lyrics-priority")
         val sourceAudio = File(sourceDir, "song.flac").apply { writeText("audio") }

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
@@ -216,6 +216,33 @@ class LocalMediaSupportTest {
     }
 
     @Test
+    fun `resolveEffectiveLocalLyricPath hides unreadable sidecar references`() {
+        assertNull(
+            LocalMediaSupport.resolveEffectiveLocalLyricPath(
+                reference = "content://lyrics/empty",
+                content = "  \n"
+            )
+        )
+        assertEquals(
+            "content://lyrics/readable",
+            LocalMediaSupport.resolveEffectiveLocalLyricPath(
+                reference = "content://lyrics/readable",
+                content = "[00:01.00]line"
+            )
+        )
+    }
+
+    @Test
+    fun `resolveEffectiveLocalLyricPath ignores embedded fallback content`() {
+        assertNull(
+            LocalMediaSupport.resolveEffectiveLocalLyricPath(
+                reference = "content://lyrics/empty",
+                content = null
+            )
+        )
+    }
+
+    @Test
     fun `findNearbyLyricFiles keeps source directory priority over Lyrics fallback`() {
         val sourceDir = tempFolder.newFolder("nearby-lyrics-priority")
         val audioFile = File(sourceDir, "song.flac").apply { writeText("audio") }

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
@@ -1,6 +1,7 @@
 package moe.ouom.neriplayer.data.local.media
 
 import java.io.File
+import moe.ouom.neriplayer.data.model.SongItem
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -256,5 +257,58 @@ class LocalMediaSupportTest {
 
         assertEquals(original.canonicalPath, found.original?.canonicalPath)
         assertEquals(translated.canonicalPath, found.translated?.canonicalPath)
+    }
+
+    @Test
+    fun `local metadata sidecar keeps fields independent and preserves existing values`() {
+        val existing = """
+            {"matchedLyric":"matched","originalLyric":"original",
+             "matchedRomanizedLyric":"romanized","custom":"keep"}
+        """.trimIndent()
+        val updated = LocalMediaSupport.buildLocalLyricsMetadataJson(
+            existingRaw = existing,
+            song = SongItem(
+                id = 1L,
+                name = "Song",
+                artist = "Artist",
+                album = "Album",
+                albumId = 0L,
+                durationMs = 1_000L,
+                coverUrl = null,
+                matchedLyric = "new matched",
+                matchedTranslatedLyric = "new translated"
+            )
+        )
+        val parsed = LocalMediaSupport.parseLocalMetadataSidecar("/tmp/song.npmeta.json", updated)
+
+        assertEquals("new matched", parsed?.matchedLyric)
+        assertEquals("original", parsed?.originalLyric)
+        assertEquals("new translated", parsed?.matchedTranslatedLyric)
+        assertEquals(null, parsed?.originalTranslatedLyric)
+        assertEquals("romanized", parsed?.matchedRomanizedLyric)
+        assertEquals(true, org.json.JSONObject(updated).has("custom"))
+    }
+
+    @Test
+    fun `local metadata sidecar accepts explicit blank lyric overrides`() {
+        val updated = LocalMediaSupport.buildLocalLyricsMetadataJson(
+            existingRaw = "{\"matchedLyric\":\"old\",\"originalLyric\":\"base\"}",
+            song = SongItem(
+                id = 2L,
+                name = "Song",
+                artist = "Artist",
+                album = "Album",
+                albumId = 0L,
+                durationMs = 1_000L,
+                coverUrl = null,
+                matchedLyric = "",
+                matchedTranslatedLyric = ""
+            )
+        )
+        val parsed = LocalMediaSupport.parseLocalMetadataSidecar("/tmp/song.npmeta.json", updated)
+
+        assertEquals("", parsed?.matchedLyric)
+        assertEquals("base", parsed?.originalLyric)
+        assertEquals("", parsed?.matchedTranslatedLyric)
     }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
@@ -179,6 +179,18 @@ class LocalMediaSupportTest {
     }
 
     @Test
+    fun `findNearbyLyricFiles discovers romanized sidecar in Lyrics directory`() {
+        val sourceDir = tempFolder.newFolder("nearby-romanized-lyrics")
+        val audioFile = File(sourceDir, "song.flac").apply { writeText("audio") }
+        val lyricsDir = File(sourceDir, "Lyrics").apply { mkdirs() }
+        val romanized = File(lyricsDir, "song_roma.lrc").apply { writeText("romanized") }
+
+        val found = LocalMediaSupport.findNearbyLyricFiles(audioFile)
+
+        assertEquals(romanized.canonicalPath, found.romanized?.canonicalPath)
+    }
+
+    @Test
     fun `resolveEffectiveLocalLyricContent falls back to embedded lyrics for blank sidecar`() {
         assertEquals(
             "[00:00.00]embedded",


### PR DESCRIPTION
fix #339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 用户可见行为

- 支持从 SAF 的 `Lyrics` 目录读取原文、翻译和罗马化歌词旁车文件。
- 本地歌词优先于已存储和远程歌词。
- 支持多种罗马化歌词文件名。
- 下载、导入和清理流程支持罗马化歌词旁车文件。

## 兼容性

- 数据库升级至版本 15，并新增可空的 `romanized_lyric_path` 字段。
- 保留已有下载快照和旧版歌词命名兼容性。
- SAF 播放引用优先于远程下载身份。

## 测试

- 新增 SAF 文档树和普通文档的本地歌词读取测试。
- 新增罗马化歌词的下载、导入、缓存、清理和共享引用测试。
- 新增数据库 14 到 15 的迁移测试。
- 新增本地歌词优先级、空白覆盖和旁车路径处理测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->