### PR TITLE
fix(settings): prioritize DataStore over stale playback preference snapshots

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/data/settings/NeteaseLocalSourceFallbackSettingAndroidTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/data/settings/NeteaseLocalSourceFallbackSettingAndroidTest.kt
@@ -85,6 +85,22 @@ class NeteaseLocalSourceFallbackSettingAndroidTest {
     }
 
     @Test
+    fun disabledValueSurvivesStaleSnapshotMirror() {
+        runBlocking {
+            repository.setNeteaseLocalSourceFallback(false)
+            context.getSharedPreferences(TestPlaybackSnapshotPrefs, Context.MODE_PRIVATE)
+                .edit()
+                .putBoolean("ready", true)
+                .putInt("schema_version", 5)
+                .putBoolean("netease_local_source_fallback", true)
+                .commit()
+
+            assertFalse(readPlaybackPreferenceSnapshot(context).neteaseLocalSourceFallback)
+            assertFalse(readPlaybackPreferenceSnapshotCached(context)!!.neteaseLocalSourceFallback)
+        }
+    }
+
+    @Test
     fun disablingDoesNotDisturbTheAutoSourceSwitch() {
         runBlocking {
             repository.setNeteaseAutoSourceSwitch(true)

--- a/app/src/main/java/moe/ouom/neriplayer/data/settings/PlaybackPreferenceSnapshot.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/settings/PlaybackPreferenceSnapshot.kt
@@ -225,12 +225,10 @@ data class PlaybackPreferenceSnapshot(
 }
 
 suspend fun readPlaybackPreferenceSnapshot(context: Context): PlaybackPreferenceSnapshot {
-    readCachedPlaybackPreferenceSnapshot(context)?.let { return it }
-
     return runCatching {
         context.dataStore.data.first().toPlaybackPreferenceSnapshot()
     }.getOrElse {
-        PlaybackPreferenceSnapshot()
+        readCachedPlaybackPreferenceSnapshot(context) ?: PlaybackPreferenceSnapshot()
     }.also { snapshot ->
         persistPlaybackPreferenceSnapshot(context, snapshot)
     }
@@ -272,8 +270,11 @@ internal suspend fun updatePlaybackPreferenceSnapshot(
     context: Context,
     transform: (PlaybackPreferenceSnapshot) -> PlaybackPreferenceSnapshot
 ) {
-    val currentSnapshot = readCachedPlaybackPreferenceSnapshot(context)
-        ?: context.dataStore.data.first().toPlaybackPreferenceSnapshot()
+    val currentSnapshot = runCatching {
+        context.dataStore.data.first().toPlaybackPreferenceSnapshot()
+    }.getOrElse {
+        readCachedPlaybackPreferenceSnapshot(context) ?: PlaybackPreferenceSnapshot()
+    }
     persistPlaybackPreferenceSnapshot(context, transform(currentSnapshot))
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 优先使用 DataStore 中的播放偏好，避免旧版 SharedPreferences 镜像覆盖最新设置。
- 当 DataStore 读取失败时，仍回退到缓存或默认值。
- 新增 Android 测试，验证本地音频兜底设置为 `false` 时，旧镜像不会改变读取结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->