### PR TITLE
feat: implement persistent lyrics caching and optimize local lyric loading

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/SettingsStorageCacheSectionTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/SettingsStorageCacheSectionTest.kt
@@ -69,6 +69,8 @@ class SettingsStorageCacheSectionTest {
                     onClearDownloadStagingCacheChange = {},
                     clearSharedMediaCache = false,
                     onClearSharedMediaCacheChange = {},
+                    clearLyricsCache = false,
+                    onClearLyricsCacheChange = {},
                     clearNeteasePlaylistCache = false,
                     onClearNeteasePlaylistCacheChange = {},
                     clearBiliFavoriteCache = false,

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProvider.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProvider.kt
@@ -27,6 +27,8 @@ import android.app.Application
 import android.util.LruCache
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import moe.ouom.neriplayer.core.api.lyrics.AmllTtmlClient
 import moe.ouom.neriplayer.core.api.lyrics.EditableLyricMatchCandidate
@@ -63,6 +65,7 @@ import org.json.JSONObject
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.locks.ReentrantReadWriteLock
 
 internal fun extractPreferredNeteaseLyricContent(rawResponse: String): String {
     val payload: JSONObject = JSONObject(rawResponse)
@@ -198,9 +201,27 @@ internal fun sanitizeYouTubeMusicLyricsCacheEntry(
 }
 
 internal object PlayerLyricsProvider {
+    internal interface NeteaseLyricsCacheStore {
+        fun get(songId: Long): NeteaseLyricsCacheEntry?
+
+        fun put(songId: Long, entry: NeteaseLyricsCacheEntry)
+    }
+
+    private class LruNeteaseLyricsCacheStore(
+        private val cache: LruCache<Long, NeteaseLyricsCacheEntry>
+    ) : NeteaseLyricsCacheStore {
+        override fun get(songId: Long): NeteaseLyricsCacheEntry? = cache.get(songId)
+
+        override fun put(songId: Long, entry: NeteaseLyricsCacheEntry) {
+            cache.put(songId, entry)
+        }
+    }
+
     private val amllLyricsCache = LruCache<String, List<LyricEntry>>(40)
     private val neteaseRefreshInFlight = ConcurrentHashMap.newKeySet<Long>()
+    private val neteaseColdLoadLocks = ConcurrentHashMap<Long, Mutex>()
     private val lyricsCacheGeneration = AtomicLong(0L)
+    private val lyricsCacheStateLock = ReentrantReadWriteLock()
 
     private fun parseBestLyricEntries(rawLyric: String): List<LyricEntry> {
         return parseNeteaseLyricsAuto(rawLyric)
@@ -211,27 +232,59 @@ internal object PlayerLyricsProvider {
     }
 
     internal fun clearLyricsCaches() {
-        lyricsCacheGeneration.incrementAndGet()
-        amllLyricsCache.evictAll()
-        LocalMediaSupport.clearLyricsLookupCache()
+        withLyricsCacheWriteLock {
+            lyricsCacheGeneration.incrementAndGet()
+            amllLyricsCache.evictAll()
+            LocalMediaSupport.clearLyricsLookupCache()
+        }
     }
 
     internal fun clearLyricsCaches(
         neteaseLyricsCache: LruCache<Long, NeteaseLyricsCacheEntry>,
         ytMusicLyricsCache: LruCache<String, YouTubeMusicLyricsCacheEntry>
     ) {
-        clearLyricsCaches()
-        neteaseLyricsCache.evictAll()
-        ytMusicLyricsCache.evictAll()
+        withLyricsCacheWriteLock {
+            lyricsCacheGeneration.incrementAndGet()
+            amllLyricsCache.evictAll()
+            LocalMediaSupport.clearLyricsLookupCache()
+            neteaseLyricsCache.evictAll()
+            ytMusicLyricsCache.evictAll()
+        }
     }
 
     internal fun clearPersistentLyricCache(application: Application) {
-        lyricsCacheGeneration.incrementAndGet()
-        runCatching {
-            lyricsCacheDirectory(application).deleteRecursively()
-        }.onFailure {
-            NPLogger.w("NERI-PlayerManager", "清理歌词缓存失败: ${it.message}")
+        withLyricsCacheWriteLock {
+            lyricsCacheGeneration.incrementAndGet()
+            runCatching {
+                lyricsCacheDirectory(application).deleteRecursively()
+            }.onFailure {
+                NPLogger.w("NERI-PlayerManager", "清理歌词缓存失败: ${it.message}")
+            }
         }
+    }
+
+    private fun <T> withLyricsCacheReadLock(block: () -> T): T {
+        val lock = lyricsCacheStateLock.readLock()
+        lock.lock()
+        return try {
+            block()
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    private fun <T> withLyricsCacheWriteLock(block: () -> T): T {
+        val lock = lyricsCacheStateLock.writeLock()
+        lock.lock()
+        return try {
+            block()
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    private fun currentLyricsCacheGeneration(): Long {
+        return withLyricsCacheReadLock { lyricsCacheGeneration.get() }
     }
 
     private fun buildYouTubeMusicLyricsCacheKey(song: SongItem): String {
@@ -363,30 +416,70 @@ internal object PlayerLyricsProvider {
         neteaseLyricsCache: LruCache<Long, NeteaseLyricsCacheEntry>,
         loader: suspend (Long) -> String
     ): NeteaseLyricsCacheEntry {
+        return getOrLoadNeteaseLyricsCacheEntry(
+            songId = songId,
+            neteaseLyricsCache = LruNeteaseLyricsCacheStore(neteaseLyricsCache),
+            loader = loader
+        )
+    }
+
+    internal suspend fun getOrLoadNeteaseLyricsCacheEntry(
+        songId: Long,
+        neteaseLyricsCache: NeteaseLyricsCacheStore,
+        loader: suspend (Long) -> String
+    ): NeteaseLyricsCacheEntry {
         neteaseLyricsCache.get(songId)?.let { cached ->
             NPLogger.d("NERI-PlayerManager", "Using cached NetEase lyrics for songId=$songId")
             scheduleNeteaseLyricsRefresh(songId, cached, neteaseLyricsCache, loader)
             return cached
         }
 
-        val persisted = readPersistedNeteaseLyricsEntry(songId)
-        if (persisted != null) {
-            neteaseLyricsCache.put(songId, persisted)
-            NPLogger.d("NERI-PlayerManager", "Using persisted NetEase lyrics for songId=$songId")
-            scheduleNeteaseLyricsRefresh(songId, persisted, neteaseLyricsCache, loader)
-            return persisted
-        }
+        val loadLock = neteaseColdLoadLocks.computeIfAbsent(songId) { Mutex() }
+        return try {
+            loadLock.withLock {
+                neteaseLyricsCache.get(songId)?.let { return@withLock it }
 
-        val entry = buildNeteaseLyricsCacheEntry(loader(songId))
-        neteaseLyricsCache.put(songId, entry)
-        persistNeteaseLyricsEntry(songId, entry)
-        return entry
+                val persistedGeneration = currentLyricsCacheGeneration()
+                val persisted = readPersistedNeteaseLyricsEntry(songId)
+                if (
+                    persisted != null &&
+                    currentLyricsCacheGeneration() == persistedGeneration &&
+                    writeNeteaseLyricsEntryIfCurrent(
+                        songId = songId,
+                        cache = neteaseLyricsCache,
+                        entry = persisted,
+                        expectedGeneration = persistedGeneration
+                    )
+                ) {
+                    NPLogger.d(
+                        "NERI-PlayerManager",
+                        "Using persisted NetEase lyrics for songId=$songId"
+                    )
+                    scheduleNeteaseLyricsRefresh(songId, persisted, neteaseLyricsCache, loader)
+                    return@withLock persisted
+                }
+
+                val generation = currentLyricsCacheGeneration()
+                val entry = buildNeteaseLyricsCacheEntry(loader(songId))
+                writeNeteaseLyricsEntryIfCurrent(
+                    songId = songId,
+                    cache = neteaseLyricsCache,
+                    entry = entry,
+                    expectedGeneration = generation
+                )
+                entry
+            }
+        } finally {
+            if (!loadLock.isLocked) {
+                neteaseColdLoadLocks.remove(songId, loadLock)
+            }
+        }
     }
 
     private fun scheduleNeteaseLyricsRefresh(
         songId: Long,
         cached: NeteaseLyricsCacheEntry,
-        cache: LruCache<Long, NeteaseLyricsCacheEntry>,
+        cache: NeteaseLyricsCacheStore,
         loader: suspend (Long) -> String
     ) {
         if (!AppContainer.isInitialized()) {
@@ -395,20 +488,26 @@ internal object PlayerLyricsProvider {
         if (!neteaseRefreshInFlight.add(songId)) {
             return
         }
-        val generation = lyricsCacheGeneration.get()
+        val generation = currentLyricsCacheGeneration()
         AppContainer.launchBackgroundIo {
             try {
                 val refreshed = buildNeteaseLyricsCacheEntry(loader(songId))
                 if (
-                    lyricsCacheGeneration.get() == generation &&
                     !sameNeteaseLyrics(cached, refreshed)
                 ) {
-                    cache.put(songId, refreshed)
-                    persistNeteaseLyricsEntry(songId, refreshed)
-                    NPLogger.d(
-                        "NERI-PlayerManager",
-                        "Updated NetEase lyric cache for songId=$songId"
-                    )
+                    if (
+                        writeNeteaseLyricsEntryIfCurrent(
+                            songId = songId,
+                            cache = cache,
+                            entry = refreshed,
+                            expectedGeneration = generation
+                        )
+                    ) {
+                        NPLogger.d(
+                            "NERI-PlayerManager",
+                            "Updated NetEase lyric cache for songId=$songId"
+                        )
+                    }
                 }
             } catch (error: CancellationException) {
                 throw error
@@ -436,19 +535,38 @@ internal object PlayerLyricsProvider {
         return File(lyricsCacheDirectory(AppContainer.applicationContext), "netease_$songId.json")
     }
 
+    private fun writeNeteaseLyricsEntryIfCurrent(
+        songId: Long,
+        cache: NeteaseLyricsCacheStore,
+        entry: NeteaseLyricsCacheEntry,
+        expectedGeneration: Long
+    ): Boolean {
+        return withLyricsCacheWriteLock {
+            if (lyricsCacheGeneration.get() != expectedGeneration) {
+                false
+            } else {
+                cache.put(songId, entry)
+                persistNeteaseLyricsEntry(songId, entry)
+                true
+            }
+        }
+    }
+
     private fun readPersistedNeteaseLyricsEntry(songId: Long): NeteaseLyricsCacheEntry? {
         if (!AppContainer.isInitialized()) {
             return null
         }
-        val file = persistedNeteaseLyricsFile(songId)
-        if (!file.isFile || file.length() <= 0L) {
-            return null
+        return withLyricsCacheReadLock {
+            val file = persistedNeteaseLyricsFile(songId)
+            if (!file.isFile || file.length() <= 0L) {
+                return@withLyricsCacheReadLock null
+            }
+            runCatching {
+                buildNeteaseLyricsCacheEntry(file.readText(Charsets.UTF_8))
+            }.onFailure {
+                NPLogger.w("NERI-PlayerManager", "读取持久化歌词缓存失败: ${it.message}")
+            }.getOrNull()
         }
-        return runCatching {
-            buildNeteaseLyricsCacheEntry(file.readText(Charsets.UTF_8))
-        }.onFailure {
-            NPLogger.w("NERI-PlayerManager", "读取持久化歌词缓存失败: ${it.message}")
-        }.getOrNull()
     }
 
     private fun persistNeteaseLyricsEntry(

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProvider.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProvider.kt
@@ -40,9 +40,9 @@ import moe.ouom.neriplayer.core.api.lyrics.isExternalLyricDurationCompatible
 import moe.ouom.neriplayer.core.api.netease.NeteaseClient
 import moe.ouom.neriplayer.core.api.search.MusicPlatform
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicClient
+import moe.ouom.neriplayer.core.di.AppContainer
 import moe.ouom.neriplayer.core.player.download.AudioDownloadManager
 import moe.ouom.neriplayer.data.local.media.LocalMediaSupport
-import moe.ouom.neriplayer.data.local.media.LocalMediaDetails
 import moe.ouom.neriplayer.data.local.media.isLocalSong
 import moe.ouom.neriplayer.data.model.stableKey
 import moe.ouom.neriplayer.data.platform.youtube.extractYouTubeMusicVideoId
@@ -52,9 +52,13 @@ import moe.ouom.neriplayer.ui.component.lyrics.hasWordTimedEntries
 import moe.ouom.neriplayer.ui.component.lyrics.parseNeteaseLyricsAuto
 import moe.ouom.neriplayer.ui.component.lyrics.resolveStoredLyricText
 import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.storage.lyricsCacheDirectory
 import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.util.network.isTransientHttp2StreamReset
 import org.json.JSONObject
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 internal fun extractPreferredNeteaseLyricContent(rawResponse: String): String {
     val payload: JSONObject = JSONObject(rawResponse)
@@ -83,10 +87,12 @@ internal fun extractRomanizedNeteaseLyricContent(rawResponse: String): String {
 
 internal data class NeteaseLyricsCacheEntry(
     val preferredLyricText: String,
+    val translatedLyricText: String = "",
     val romanizedLyricText: String,
     val preferredLyricEntries: List<LyricEntry>,
     val translatedLyricEntries: List<LyricEntry>,
-    val romanizedLyricEntries: List<LyricEntry>
+    val romanizedLyricEntries: List<LyricEntry>,
+    val rawResponse: String = ""
 )
 
 internal enum class LocalLyricOverrideState {
@@ -109,6 +115,10 @@ internal fun resolveLocalFirstLyricText(
     downloadedLyric: String?
 ): String? {
     return localLyric ?: storedLyric ?: downloadedLyric
+}
+
+internal fun shouldLoadRemoteLyrics(song: SongItem): Boolean {
+    return !song.isLocalSong()
 }
 
 internal fun hasCollapsedLyricEntryTimeline(entries: List<LyricEntry>): Boolean {
@@ -182,6 +192,8 @@ internal fun sanitizeYouTubeMusicLyricsCacheEntry(
 
 internal object PlayerLyricsProvider {
     private val amllLyricsCache = LruCache<String, List<LyricEntry>>(40)
+    private val neteaseRefreshInFlight = ConcurrentHashMap.newKeySet<Long>()
+    private val lyricsCacheGeneration = AtomicLong(0L)
 
     private fun parseBestLyricEntries(rawLyric: String): List<LyricEntry> {
         return parseNeteaseLyricsAuto(rawLyric)
@@ -189,6 +201,30 @@ internal object PlayerLyricsProvider {
 
     internal fun clearAmllLyricsCache() {
         amllLyricsCache.evictAll()
+    }
+
+    internal fun clearLyricsCaches() {
+        lyricsCacheGeneration.incrementAndGet()
+        amllLyricsCache.evictAll()
+        LocalMediaSupport.clearLyricsLookupCache()
+    }
+
+    internal fun clearLyricsCaches(
+        neteaseLyricsCache: LruCache<Long, NeteaseLyricsCacheEntry>,
+        ytMusicLyricsCache: LruCache<String, YouTubeMusicLyricsCacheEntry>
+    ) {
+        clearLyricsCaches()
+        neteaseLyricsCache.evictAll()
+        ytMusicLyricsCache.evictAll()
+    }
+
+    internal fun clearPersistentLyricCache(application: Application) {
+        lyricsCacheGeneration.incrementAndGet()
+        runCatching {
+            lyricsCacheDirectory(application).deleteRecursively()
+        }.onFailure {
+            NPLogger.w("NERI-PlayerManager", "清理歌词缓存失败: ${it.message}")
+        }
     }
 
     private fun buildYouTubeMusicLyricsCacheKey(song: SongItem): String {
@@ -281,6 +317,7 @@ internal object PlayerLyricsProvider {
         val romanizedLyric = extractRomanizedNeteaseLyricContent(rawResponse)
         return NeteaseLyricsCacheEntry(
             preferredLyricText = preferredLyric,
+            translatedLyricText = translatedLyric,
             romanizedLyricText = romanizedLyric,
             preferredLyricEntries = parseRemoteLyricEntriesOrEmpty(
                 rawLyric = preferredLyric,
@@ -293,7 +330,8 @@ internal object PlayerLyricsProvider {
             romanizedLyricEntries = parseRemoteLyricEntriesOrEmpty(
                 rawLyric = romanizedLyric,
                 logPrefix = "网易云音译歌词解析失败"
-            )
+            ),
+            rawResponse = rawResponse
         )
     }
 
@@ -304,12 +342,111 @@ internal object PlayerLyricsProvider {
     ): NeteaseLyricsCacheEntry {
         neteaseLyricsCache.get(songId)?.let { cached ->
             NPLogger.d("NERI-PlayerManager", "Using cached NetEase lyrics for songId=$songId")
+            scheduleNeteaseLyricsRefresh(songId, cached, neteaseLyricsCache, loader)
             return cached
+        }
+
+        val persisted = readPersistedNeteaseLyricsEntry(songId)
+        if (persisted != null) {
+            neteaseLyricsCache.put(songId, persisted)
+            NPLogger.d("NERI-PlayerManager", "Using persisted NetEase lyrics for songId=$songId")
+            scheduleNeteaseLyricsRefresh(songId, persisted, neteaseLyricsCache, loader)
+            return persisted
         }
 
         val entry = buildNeteaseLyricsCacheEntry(loader(songId))
         neteaseLyricsCache.put(songId, entry)
+        persistNeteaseLyricsEntry(songId, entry)
         return entry
+    }
+
+    private fun scheduleNeteaseLyricsRefresh(
+        songId: Long,
+        cached: NeteaseLyricsCacheEntry,
+        cache: LruCache<Long, NeteaseLyricsCacheEntry>,
+        loader: suspend (Long) -> String
+    ) {
+        if (!AppContainer.isInitialized()) {
+            return
+        }
+        if (!neteaseRefreshInFlight.add(songId)) {
+            return
+        }
+        val generation = lyricsCacheGeneration.get()
+        AppContainer.launchBackgroundIo {
+            try {
+                val refreshed = buildNeteaseLyricsCacheEntry(loader(songId))
+                if (
+                    lyricsCacheGeneration.get() == generation &&
+                    !sameNeteaseLyrics(cached, refreshed)
+                ) {
+                    cache.put(songId, refreshed)
+                    persistNeteaseLyricsEntry(songId, refreshed)
+                    NPLogger.d(
+                        "NERI-PlayerManager",
+                        "Updated NetEase lyric cache for songId=$songId"
+                    )
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                logNeteaseLyricLoadFailure("refreshNeteaseLyrics", error)
+            } finally {
+                neteaseRefreshInFlight.remove(songId)
+            }
+        }
+    }
+
+    private fun sameNeteaseLyrics(
+        first: NeteaseLyricsCacheEntry,
+        second: NeteaseLyricsCacheEntry
+    ): Boolean {
+        return first.preferredLyricText == second.preferredLyricText &&
+            first.translatedLyricText == second.translatedLyricText &&
+            first.romanizedLyricText == second.romanizedLyricText &&
+            first.preferredLyricEntries == second.preferredLyricEntries &&
+            first.translatedLyricEntries == second.translatedLyricEntries &&
+            first.romanizedLyricEntries == second.romanizedLyricEntries
+    }
+
+    private fun persistedNeteaseLyricsFile(songId: Long): File {
+        return File(lyricsCacheDirectory(AppContainer.applicationContext), "netease_$songId.json")
+    }
+
+    private fun readPersistedNeteaseLyricsEntry(songId: Long): NeteaseLyricsCacheEntry? {
+        if (!AppContainer.isInitialized()) {
+            return null
+        }
+        val file = persistedNeteaseLyricsFile(songId)
+        if (!file.isFile || file.length() <= 0L) {
+            return null
+        }
+        return runCatching {
+            buildNeteaseLyricsCacheEntry(file.readText(Charsets.UTF_8))
+        }.onFailure {
+            NPLogger.w("NERI-PlayerManager", "读取持久化歌词缓存失败: ${it.message}")
+        }.getOrNull()
+    }
+
+    private fun persistNeteaseLyricsEntry(
+        songId: Long,
+        entry: NeteaseLyricsCacheEntry
+    ) {
+        if (entry.rawResponse.isBlank() || !AppContainer.isInitialized()) {
+            return
+        }
+        runCatching {
+            val target = persistedNeteaseLyricsFile(songId)
+            target.parentFile?.mkdirs()
+            val temporary = File(target.parentFile, ".${target.name}.tmp")
+            temporary.writeText(entry.rawResponse, Charsets.UTF_8)
+            if (!temporary.renameTo(target)) {
+                target.writeText(entry.rawResponse, Charsets.UTF_8)
+                temporary.delete()
+            }
+        }.onFailure {
+            NPLogger.w("NERI-PlayerManager", "写入持久化歌词缓存失败: ${it.message}")
+        }
     }
 
     private suspend fun getCachedNeteaseLyricsEntry(
@@ -374,20 +511,6 @@ internal object PlayerLyricsProvider {
             return emptyList()
         }
         return convertPlainLyricsToEntries(rawLyric, durationMs)
-    }
-
-    private fun inspectLocalLyricDetails(
-        application: Application,
-        song: SongItem
-    ): LocalMediaDetails? {
-        if (!song.isLocalSong()) {
-            return null
-        }
-        return runCatching { LocalMediaSupport.inspect(application, song) }
-            .onFailure {
-                NPLogger.w("NERI-PlayerManager", "本地歌词旁车读取失败: ${it.message}")
-            }
-            .getOrNull()
     }
 
     suspend fun getNeteaseLyrics(
@@ -481,13 +604,21 @@ internal object PlayerLyricsProvider {
     ): List<LyricEntry> {
         return withContext(Dispatchers.IO) {
             val isYouTubeMusicTrack = isYouTubeMusicSong(song)
-            val localDetails = inspectLocalLyricDetails(application, song)
-            val localTranslatedLyric = localDetails?.translatedLyricContent
+        val localLyrics = if (song.isLocalSong()) {
+            LocalMediaSupport.inspectLyricsFast(song)
+        } else {
+            null
+        }
+        val localTranslatedLyric = localLyrics?.translatedLyric
             val storedTranslatedLyric = resolveStoredLyricText(
                 currentLyric = song.matchedTranslatedLyric,
                 legacyLyric = song.originalTranslatedLyric
             )
-            val downloadedTranslatedLyric = AudioDownloadManager.getTranslatedLyricContent(application, song)
+            val downloadedTranslatedLyric = if (song.isLocalSong()) {
+                null
+            } else {
+                AudioDownloadManager.getTranslatedLyricContent(application, song)
+            }
             val selectedTranslatedLyric = resolveLocalFirstLyricText(
                 localLyric = localTranslatedLyric,
                 storedLyric = storedTranslatedLyric,
@@ -513,6 +644,9 @@ internal object PlayerLyricsProvider {
             } else {
                 NPLogger.w("NERI-PlayerManager", "已忽略 YouTube 全零翻译时间轴: ${song.name}")
             }
+            if (!shouldLoadRemoteLyrics(song)) {
+                return@withContext emptyList()
+            }
             val deferredDownloadedTranslation = if (isYouTubeMusicTrack) {
                 downloadedTranslatedLyric?.let(::extractPlainLyricsFromCollapsedTimedLyrics)
             } else {
@@ -528,12 +662,19 @@ internal object PlayerLyricsProvider {
                 NPLogger.w("NERI-PlayerManager", "已忽略下载的 YouTube 全零翻译时间轴: ${song.name}")
             }
 
+            if (!shouldLoadRemoteLyrics(song)) {
+                return@withContext emptyList()
+            }
             if (isYouTubeMusicTrack) {
                 val storedLyric = resolveStoredLyricText(
                     currentLyric = song.matchedLyric,
                     legacyLyric = song.originalLyric
                 )
-                val downloadedLyric = AudioDownloadManager.getLyricContent(application, song)
+                val downloadedLyric = if (song.isLocalSong()) {
+                    null
+                } else {
+                    AudioDownloadManager.getLyricContent(application, song)
+                }
                 if (
                     shouldBlockExternalYouTubeMusicTranslation(storedLyric) ||
                     shouldBlockExternalYouTubeMusicTranslation(downloadedLyric)
@@ -585,8 +726,11 @@ internal object PlayerLyricsProvider {
         biliSourceTag: String
     ): List<LyricEntry> {
         return withContext(Dispatchers.IO) {
-            val localRomanizedLyric = inspectLocalLyricDetails(application, song)
-                ?.romanizedLyricContent
+            val localRomanizedLyric = if (song.isLocalSong()) {
+                LocalMediaSupport.inspectLyricsFast(song).romanizedLyric
+            } else {
+                null
+            }
             localRomanizedLyric?.let { rawLyric ->
                 parseLocalLyricOverride(
                     rawLyric = rawLyric,
@@ -594,12 +738,20 @@ internal object PlayerLyricsProvider {
                     logPrefix = "本地音译歌词读取失败"
                 )?.let { return@withContext it }
             }
-            AudioDownloadManager.getRomanizedLyricContent(application, song)?.let { rawLyric ->
+            val downloadedRomanizedLyric = if (song.isLocalSong()) {
+                null
+            } else {
+                AudioDownloadManager.getRomanizedLyricContent(application, song)
+            }
+            downloadedRomanizedLyric?.let { rawLyric ->
                 parseLocalLyricOverride(
                     rawLyric = rawLyric,
                     durationMs = song.durationMs,
                     logPrefix = "本地音译歌词读取失败"
                 )?.let { return@withContext it }
+            }
+            if (!shouldLoadRemoteLyrics(song)) {
+                return@withContext emptyList()
             }
             if (isYouTubeMusicSong(song)) {
                 return@withContext emptyList()
@@ -650,12 +802,20 @@ internal object PlayerLyricsProvider {
     ): List<LyricEntry> {
         return withContext(Dispatchers.IO) {
             val isYouTubeMusicTrack = isYouTubeMusicSong(song)
-            val localLyric = inspectLocalLyricDetails(application, song)?.lyricContent
+            val localLyric = if (song.isLocalSong()) {
+                LocalMediaSupport.inspectLyricsFast(song).lyric
+            } else {
+                null
+            }
             val storedLyric = resolveStoredLyricText(
                 currentLyric = song.matchedLyric,
                 legacyLyric = song.originalLyric
             )
-            val downloadedLyric = AudioDownloadManager.getLyricContent(application, song)
+            val downloadedLyric = if (song.isLocalSong()) {
+                null
+            } else {
+                AudioDownloadManager.getLyricContent(application, song)
+            }
             val selectedLyric = resolveLocalFirstLyricText(
                 localLyric = localLyric,
                 storedLyric = storedLyric,
@@ -704,6 +864,9 @@ internal object PlayerLyricsProvider {
                     }
                     return@withContext entries
                 }
+            }
+            if (song.isLocalSong()) {
+                return@withContext emptyList()
             }
             if (isYouTubeMusicTrack) {
                 return@withContext getYouTubeMusicLyrics(

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManager.kt
@@ -533,7 +533,9 @@ object LocalAudioImportManager {
             ?: quickSong.name
         val resolvedArtist = detailedSong.artist.takeIf { it.isNotBlank() } ?: quickSong.artist
         val resolvedAlbum = detailedSong.album.takeIf { it.isNotBlank() } ?: quickSong.album
-        val resolvedCoverUrl = detailedSong.coverUrl ?: quickSong.coverUrl
+        val resolvedCoverUrl = quickSong.coverUrl
+            ?.takeIf { it.isNotBlank() }
+            ?: detailedSong.coverUrl
         val quickLocalPath = quickSong.localFilePath?.takeIf { it.isNotBlank() }
         val detailedLocalPath = detailedSong.localFilePath?.takeIf { it.isNotBlank() }
         val resolvedLocalPath = quickLocalPath ?: detailedLocalPath

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
@@ -338,7 +338,7 @@ object LocalMediaSupport {
     private val lyricExtensions = listOf("lrc", "txt")
     private val coverFileNames = listOf("cover", "folder", "front")
     private val imageExtensions = listOf("jpg", "jpeg", "png", "webp")
-    private data class LocalCoverCacheHit(val coverUri: String?)
+    private data class LocalCoverCacheHit(val coverUri: String)
     private data class FilePathCacheHit(val path: String?)
     private val localLyricsLookupCache = object : LinkedHashMap<String, LocalLyricsScanMetadata>(
         LOCAL_LYRICS_LOOKUP_CACHE_LIMIT,
@@ -351,12 +351,12 @@ object LocalMediaSupport {
             return size > LOCAL_LYRICS_LOOKUP_CACHE_LIMIT
         }
     }
-    private val localCoverLookupCache = object : LinkedHashMap<String, String?>(
+    private val localCoverLookupCache = object : LinkedHashMap<String, String>(
         LOCAL_COVER_LOOKUP_CACHE_LIMIT,
         0.75f,
         true
     ) {
-        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, String?>): Boolean {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, String>): Boolean {
             return size > LOCAL_COVER_LOOKUP_CACHE_LIMIT
         }
     }
@@ -1489,6 +1489,11 @@ object LocalMediaSupport {
             file = file,
             displayName = resolved.displayName
         )
+        val coverUri = runCatching {
+            resolveCoverUri(context, uri)
+        }.onFailure {
+            NPLogger.w(TAG, "resolve metadata-only cover failed for $uri: ${it.message}")
+        }.getOrNull()
 
         return LocalMediaDetails(
             sourceUri = uri,
@@ -1527,7 +1532,7 @@ object LocalMediaSupport {
             sizeBytes = queried.sizeBytes ?: file?.length(),
             lastModifiedMs = queried.lastModifiedMs ?: file?.lastModified(),
             filePath = file?.absolutePath ?: queried.filePath,
-            coverUri = null,
+            coverUri = coverUri,
             coverSource = null,
             lyricContent = localMetadata?.lyric,
             lyricPath = null,
@@ -3538,14 +3543,17 @@ object LocalMediaSupport {
 
     private fun cachedLocalCoverLookup(cacheKey: String): LocalCoverCacheHit? {
         synchronized(localCoverLookupCache) {
-            if (!localCoverLookupCache.containsKey(cacheKey)) return null
-            return LocalCoverCacheHit(localCoverLookupCache[cacheKey])
+            return localCoverLookupCache[cacheKey]?.let(::LocalCoverCacheHit)
         }
     }
 
     private fun rememberLocalCoverLookup(cacheKey: String, coverUri: String?) {
+        val normalizedCoverUri = coverUri
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: return
         synchronized(localCoverLookupCache) {
-            localCoverLookupCache[cacheKey] = coverUri
+            localCoverLookupCache[cacheKey] = normalizedCoverUri
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
@@ -85,6 +85,7 @@ private const val SHARED_LOCAL_MEDIA_DIR = "shared_media_exports"
 private const val LOCAL_COVER_LOOKUP_CACHE_LIMIT = 768
 private const val NEARBY_COVER_LOOKUP_CACHE_LIMIT = 2048
 private const val DIRECTORY_COVER_LOOKUP_CACHE_LIMIT = 256
+private const val LOCAL_LYRICS_LOOKUP_CACHE_LIMIT = 768
 private const val MAX_EDITABLE_COVER_BYTES = 8L * 1024L * 1024L
 private const val FRONT_COVER_PICTURE_TYPE = "Front Cover"
 private val ROLELESS_COVER_PICTURE_EXTENSIONS = setOf(
@@ -339,6 +340,17 @@ object LocalMediaSupport {
     private val imageExtensions = listOf("jpg", "jpeg", "png", "webp")
     private data class LocalCoverCacheHit(val coverUri: String?)
     private data class FilePathCacheHit(val path: String?)
+    private val localLyricsLookupCache = object : LinkedHashMap<String, LocalLyricsScanMetadata>(
+        LOCAL_LYRICS_LOOKUP_CACHE_LIMIT,
+        0.75f,
+        true
+    ) {
+        override fun removeEldestEntry(
+            eldest: MutableMap.MutableEntry<String, LocalLyricsScanMetadata>
+        ): Boolean {
+            return size > LOCAL_LYRICS_LOOKUP_CACHE_LIMIT
+        }
+    }
     private val localCoverLookupCache = object : LinkedHashMap<String, String?>(
         LOCAL_COVER_LOOKUP_CACHE_LIMIT,
         0.75f,
@@ -606,6 +618,120 @@ object LocalMediaSupport {
             )
         }
         fallbackOutcome
+    }
+
+    /**
+     * 只读取歌词相关字段，避免歌词首屏触发 TagLib、封面和音频轨道解析
+     */
+    internal fun inspectLyricsFast(
+        song: SongItem
+    ): LocalLyricsScanMetadata {
+        val stored = LocalLyricsScanMetadata(
+            lyric = song.matchedLyric ?: song.originalLyric,
+            translatedLyric = song.matchedTranslatedLyric ?: song.originalTranslatedLyric,
+            romanizedLyric = null
+        )
+        if (
+            song.matchedLyric != null ||
+            song.originalLyric != null ||
+            song.matchedTranslatedLyric != null ||
+            song.originalTranslatedLyric != null
+        ) {
+            return stored
+        }
+
+        val source = song.localMediaUri()
+        val cacheKey = buildLocalLyricsCacheKey(song, source)
+        synchronized(localLyricsLookupCache) {
+            localLyricsLookupCache[cacheKey]?.let { return it }
+        }
+
+        val directFile = song.localFilePath
+            ?.takeIf(String::isNotBlank)
+            ?.let(::File)
+            ?.takeIf(File::isFile)
+            ?: source
+                ?.takeIf { it.scheme.equals("file", ignoreCase = true) }
+                ?.path
+                ?.let(::File)
+                ?.takeIf(File::isFile)
+        val result = if (directFile != null) {
+            runCatching {
+                inspectLyricsFromDirectFile(
+                    file = directFile
+                )
+            }.getOrElse {
+                NPLogger.w(TAG, "fast local lyrics inspection failed for $source: ${it.message}")
+                LocalLyricsScanMetadata(null, null, null)
+            }
+        } else {
+            // SAF 歌词引用在导入阶段已写入 SongItem, 首屏不再同步查询文档树
+            LocalLyricsScanMetadata(null, null, null)
+        }
+        synchronized(localLyricsLookupCache) {
+            localLyricsLookupCache[cacheKey] = result
+        }
+        return result
+    }
+
+    private fun inspectLyricsFromDirectFile(
+        file: File
+    ): LocalLyricsScanMetadata {
+        val metadataFile = File(
+            file.parentFile ?: return LocalLyricsScanMetadata(null, null, null),
+            file.name + LOCAL_METADATA_SUFFIX
+        )
+        val localMetadata = if (metadataFile.isFile) {
+            readTextFile(metadataFile)?.let {
+                parseLocalMetadataSidecar(metadataFile.absolutePath, it)
+            }
+        } else {
+            null
+        }
+        val nearbyFiles = findNearbyLyricFiles(file)
+        fun read(reference: File?): String? {
+            return reference?.let(::readTextFile)
+        }
+        val nearbyLyric = read(nearbyFiles.original)
+        val nearbyTranslatedLyric = read(nearbyFiles.translated)
+        val nearbyRomanizedLyric = read(nearbyFiles.romanized)
+        return LocalLyricsScanMetadata(
+            lyric = if (localMetadata?.hasLyricOverride == true) {
+                localMetadata.lyric
+            } else {
+                nearbyLyric
+            },
+            translatedLyric = if (localMetadata?.hasTranslatedLyricOverride == true) {
+                localMetadata.translatedLyric
+            } else {
+                nearbyTranslatedLyric
+            },
+            romanizedLyric = if (localMetadata?.hasRomanizedLyricOverride == true) {
+                localMetadata.romanizedLyric
+            } else {
+                nearbyRomanizedLyric
+            }
+        )
+    }
+
+    internal fun clearLyricsLookupCache() {
+        synchronized(localLyricsLookupCache) {
+            localLyricsLookupCache.clear()
+        }
+    }
+
+    private fun buildLocalLyricsCacheKey(song: SongItem, source: Uri?): String {
+        val localFile = song.localFilePath?.let(::File)
+        val localFileState = localFile?.let {
+            "${it.length()}:${it.lastModified()}:${it.parentFile?.lastModified()}"
+        }.orEmpty()
+        return listOf(
+            song.sourceStableKey,
+            song.localFilePath,
+            song.localFileName,
+            source?.toString(),
+            localFileState
+        ).joinToString("|")
     }
 
     private fun selectEditableMetadataWriteFallback(

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
@@ -3543,8 +3543,22 @@ object LocalMediaSupport {
 
     private fun cachedLocalCoverLookup(cacheKey: String): LocalCoverCacheHit? {
         synchronized(localCoverLookupCache) {
-            return localCoverLookupCache[cacheKey]?.let(::LocalCoverCacheHit)
+            val coverUri = localCoverLookupCache[cacheKey] ?: return null
+            if (!isUsableCachedCoverUri(coverUri)) {
+                localCoverLookupCache.remove(cacheKey)
+                return null
+            }
+            return LocalCoverCacheHit(coverUri)
         }
+    }
+
+    private fun isUsableCachedCoverUri(coverUri: String): Boolean {
+        val uri = runCatching { coverUri.toUri() }.getOrNull() ?: return false
+        if (!uri.scheme.equals("file", ignoreCase = true)) {
+            return true
+        }
+        val path = uri.path ?: return false
+        return File(path).isFile && File(path).length() > 0L
     }
 
     private fun rememberLocalCoverLookup(cacheKey: String, coverUri: String?) {
@@ -4074,27 +4088,27 @@ object LocalMediaSupport {
 
     private fun cachedNearbyCover(cacheKey: String): FilePathCacheHit? {
         synchronized(nearbyCoverLookupCache) {
-            if (!nearbyCoverLookupCache.containsKey(cacheKey)) return null
-            return FilePathCacheHit(nearbyCoverLookupCache[cacheKey])
+            return nearbyCoverLookupCache[cacheKey]?.let(::FilePathCacheHit)
         }
     }
 
     private fun rememberNearbyCover(cacheKey: String, cover: File?) {
+        val coverPath = cover?.absolutePath ?: return
         synchronized(nearbyCoverLookupCache) {
-            nearbyCoverLookupCache[cacheKey] = cover?.absolutePath
+            nearbyCoverLookupCache[cacheKey] = coverPath
         }
     }
 
     private fun cachedDirectoryCover(cacheKey: String): FilePathCacheHit? {
         synchronized(directoryCoverLookupCache) {
-            if (!directoryCoverLookupCache.containsKey(cacheKey)) return null
-            return FilePathCacheHit(directoryCoverLookupCache[cacheKey])
+            return directoryCoverLookupCache[cacheKey]?.let(::FilePathCacheHit)
         }
     }
 
     private fun rememberDirectoryCover(cacheKey: String, cover: File?) {
+        val coverPath = cover?.absolutePath ?: return
         synchronized(directoryCoverLookupCache) {
-            directoryCoverLookupCache[cacheKey] = cover?.absolutePath
+            directoryCoverLookupCache[cacheKey] = coverPath
         }
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupport.kt
@@ -631,14 +631,6 @@ object LocalMediaSupport {
             translatedLyric = song.matchedTranslatedLyric ?: song.originalTranslatedLyric,
             romanizedLyric = null
         )
-        if (
-            song.matchedLyric != null ||
-            song.originalLyric != null ||
-            song.matchedTranslatedLyric != null ||
-            song.originalTranslatedLyric != null
-        ) {
-            return stored
-        }
 
         val source = song.localMediaUri()
         val cacheKey = buildLocalLyricsCacheKey(song, source)
@@ -655,7 +647,7 @@ object LocalMediaSupport {
                 ?.path
                 ?.let(::File)
                 ?.takeIf(File::isFile)
-        val result = if (directFile != null) {
+        val scanned = if (directFile != null) {
             runCatching {
                 inspectLyricsFromDirectFile(
                     file = directFile
@@ -668,6 +660,11 @@ object LocalMediaSupport {
             // SAF 歌词引用在导入阶段已写入 SongItem, 首屏不再同步查询文档树
             LocalLyricsScanMetadata(null, null, null)
         }
+        val result = LocalLyricsScanMetadata(
+            lyric = stored.lyric ?: scanned.lyric,
+            translatedLyric = stored.translatedLyric ?: scanned.translatedLyric,
+            romanizedLyric = scanned.romanizedLyric
+        )
         synchronized(localLyricsLookupCache) {
             localLyricsLookupCache[cacheKey] = result
         }

--- a/app/src/main/java/moe/ouom/neriplayer/data/storage/LyricsCacheStorage.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/storage/LyricsCacheStorage.kt
@@ -1,0 +1,10 @@
+package moe.ouom.neriplayer.data.storage
+
+import android.content.Context
+import java.io.File
+
+const val LYRICS_CACHE_DIRECTORY_NAME = "lyrics_cache"
+
+fun lyricsCacheDirectory(context: Context): File {
+    return File(context.applicationContext.filesDir, LYRICS_CACHE_DIRECTORY_NAME)
+}

--- a/app/src/main/java/moe/ouom/neriplayer/data/storage/StorageUsageAnalyzer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/storage/StorageUsageAnalyzer.kt
@@ -47,6 +47,7 @@ enum class StorageCacheKind {
     Image,
     DownloadStaging,
     SharedMedia,
+    Lyrics,
     NeteasePlaylist,
     BiliFavorite,
     BiliArchive,
@@ -60,6 +61,7 @@ enum class StorageUsageItemKind {
     ImageCache,
     DownloadStaging,
     SharedMedia,
+    LyricsCache,
     NeteasePlaylistCache,
     BiliFavoriteCache,
     BiliArchiveCache,
@@ -83,6 +85,7 @@ data class StorageCacheClearOptions(
     val imageCache: Boolean = true,
     val downloadStaging: Boolean = false,
     val sharedMedia: Boolean = false,
+    val lyricsCache: Boolean = false,
     val neteasePlaylistCache: Boolean = false,
     val biliFavoriteCache: Boolean = false,
     val biliArchiveCache: Boolean = false,
@@ -92,14 +95,14 @@ data class StorageCacheClearOptions(
 ) {
     val hasSelection: Boolean
         get() = audioCache || imageCache || downloadStaging || sharedMedia ||
-            hasPlatformCacheSelection || logFiles || crashLogs
+            lyricsCache || hasPlatformCacheSelection || logFiles || crashLogs
 
     val needsPlayerCacheClear: Boolean
         get() = audioCache || imageCache
 
     val needsExtraCacheClear: Boolean
         get() = downloadStaging || sharedMedia || hasPlatformCacheSelection ||
-            logFiles || crashLogs
+            lyricsCache || logFiles || crashLogs
 
     val hasPlatformCacheSelection: Boolean
         get() = neteasePlaylistCache || biliFavoriteCache || biliArchiveCache ||
@@ -184,6 +187,7 @@ suspend fun analyzeStorageUsage(context: Context): StorageUsageSummary = withCon
     val imageCacheDir = File(cacheDir, DIR_IMAGE_CACHE)
     val downloadStagingDirs = downloadStagingDirs(filesDir, cacheDir)
     val sharedMediaDir = File(cacheDir, DIR_SHARED_MEDIA_EXPORTS)
+    val lyricsCacheDir = File(filesDir, LYRICS_CACHE_DIRECTORY_NAME)
     val platformCacheDirs = platformCacheDirs(filesDir)
     val databaseFiles = databaseFiles(appContext)
     val localCoverDir = File(filesDir, DIR_LOCAL_AUDIO_COVERS)
@@ -251,7 +255,8 @@ suspend fun analyzeStorageUsage(context: Context): StorageUsageSummary = withCon
     val cacheKnownRoots = listOf(
         mediaCacheDir,
         imageCacheDir,
-        sharedMediaDir
+        sharedMediaDir,
+        lyricsCacheDir
     ) + downloadStagingDirs
     val filesKnownRoots = knownAppDataRoots(
         platformCacheDirs = platformCacheDirs,
@@ -263,7 +268,7 @@ suspend fun analyzeStorageUsage(context: Context): StorageUsageSummary = withCon
         logDir = logDir,
         crashDir = crashDir,
         downloadedStorageFiles = scanInputs.downloadLibraryUsage.localFiles
-    )
+    ) + lyricsCacheDir
 
     StorageUsageSummary(
         sections = listOf(
@@ -301,6 +306,14 @@ suspend fun analyzeStorageUsage(context: Context): StorageUsageSummary = withCon
                         file = sharedMediaDir,
                         kind = StorageUsageItemKind.SharedMedia,
                         cacheKind = StorageCacheKind.SharedMedia
+                    ),
+                    usageItem(
+                        context = appContext,
+                        titleRes = R.string.storage_type_lyrics_cache,
+                        descriptionRes = R.string.storage_desc_lyrics_cache,
+                        file = lyricsCacheDir,
+                        kind = StorageUsageItemKind.LyricsCache,
+                        cacheKind = StorageCacheKind.Lyrics
                     ),
                     usageItem(
                         context = appContext,
@@ -515,6 +528,7 @@ suspend fun clearExtraStorageCaches(
     val targets = buildList {
         if (options.downloadStaging) addAll(downloadStagingDirs(appContext.filesDir, appContext.cacheDir))
         if (options.sharedMedia) add(File(appContext.cacheDir, DIR_SHARED_MEDIA_EXPORTS))
+        if (options.lyricsCache) add(File(appContext.filesDir, LYRICS_CACHE_DIRECTORY_NAME))
         if (options.logFiles) add(File(appContext.getExternalFilesDir(null) ?: appContext.filesDir, DIR_LOGS))
         if (options.crashLogs) {
             add(File(appContext.getExternalFilesDir(null) ?: appContext.filesDir, DIR_CRASHES))

--- a/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
@@ -154,6 +154,7 @@ import moe.ouom.neriplayer.core.download.GlobalDownloadManager
 import moe.ouom.neriplayer.core.download.ManagedDownloadStorage
 import moe.ouom.neriplayer.core.player.effects.AudioReactive
 import moe.ouom.neriplayer.core.player.PlayerManager
+import moe.ouom.neriplayer.core.player.metadata.PlayerLyricsProvider
 import moe.ouom.neriplayer.core.player.lifecycle.recoverUsbExclusivePlaybackOnForeground
 import moe.ouom.neriplayer.core.player.lifecycle.updateUsbExclusiveForegroundState
 import moe.ouom.neriplayer.core.player.policy.usb.shouldPromptForUsbExclusiveBackgroundPermission
@@ -3154,6 +3155,15 @@ private fun NeriAppContent(
                                     messages += message
                                 }
                                 if (options.needsExtraCacheClear) {
+                                    if (options.lyricsCache) {
+                                        PlayerLyricsProvider.clearLyricsCaches(
+                                            neteaseLyricsCache = PlayerManager.neteaseLyricsCache,
+                                            ytMusicLyricsCache = PlayerManager.ytMusicLyricsCache
+                                        )
+                                        PlayerLyricsProvider.clearPersistentLyricCache(
+                                            AppContainer.applicationContext
+                                        )
+                                    }
                                     val result = clearExtraStorageCaches(context, options)
                                     messages += when {
                                         !result.success -> composeResources.getString(
@@ -4545,7 +4555,9 @@ private fun NeriAppContent(
                                     showCoverSourceBadge = showCoverSourceBadge,
                                     showLyricTranslation = showLyricTranslation,
                                     showNowPlayingTitle = showNowPlayingTitle,
-                                    offlineMode = offlineMode
+                                    offlineMode = offlineMode,
+                                    resolvedCoverUrl = displayCoverUrl,
+                                    visualCoverUrl = playbackVisualCoverUrl
                                 )
                             }
                         }

--- a/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
@@ -3160,9 +3160,11 @@ private fun NeriAppContent(
                                             neteaseLyricsCache = PlayerManager.neteaseLyricsCache,
                                             ytMusicLyricsCache = PlayerManager.ytMusicLyricsCache
                                         )
-                                        PlayerLyricsProvider.clearPersistentLyricCache(
-                                            AppContainer.applicationContext
-                                        )
+                                        withContext(Dispatchers.IO) {
+                                            PlayerLyricsProvider.clearPersistentLyricCache(
+                                                AppContainer.applicationContext
+                                            )
+                                        }
                                     }
                                     val result = clearExtraStorageCaches(context, options)
                                     messages += when {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
@@ -836,12 +836,14 @@ internal fun resolvePlaybackVisualCoverUrl(
     currentCoverUrl: String?,
     previousVisualCoverUrl: String?,
     hasCurrentSong: Boolean,
-    clearDelayElapsed: Boolean
+    clearDelayElapsed: Boolean,
+    preservePreviousVisualCover: Boolean = true
 ): String? {
     val normalizedCoverUrl = currentCoverUrl?.trim()?.takeIf { it.isNotEmpty() }
     return when {
         normalizedCoverUrl != null -> normalizedCoverUrl
         !hasCurrentSong || clearDelayElapsed -> null
+        !preservePreviousVisualCover -> null
         else -> previousVisualCoverUrl
     }
 }
@@ -861,14 +863,19 @@ private fun rememberPlaybackVisualCoverUrl(
             )
         )
     }
+    var lastObservedSongKey by remember { mutableStateOf(currentSongKey) }
+    val songChangedSinceLastObservation = currentSongKey != lastObservedSongKey
 
     LaunchedEffect(coverUrl, currentSongKey) {
+        val preservePreviousVisualCover = currentSongKey == lastObservedSongKey
         visualCoverUrl = resolvePlaybackVisualCoverUrl(
             currentCoverUrl = coverUrl,
             previousVisualCoverUrl = visualCoverUrl,
             hasCurrentSong = currentSongKey != null,
-            clearDelayElapsed = false
+            clearDelayElapsed = false,
+            preservePreviousVisualCover = preservePreviousVisualCover
         )
+        lastObservedSongKey = currentSongKey
 
         if (coverUrl.isNullOrBlank() && currentSongKey != null && visualCoverUrl != null) {
             delay(PLAYBACK_VISUAL_COVER_CLEAR_DELAY_MS)
@@ -881,7 +888,13 @@ private fun rememberPlaybackVisualCoverUrl(
         }
     }
 
-    return visualCoverUrl
+    val normalizedCoverUrl = coverUrl?.trim()?.takeIf { it.isNotEmpty() }
+    return when {
+        normalizedCoverUrl != null -> normalizedCoverUrl
+        currentSongKey == null -> null
+        songChangedSinceLastObservation -> null
+        else -> visualCoverUrl
+    }
 }
 
 @Composable
@@ -2122,7 +2135,6 @@ private fun NeriAppContent(
             startIndex = index,
             source = "ui_click_before_play"
         )
-        showNowPlaying = true
         // 播放队列可能包含歌词等大字段, 避免通过 Binder 传整份歌单导致崩溃
         val localPlaylistId = localPlaylistIdFromSourceRoute(sourceRoute)
         if (localPlaylistId == null) {
@@ -2134,6 +2146,8 @@ private fun NeriAppContent(
                 startIndex = index
             )
         }
+        // 先提交当前歌曲, 播放页首帧不能继续绘制上一首封面
+        showNowPlaying = true
         scheduleAudioServiceStart(
             "play_songs_and_open_now_playing",
             true
@@ -2149,8 +2163,9 @@ private fun NeriAppContent(
             startIndex = 0,
             source = "ui_click_preserve_queue_before_play"
         )
-        showNowPlaying = true
         PlayerManager.replaceCurrentInQueueAndPlay(song)
+        // 先提交当前歌曲, 播放页首帧不能继续绘制上一首封面
+        showNowPlaying = true
         scheduleAudioServiceStart(
             "play_search_result_preserve_queue",
             true
@@ -2183,9 +2198,9 @@ private fun NeriAppContent(
         restoreLyricsAfterAlbumBack = false
         lyricsAlbumRouteObserved = false
         currentPlaybackSourceRoute = sourceRoute
-        showNowPlaying = true
         NPLogger.d("NERI-App", "Playing audio from Bili video: ${videos[index].title}")
         PlayerManager.playBiliVideoAsAudio(videos, index)
+        showNowPlaying = true
         ensureAudioServiceStarted(source = "play_bili_audio_and_open_now_playing")
     }
 
@@ -2198,9 +2213,9 @@ private fun NeriAppContent(
         restoreLyricsAfterAlbumBack = false
         lyricsAlbumRouteObserved = false
         currentPlaybackSourceRoute = sourceRoute
-        showNowPlaying = true
         NPLogger.d("NERI-App", "Playing parts from Bili video: ${videoInfo.title}")
         PlayerManager.playBiliVideoParts(videoInfo, index, coverUrl)
+        showNowPlaying = true
         ensureAudioServiceStarted(source = "play_bili_parts_and_open_now_playing")
     }
 

--- a/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
@@ -4574,7 +4574,8 @@ private fun NeriAppContent(
                                     showNowPlayingTitle = showNowPlayingTitle,
                                     offlineMode = offlineMode,
                                     resolvedCoverUrl = displayCoverUrl,
-                                    visualCoverUrl = playbackVisualCoverUrl
+                                    visualCoverUrl = playbackVisualCoverUrl,
+                                    playbackSongKey = currentSongKey
                                 )
                             }
                         }

--- a/app/src/main/java/moe/ouom/neriplayer/ui/component/playback/NeriMiniPlayer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/component/playback/NeriMiniPlayer.kt
@@ -46,6 +46,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -67,6 +68,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import moe.ouom.neriplayer.R
 import moe.ouom.neriplayer.ui.effect.glass.AdvancedGlassRole
@@ -79,6 +81,24 @@ import kotlin.math.sign
 
 object NeriMiniPlayerDefaults {
     val Height = 64.dp
+}
+
+private const val MINI_PLAYER_COVER_CLEAR_DELAY_MS = 900L
+
+internal fun resolveMiniPlayerDisplayedCoverUrl(
+    requestedCoverUrl: String?,
+    displayedCoverUrl: String?,
+    requestSucceeded: Boolean,
+    clearDelayElapsed: Boolean = false
+): String? {
+    val requested = requestedCoverUrl?.trim()?.takeIf { it.isNotEmpty() }
+    val displayed = displayedCoverUrl?.trim()?.takeIf { it.isNotEmpty() }
+    return when {
+        requested == null && clearDelayElapsed -> null
+        requested == null -> displayed
+        requested == displayed || requestSucceeded -> requested
+        else -> displayed
+    }
 }
 
 @Composable
@@ -98,6 +118,10 @@ fun NeriMiniPlayer(
     isPlaybackWaiting: Boolean = false
 ) {
     val shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+    val context = LocalContext.current
+    val requestedCoverUrl = coverUrl?.trim()?.takeIf { it.isNotEmpty() }
+    var displayedCoverUrl by remember { mutableStateOf(requestedCoverUrl) }
+    val latestRequestedCoverUrl by rememberUpdatedState(requestedCoverUrl)
     val currentOnPrevious by rememberUpdatedState(onPrevious)
     val currentOnNext by rememberUpdatedState(onNext)
     val swipeOffset = remember { Animatable(0f) }
@@ -124,6 +148,20 @@ fun NeriMiniPlayer(
                 animationSpec = tween(durationMillis = 180, easing = FastOutSlowInEasing)
             )
             onComplete()
+        }
+    }
+
+    LaunchedEffect(requestedCoverUrl) {
+        if (requestedCoverUrl == null) {
+            delay(MINI_PLAYER_COVER_CLEAR_DELAY_MS)
+            if (latestRequestedCoverUrl == null) {
+                displayedCoverUrl = resolveMiniPlayerDisplayedCoverUrl(
+                    requestedCoverUrl = null,
+                    displayedCoverUrl = displayedCoverUrl,
+                    requestSucceeded = false,
+                    clearDelayElapsed = true
+                )
+            }
         }
     }
 
@@ -212,7 +250,7 @@ fun NeriMiniPlayer(
                     modifier = Modifier
                         .size(40.dp)
                         .background(
-                            color = if (coverUrl != null) {
+                            color = if (displayedCoverUrl != null || requestedCoverUrl != null) {
                                 Color.Transparent
                             } else {
                                 MaterialTheme.colorScheme.primaryContainer
@@ -220,12 +258,11 @@ fun NeriMiniPlayer(
                             shape = RoundedCornerShape(8.dp)
                         )
                 ) {
-                    if (coverUrl != null) {
-                        val context = LocalContext.current
+                    if (displayedCoverUrl != null) {
                         AsyncImage(
                             model = fastScrollableImageRequest(
                                 context = context,
-                                data = coverUrl,
+                                data = displayedCoverUrl,
                                 sizePx = 128,
                                 crossfade = false,
                                 offlineMode = offlineMode
@@ -236,7 +273,33 @@ fun NeriMiniPlayer(
                                 .matchParentSize()
                                 .clip(RoundedCornerShape(8.dp))
                         )
-                    } else {
+                    }
+
+                    if (requestedCoverUrl != null && requestedCoverUrl != displayedCoverUrl) {
+                        AsyncImage(
+                            model = fastScrollableImageRequest(
+                                context = context,
+                                data = requestedCoverUrl,
+                                sizePx = 128,
+                                crossfade = false,
+                                offlineMode = offlineMode
+                            ),
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .matchParentSize()
+                                .graphicsLayer { alpha = 0f },
+                            onSuccess = {
+                                if (latestRequestedCoverUrl == requestedCoverUrl) {
+                                    displayedCoverUrl = resolveMiniPlayerDisplayedCoverUrl(
+                                        requestedCoverUrl = requestedCoverUrl,
+                                        displayedCoverUrl = displayedCoverUrl,
+                                        requestSucceeded = true
+                                    )
+                                }
+                            }
+                        )
+                    } else if (displayedCoverUrl == null) {
                         Box(
                             modifier = Modifier.matchParentSize(),
                             contentAlignment = Alignment.Center

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
@@ -326,7 +326,6 @@ import moe.ouom.neriplayer.util.format.formatDuration
 import moe.ouom.neriplayer.util.media.offlineCachedImageRequest
 import moe.ouom.neriplayer.ui.haptic.performHapticFeedback
 import moe.ouom.neriplayer.util.media.saveCoverToPictures
-import moe.ouom.neriplayer.ui.util.rememberSongDisplayCoverUrl
 import org.burnoutcrew.reorderable.ItemPosition
 import org.burnoutcrew.reorderable.ReorderableItem
 import org.burnoutcrew.reorderable.SpringDragCancelledAnimation
@@ -370,6 +369,7 @@ internal fun resolveDisplayedNowPlayingCoverUrl(
 @Composable
 private fun StableNowPlayingCoverImage(
     coverUrl: String?,
+    songKey: String?,
     context: Context,
     coverRequestSizePx: Int,
     offlineMode: Boolean,
@@ -377,7 +377,7 @@ private fun StableNowPlayingCoverImage(
     modifier: Modifier = Modifier
 ) {
     val requestedCoverUrl = coverUrl?.trim()?.takeIf { it.isNotEmpty() }
-    var displayedCoverUrl by remember { mutableStateOf<String?>(null) }
+    var displayedCoverUrl by remember(songKey) { mutableStateOf(requestedCoverUrl) }
     val latestRequestedCoverUrl by rememberUpdatedState(requestedCoverUrl)
 
     LaunchedEffect(requestedCoverUrl) {
@@ -389,14 +389,18 @@ private fun StableNowPlayingCoverImage(
     }
 
     Box(modifier = modifier) {
-        val targetDisplayedCoverUrl = if (requestedCoverUrl == null) {
-            null
-        } else {
-            displayedCoverUrl
+        val targetDisplayedCoverUrl = when {
+            requestedCoverUrl == null -> null
+            displayedCoverUrl == null -> requestedCoverUrl
+            else -> displayedCoverUrl
         }
         Crossfade(
             targetState = targetDisplayedCoverUrl,
-            animationSpec = tween(durationMillis = NowPlayingCoverImageCrossfadeMs),
+            animationSpec = if (targetDisplayedCoverUrl == null) {
+                snap()
+            } else {
+                tween(durationMillis = NowPlayingCoverImageCrossfadeMs)
+            },
             label = "NowPlayingCoverImage"
         ) { displayedCover ->
             if (displayedCover.isNullOrBlank()) {
@@ -1780,6 +1784,7 @@ fun NowPlayingScreen(
     offlineMode: Boolean = false,
     resolvedCoverUrl: String? = null,
     visualCoverUrl: String? = null,
+    playbackSongKey: String? = null,
 ) {
     val coverLyricFontScale = lyricFontScales.coverLyric
     val coverTranslationFontScale = lyricFontScales.coverTranslation
@@ -1884,9 +1889,9 @@ fun NowPlayingScreen(
     val context = LocalContext.current
     val composeResources = LocalResources.current
     val downloadPresenceVersion by GlobalDownloadManager.downloadPresenceVersion.collectAsStateWithLifecycle()
-    val rememberedCoverUrl = rememberSongDisplayCoverUrl(currentSong)
-    val actualCoverUrl = resolvedCoverUrl ?: rememberedCoverUrl
+    val actualCoverUrl = resolvedCoverUrl ?: visualCoverUrl
     val currentCoverUrl = visualCoverUrl ?: actualCoverUrl
+    val coverSongKey = playbackSongKey ?: currentSong?.stableKey()
     val coverPreviewOnTapEnabled = shouldOpenNowPlayingCoverPreviewOnTap(currentSong)
     val coverPreviewOnLongPressEnabled =
         shouldOpenNowPlayingCoverPreviewOnLongPress(currentSong)
@@ -3017,6 +3022,7 @@ fun NowPlayingScreen(
                             ) {
                                 StableNowPlayingCoverImage(
                                     coverUrl = currentCoverUrl,
+                                    songKey = coverSongKey,
                                     context = context,
                                     coverRequestSizePx = coverRequestSizePx,
                                     offlineMode = offlineMode,

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
@@ -389,8 +389,13 @@ private fun StableNowPlayingCoverImage(
     }
 
     Box(modifier = modifier) {
+        val targetDisplayedCoverUrl = if (requestedCoverUrl == null) {
+            null
+        } else {
+            displayedCoverUrl
+        }
         Crossfade(
-            targetState = displayedCoverUrl,
+            targetState = targetDisplayedCoverUrl,
             animationSpec = tween(durationMillis = NowPlayingCoverImageCrossfadeMs),
             label = "NowPlayingCoverImage"
         ) { displayedCover ->

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
@@ -353,6 +353,109 @@ private val PlaybackActionToolbarSmallSlotThreshold = 40.dp
 private val NowPlayingMainControlsMinimumSpacing = 4.dp
 private val LyricOffsetStepMsFloat = LYRIC_DEFAULT_OFFSET_STEP_MS.toFloat()
 
+internal fun resolveDisplayedNowPlayingCoverUrl(
+    requestedCoverUrl: String?,
+    displayedCoverUrl: String?,
+    requestSucceeded: Boolean
+): String? {
+    val requested = requestedCoverUrl?.trim()?.takeIf { it.isNotEmpty() }
+    val displayed = displayedCoverUrl?.trim()?.takeIf { it.isNotEmpty() }
+    return when {
+        requested == null -> null
+        requested == displayed || requestSucceeded -> requested
+        else -> displayed
+    }
+}
+
+@Composable
+private fun StableNowPlayingCoverImage(
+    coverUrl: String?,
+    context: Context,
+    coverRequestSizePx: Int,
+    offlineMode: Boolean,
+    contentDescription: String?,
+    modifier: Modifier = Modifier
+) {
+    val requestedCoverUrl = coverUrl?.trim()?.takeIf { it.isNotEmpty() }
+    var displayedCoverUrl by remember { mutableStateOf<String?>(null) }
+    val latestRequestedCoverUrl by rememberUpdatedState(requestedCoverUrl)
+
+    LaunchedEffect(requestedCoverUrl) {
+        if (requestedCoverUrl == null) {
+            displayedCoverUrl = null
+        } else if (displayedCoverUrl == requestedCoverUrl) {
+            displayedCoverUrl = requestedCoverUrl
+        }
+    }
+
+    Box(modifier = modifier) {
+        Crossfade(
+            targetState = displayedCoverUrl,
+            animationSpec = tween(durationMillis = NowPlayingCoverImageCrossfadeMs),
+            label = "NowPlayingCoverImage"
+        ) { displayedCover ->
+            if (displayedCover.isNullOrBlank()) {
+                Box(modifier = Modifier.fillMaxSize())
+            } else {
+                AsyncImage(
+                    model = remember(
+                        context,
+                        displayedCover,
+                        coverRequestSizePx,
+                        offlineMode
+                    ) {
+                        offlineCachedImageRequest(
+                            context = context,
+                            data = displayedCover,
+                            sizePx = coverRequestSizePx,
+                            allowHardware = false,
+                            crossfade = false,
+                            offlineMode = offlineMode
+                        )
+                    },
+                    contentDescription = contentDescription,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+
+        if (requestedCoverUrl != null && requestedCoverUrl != displayedCoverUrl) {
+            AsyncImage(
+                model = remember(
+                    context,
+                    requestedCoverUrl,
+                    coverRequestSizePx,
+                    offlineMode
+                ) {
+                    offlineCachedImageRequest(
+                        context = context,
+                        data = requestedCoverUrl,
+                        sizePx = coverRequestSizePx,
+                        allowHardware = false,
+                        crossfade = false,
+                        offlineMode = offlineMode
+                    )
+                },
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer { alpha = 0f },
+                onSuccess = {
+                    if (latestRequestedCoverUrl == requestedCoverUrl) {
+                        displayedCoverUrl = resolveDisplayedNowPlayingCoverUrl(
+                            requestedCoverUrl = requestedCoverUrl,
+                            displayedCoverUrl = displayedCoverUrl,
+                            requestSucceeded = true
+                        )
+                    }
+                }
+            )
+        }
+    }
+}
+
 internal enum class NowPlayingWideLyricsMode {
     NO_LYRICS,
     ADVANCED,
@@ -2907,33 +3010,16 @@ fun NowPlayingScreen(
                                         }
                                     )
                             ) {
-                                Crossfade(
-                                    targetState = currentCoverUrl,
-                                    animationSpec = tween(
-                                        durationMillis = NowPlayingCoverImageCrossfadeMs
-                                    ),
-                                    label = "NowPlayingCoverImage"
-                                ) { cover ->
-                                    if (cover.isNullOrBlank()) {
-                                        Box(modifier = Modifier.fillMaxSize())
-                                        return@Crossfade
-                                    }
-                                    AsyncImage(
-                                        model = remember(context, cover, coverRequestSizePx, offlineMode) {
-                                            offlineCachedImageRequest(
-                                                context = context,
-                                                data = cover,
-                                                sizePx = coverRequestSizePx,
-                                                allowHardware = false,
-                                                crossfade = false,
-                                                offlineMode = offlineMode
-                                            )
-                                        },
-                                        contentDescription = currentSong?.customName ?: currentSong?.name ?: "",
-                                        contentScale = ContentScale.Crop,
-                                        modifier = Modifier.fillMaxSize()
-                                    )
-                                }
+                                StableNowPlayingCoverImage(
+                                    coverUrl = currentCoverUrl,
+                                    context = context,
+                                    coverRequestSizePx = coverRequestSizePx,
+                                    offlineMode = offlineMode,
+                                    contentDescription = currentSong?.customName
+                                        ?: currentSong?.name
+                                        ?: "",
+                                    modifier = Modifier.fillMaxSize()
+                                )
                             }
 
                             val coverPageSourceBadgeScale by animateFloatAsState(

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
@@ -37,6 +37,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalSharedTransitionApi
@@ -323,6 +324,7 @@ import moe.ouom.neriplayer.util.format.formatDuration
 import moe.ouom.neriplayer.util.media.offlineCachedImageRequest
 import moe.ouom.neriplayer.ui.haptic.performHapticFeedback
 import moe.ouom.neriplayer.util.media.saveCoverToPictures
+import moe.ouom.neriplayer.ui.util.rememberSongDisplayCoverUrl
 import org.burnoutcrew.reorderable.ItemPosition
 import org.burnoutcrew.reorderable.ReorderableItem
 import org.burnoutcrew.reorderable.SpringDragCancelledAnimation
@@ -336,6 +338,7 @@ private const val LyricsPageTransitionDurationMs = 300
 private const val CoverSourceBadgeRevealBufferMs = 120
 private const val CoverSourceBadgeRevealDelayMs =
     LyricsPageTransitionDurationMs + CoverSourceBadgeRevealBufferMs
+private const val NowPlayingCoverImageCrossfadeMs = 220
 private const val QueueSheetMaxHeightFraction = 0.9f
 internal val NowPlayingQueueReorderAutoScrollMaxPerFrame = 2.dp
 private val QueueReorderDragCancelStiffness = Spring.StiffnessMediumLow
@@ -1665,6 +1668,8 @@ fun NowPlayingScreen(
     showLyricTranslation: Boolean = true,
     showNowPlayingTitle: Boolean = true,
     offlineMode: Boolean = false,
+    resolvedCoverUrl: String? = null,
+    visualCoverUrl: String? = null,
 ) {
     val coverLyricFontScale = lyricFontScales.coverLyric
     val coverTranslationFontScale = lyricFontScales.coverTranslation
@@ -1769,9 +1774,9 @@ fun NowPlayingScreen(
     val context = LocalContext.current
     val composeResources = LocalResources.current
     val downloadPresenceVersion by GlobalDownloadManager.downloadPresenceVersion.collectAsStateWithLifecycle()
-    val currentCoverUrl = remember(currentSong, context, downloadPresenceVersion) {
-        currentSong?.displayCoverUrl(context)
-    }
+    val rememberedCoverUrl = rememberSongDisplayCoverUrl(currentSong)
+    val actualCoverUrl = resolvedCoverUrl ?: rememberedCoverUrl
+    val currentCoverUrl = visualCoverUrl ?: actualCoverUrl
     val coverPreviewOnTapEnabled = shouldOpenNowPlayingCoverPreviewOnTap(currentSong)
     val coverPreviewOnLongPressEnabled =
         shouldOpenNowPlayingCoverPreviewOnLongPress(currentSong)
@@ -1825,7 +1830,7 @@ fun NowPlayingScreen(
 
     val downloadCurrentCover: () -> Unit = {
         val song = currentSong
-        if (song == null || currentCoverUrl.isNullOrBlank()) {
+        if (song == null || actualCoverUrl.isNullOrBlank()) {
             screenScope.launch {
                 snackbarHostState.showNeriSnackbar(
                     composeResources.getString(R.string.cover_download_unavailable)
@@ -1835,7 +1840,7 @@ fun NowPlayingScreen(
             screenScope.launch {
                 saveCoverToPictures(
                     context = context,
-                    imageUrl = currentCoverUrl,
+                    imageUrl = actualCoverUrl,
                     suggestedName = "${song.displayArtist()} - ${song.displayName()} 封面"
                 ).onSuccess { fileName ->
                     snackbarHostState.showNeriSnackbar(
@@ -2071,22 +2076,23 @@ fun NowPlayingScreen(
     ) {
         val song = currentSong
         val loadedLyricsState = withContext(Dispatchers.IO) {
-            val localDetails = if (song?.isLocalSong() == true) {
-                runCatching { LocalMediaSupport.inspect(context, song) }
+            val isLocalSong = song?.isLocalSong() == true
+            val localLyrics = if (isLocalSong) {
+                runCatching { LocalMediaSupport.inspectLyricsFast(song) }
                     .onFailure { error ->
                         NPLogger.w(
                             "NowPlayingLyrics",
-                            "本地歌词旁车读取失败: ${error.message}"
+                            "本地歌词快速读取失败: ${error.message}"
                         )
                     }
                     .getOrNull()
             } else {
                 null
             }
-            val localRawLyrics = localDetails?.lyricContent
-            val localRawTranslatedLyrics = localDetails?.translatedLyricContent
-            val localRawPhoneticLyrics = localDetails?.romanizedLyricContent
-            val downloadedRawLyrics = song?.let { downloadedSong ->
+            val localRawLyrics = localLyrics?.lyric
+            val localRawTranslatedLyrics = localLyrics?.translatedLyric
+            val localRawPhoneticLyrics = localLyrics?.romanizedLyric
+            val downloadedRawLyrics = song?.takeUnless { it.isLocalSong() }?.let { downloadedSong ->
                 runCatching {
                     AudioDownloadManager.getLyricContent(context, downloadedSong)
                 }.onFailure { error ->
@@ -2096,7 +2102,8 @@ fun NowPlayingScreen(
                     )
                 }.getOrNull()
             }
-            val downloadedRawTranslatedLyrics = song?.let { downloadedSong ->
+            val downloadedRawTranslatedLyrics =
+                song?.takeUnless { it.isLocalSong() }?.let { downloadedSong ->
                 runCatching {
                     AudioDownloadManager.getTranslatedLyricContent(context, downloadedSong)
                 }.onFailure { error ->
@@ -2106,7 +2113,8 @@ fun NowPlayingScreen(
                     )
                 }.getOrNull()
             }
-            val downloadedRawPhoneticLyrics = song?.let { downloadedSong ->
+            val downloadedRawPhoneticLyrics =
+                song?.takeUnless { it.isLocalSong() }?.let { downloadedSong ->
                 runCatching {
                     AudioDownloadManager.getRomanizedLyricContent(context, downloadedSong)
                 }.onFailure { error ->
@@ -2127,6 +2135,7 @@ fun NowPlayingScreen(
             val preferredSongId = resolvePreferredNeteaseLyricSongId(song)
             val preferredNeteaseLyric = runCatching {
                 if (
+                    !isLocalSong &&
                     localRawLyrics == null &&
                     storedRawLyrics == null &&
                     downloadedRawLyrics == null &&
@@ -2139,6 +2148,7 @@ fun NowPlayingScreen(
             }.getOrNull().orEmpty()
             val rawNeteasePhoneticLyric = runCatching {
                 if (
+                    !isLocalSong &&
                     localRawPhoneticLyrics == null &&
                     downloadedRawPhoneticLyrics == null &&
                     preferredSongId != null
@@ -2178,6 +2188,12 @@ fun NowPlayingScreen(
             val resolvedLyrics = when {
                 localRawLyrics != null && song != null -> {
                     PlayerManager.getLyrics(song)
+                }
+                isLocalSong && !effectiveRawLyrics.isNullOrBlank() -> {
+                    parseNeteaseLyricsAuto(effectiveRawLyrics)
+                }
+                isLocalSong -> {
+                    emptyList()
                 }
                 bypassStoredRawLyrics && song != null -> {
                     PlayerManager.getLyrics(song)
@@ -2224,6 +2240,9 @@ fun NowPlayingScreen(
                             parseNeteaseLyricsAuto(effectiveRawTranslatedLyrics)
                         }
                     }
+                    isLocalSong -> {
+                        emptyList()
+                    }
                     song != null -> {
                         PlayerManager.getTranslatedLyrics(song)
                     }
@@ -2242,6 +2261,9 @@ fun NowPlayingScreen(
                     }
                     rawNeteasePhoneticLyric.isNotBlank() -> {
                         parseNeteaseLyricsAuto(rawNeteasePhoneticLyric)
+                    }
+                    isLocalSong -> {
+                        emptyList()
                     }
                     song != null -> {
                         PlayerManager.getRomanizedLyrics(song)
@@ -2445,7 +2467,7 @@ fun NowPlayingScreen(
         }
     }
 
-    val previewCoverUrl = currentCoverUrl
+    val previewCoverUrl = actualCoverUrl
     if (showCoverPreview && !previewCoverUrl.isNullOrBlank()) {
         NowPlayingCoverPreviewDialog(
             coverUrl = previewCoverUrl,
@@ -2849,7 +2871,7 @@ fun NowPlayingScreen(
                                             Modifier.combinedClickable(
                                                 onClick = {
                                                     if (coverPreviewOnTapEnabled) {
-                                                        if (currentCoverUrl.isNullOrBlank()) {
+                                                        if (actualCoverUrl.isNullOrBlank()) {
                                                             screenScope.launch {
                                                                 snackbarHostState.showNeriSnackbar(
                                                                     composeResources.getString(
@@ -2864,7 +2886,7 @@ fun NowPlayingScreen(
                                                 },
                                                 onLongClick = {
                                                     if (coverPreviewOnLongPressEnabled) {
-                                                        if (currentCoverUrl.isNullOrBlank()) {
+                                                        if (actualCoverUrl.isNullOrBlank()) {
                                                             screenScope.launch {
                                                                 snackbarHostState.showNeriSnackbar(
                                                                     composeResources.getString(
@@ -2883,7 +2905,17 @@ fun NowPlayingScreen(
                                         }
                                     )
                             ) {
-                                currentCoverUrl?.let { cover ->
+                                Crossfade(
+                                    targetState = currentCoverUrl,
+                                    animationSpec = tween(
+                                        durationMillis = NowPlayingCoverImageCrossfadeMs
+                                    ),
+                                    label = "NowPlayingCoverImage"
+                                ) { cover ->
+                                    if (cover.isNullOrBlank()) {
+                                        Box(modifier = Modifier.fillMaxSize())
+                                        return@Crossfade
+                                    }
                                     AsyncImage(
                                         model = remember(context, cover, coverRequestSizePx, offlineMode) {
                                             offlineCachedImageRequest(
@@ -2891,6 +2923,7 @@ fun NowPlayingScreen(
                                                 data = cover,
                                                 sizePx = coverRequestSizePx,
                                                 allowHardware = false,
+                                                crossfade = false,
                                                 offlineMode = offlineMode
                                             )
                                         },
@@ -4752,20 +4785,21 @@ fun EditSongInfoSheet(
                     coroutineScope.launch {
                         try {
                             val loadedLyricsResult: Pair<String, String> = withContext(Dispatchers.IO) {
-                                val localDetails = if (actualSong.isLocalSong()) {
-                                    runCatching { LocalMediaSupport.inspect(context, actualSong) }
+                                val isLocalSong = actualSong.isLocalSong()
+                                val localLyrics = if (isLocalSong) {
+                                    runCatching { LocalMediaSupport.inspectLyricsFast(actualSong) }
                                         .onFailure { error ->
                                             NPLogger.w(
                                                 "NowPlayingLyrics",
-                                                "编辑器读取本地歌词旁车失败: ${error.message}"
+                                                "编辑器读取本地歌词快速失败: ${error.message}"
                                             )
                                         }
                                         .getOrNull()
                                 } else {
                                     null
                                 }
-                                val localRawLyrics = localDetails?.lyricContent
-                                val localRawTranslatedLyrics = localDetails?.translatedLyricContent
+                                val localRawLyrics = localLyrics?.lyric
+                                val localRawTranslatedLyrics = localLyrics?.translatedLyric
                                 val storedRawLyrics = resolveStoredLyricText(
                                     currentLyric = actualSong.matchedLyric,
                                     legacyLyric = actualSong.originalLyric
@@ -4774,22 +4808,36 @@ fun EditSongInfoSheet(
                                     currentLyric = actualSong.matchedTranslatedLyric,
                                     legacyLyric = actualSong.originalTranslatedLyric
                                 )
-                                val downloadedRawLyrics = runCatching {
-                                    AudioDownloadManager.getLyricContent(context, actualSong)
-                                }.onFailure { error ->
-                                    NPLogger.w(
-                                        "NowPlayingLyrics",
-                                        "编辑器读取下载原文歌词失败: ${error.message}"
-                                    )
-                                }.getOrNull()
-                                val downloadedRawTranslatedLyrics = runCatching {
-                                    AudioDownloadManager.getTranslatedLyricContent(context, actualSong)
-                                }.onFailure { error ->
-                                    NPLogger.w(
-                                        "NowPlayingLyrics",
-                                        "编辑器读取下载翻译歌词失败: ${error.message}"
-                                    )
-                                }.getOrNull()
+                                val downloadedRawLyrics = actualSong
+                                    .takeUnless { isLocalSong }
+                                    ?.let { downloadedSong ->
+                                        runCatching {
+                                            AudioDownloadManager.getLyricContent(
+                                                context,
+                                                downloadedSong
+                                            )
+                                        }.onFailure { error ->
+                                            NPLogger.w(
+                                                "NowPlayingLyrics",
+                                                "编辑器读取下载原文歌词失败: ${error.message}"
+                                            )
+                                        }.getOrNull()
+                                    }
+                                val downloadedRawTranslatedLyrics = actualSong
+                                    .takeUnless { isLocalSong }
+                                    ?.let { downloadedSong ->
+                                        runCatching {
+                                            AudioDownloadManager.getTranslatedLyricContent(
+                                                context,
+                                                downloadedSong
+                                            )
+                                        }.onFailure { error ->
+                                            NPLogger.w(
+                                                "NowPlayingLyrics",
+                                                "编辑器读取下载翻译歌词失败: ${error.message}"
+                                            )
+                                        }.getOrNull()
+                                    }
                                 val selectedRawLyrics = resolveLocalFirstLyricText(
                                     localLyric = localRawLyrics,
                                     storedLyric = storedRawLyrics,
@@ -4802,7 +4850,11 @@ fun EditSongInfoSheet(
                                 )
                                 val rawNeteaseLyric = runCatching {
                                     val preferredSongId = resolvePreferredNeteaseLyricSongId(actualSong)
-                                    if (selectedRawLyrics == null && preferredSongId != null) {
+                                    if (
+                                        !isLocalSong &&
+                                        selectedRawLyrics == null &&
+                                        preferredSongId != null
+                                    ) {
                                         PlayerManager.getPreferredNeteaseLyricContent(preferredSongId)
                                     } else {
                                         null
@@ -4811,14 +4863,14 @@ fun EditSongInfoSheet(
                                 val displayedLyricsText = displayedLyricsSnapshot.toEditableLyricsText()
 
                                 // 把歌词准备挪到后台, 避免打开编辑器时把主线程卡住
-                                val fallbackLyricsText = run {
-                                    val lyricEntries = PlayerManager.getLyrics(actualSong)
-                                    if (lyricEntries.isNotEmpty()) {
-                                        lyricEntries.toEditableLyricsText()
-                                    } else {
-                                        null
+                                val fallbackLyricsText = actualSong
+                                    .takeUnless { isLocalSong }
+                                    ?.let {
+                                        val lyricEntries = PlayerManager.getLyrics(actualSong)
+                                        lyricEntries
+                                            .takeIf { it.isNotEmpty() }
+                                            ?.toEditableLyricsText()
                                     }
-                                }
                                 val lyrics = resolveLyricsEditorInitialText(
                                     matchedLyric = selectedRawLyrics,
                                     preferredNeteaseLyric = rawNeteaseLyric,
@@ -4833,6 +4885,8 @@ fun EditSongInfoSheet(
                                         val translatedEntries =
                                             if (displayedTranslatedLyricsSnapshot.isNotEmpty()) {
                                                 displayedTranslatedLyricsSnapshot
+                                            } else if (isLocalSong) {
+                                                emptyList()
                                             } else {
                                                 PlayerManager.getTranslatedLyrics(actualSong)
                                             }

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/SettingsScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/SettingsScreen.kt
@@ -638,6 +638,7 @@ fun SettingsScreen(
     var clearImageCache by remember { mutableStateOf(true) }
     var clearDownloadStagingCache by remember { mutableStateOf(false) }
     var clearSharedMediaCache by remember { mutableStateOf(false) }
+    var clearLyricsCache by remember { mutableStateOf(false) }
     var clearNeteasePlaylistCache by remember { mutableStateOf(false) }
     var clearBiliFavoriteCache by remember { mutableStateOf(false) }
     var clearBiliArchiveCache by remember { mutableStateOf(false) }
@@ -1992,6 +1993,8 @@ fun SettingsScreen(
                                 onClearDownloadStagingCacheChange = { clearDownloadStagingCache = it },
                                 clearSharedMediaCache = clearSharedMediaCache,
                                 onClearSharedMediaCacheChange = { clearSharedMediaCache = it },
+                                clearLyricsCache = clearLyricsCache,
+                                onClearLyricsCacheChange = { clearLyricsCache = it },
                                 clearNeteasePlaylistCache = clearNeteasePlaylistCache,
                                 onClearNeteasePlaylistCacheChange = { clearNeteasePlaylistCache = it },
                                 clearBiliFavoriteCache = clearBiliFavoriteCache,

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/SettingsStorageCacheSection.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/SettingsStorageCacheSection.kt
@@ -114,6 +114,8 @@ internal fun SettingsStorageCacheSection(
     onClearDownloadStagingCacheChange: (Boolean) -> Unit,
     clearSharedMediaCache: Boolean,
     onClearSharedMediaCacheChange: (Boolean) -> Unit,
+    clearLyricsCache: Boolean,
+    onClearLyricsCacheChange: (Boolean) -> Unit,
     clearNeteasePlaylistCache: Boolean,
     onClearNeteasePlaylistCacheChange: (Boolean) -> Unit,
     clearBiliFavoriteCache: Boolean,
@@ -504,6 +506,16 @@ internal fun SettingsStorageCacheSection(
                         onCheckedChange = onClearSharedMediaCacheChange
                     )
                     CacheTypeRow(
+                        checked = clearLyricsCache,
+                        title = stringResource(R.string.storage_type_lyrics_cache),
+                        description = cacheTypeDescription(
+                            storageDetails = storageDetails,
+                            kind = StorageCacheKind.Lyrics,
+                            fallback = stringResource(R.string.storage_desc_lyrics_cache)
+                        ),
+                        onCheckedChange = onClearLyricsCacheChange
+                    )
+                    CacheTypeRow(
                         checked = clearNeteasePlaylistCache,
                         title = stringResource(R.string.storage_type_netease_playlist_cache),
                         description = cacheTypeDescription(
@@ -571,6 +583,7 @@ internal fun SettingsStorageCacheSection(
                     imageCache = clearImageCache,
                     downloadStaging = clearDownloadStagingCache && downloadStagingClearEnabled,
                     sharedMedia = clearSharedMediaCache,
+                    lyricsCache = clearLyricsCache,
                     neteasePlaylistCache = clearNeteasePlaylistCache,
                     biliFavoriteCache = clearBiliFavoriteCache,
                     biliArchiveCache = clearBiliArchiveCache,

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/StorageCacheDetailsContent.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/settings/component/StorageCacheDetailsContent.kt
@@ -554,6 +554,7 @@ private fun StorageUsageItemKind.toStorageIcon(): ImageVector {
         StorageUsageItemKind.ImageCache -> Icons.Outlined.PictureInPictureAlt
         StorageUsageItemKind.DownloadStaging -> Icons.Outlined.CloudDownload
         StorageUsageItemKind.SharedMedia -> Icons.Outlined.Share
+        StorageUsageItemKind.LyricsCache -> Icons.Outlined.Subtitles
         StorageUsageItemKind.NeteasePlaylistCache -> Icons.Outlined.LibraryMusic
         StorageUsageItemKind.BiliFavoriteCache -> Icons.Outlined.Favorite
         StorageUsageItemKind.BiliArchiveCache -> Icons.Outlined.VideoLibrary

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1643,6 +1643,7 @@
     <string name="storage_type_image_cache">Image Cache</string>
     <string name="storage_type_download_staging">Download Staging</string>
     <string name="storage_type_shared_media">Share Staging</string>
+    <string name="storage_type_lyrics_cache">Online Lyrics Cache</string>
     <string name="storage_type_netease_playlist_cache">NetEase Playlist Cache</string>
     <string name="storage_type_bili_favorite_cache">Bilibili Favorites Cache</string>
     <string name="storage_type_bili_archive_cache">Bilibili Collection/Series Cache</string>
@@ -1664,6 +1665,7 @@
     <string name="storage_desc_image_cache">Covers, avatars, and blurred background images that can be loaded again</string>
     <string name="storage_desc_download_staging">Incomplete downloads, resume metadata, and HLS checkpoints</string>
     <string name="storage_desc_shared_media">Temporary copies created when sharing local music</string>
+    <string name="storage_desc_lyrics_cache">Local copies of online lyrics that can be checked for updates</string>
     <string name="storage_desc_netease_playlist_cache">Room cache for NetEase playlist details, apportioned by SQLite pages and safe to fetch again</string>
     <string name="storage_desc_bili_favorite_cache">Room cache for Bilibili favorite details, apportioned by SQLite pages and safe to fetch again</string>
     <string name="storage_desc_bili_archive_cache">Room cache for Bilibili collection and series details, apportioned by SQLite pages and safe to fetch again</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1643,6 +1643,7 @@
     <string name="storage_type_image_cache">图片缓存</string>
     <string name="storage_type_download_staging">下载暂存</string>
     <string name="storage_type_shared_media">分享暂存</string>
+    <string name="storage_type_lyrics_cache">在线歌词缓存</string>
     <string name="storage_type_netease_playlist_cache">网易云歌单缓存</string>
     <string name="storage_type_bili_favorite_cache">哔哩哔哩收藏夹缓存</string>
     <string name="storage_type_bili_archive_cache">哔哩哔哩合集/系列缓存</string>
@@ -1664,6 +1665,7 @@
     <string name="storage_desc_image_cache">封面、头像和模糊背景图缓存，可重新加载</string>
     <string name="storage_desc_download_staging">未完成下载、断点续传和 HLS 检查点</string>
     <string name="storage_desc_shared_media">分享本地音乐时临时复制出的文件</string>
+    <string name="storage_desc_lyrics_cache">在线歌词的本地副本，可重新从网络校验更新</string>
     <string name="storage_desc_netease_playlist_cache">网易云歌单详情的 Room 缓存，按 SQLite 页面分摊统计，清理后可重新获取</string>
     <string name="storage_desc_bili_favorite_cache">哔哩哔哩收藏夹详情的 Room 缓存，按 SQLite 页面分摊统计，清理后可重新获取</string>
     <string name="storage_desc_bili_archive_cache">哔哩哔哩合集和系列的 Room 缓存，按 SQLite 页面分摊统计，清理后可重新获取</string>

--- a/app/src/test/java/moe/ouom/neriplayer/core/api/youtube/YouTubeMusicPlaybackRepositoryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/api/youtube/YouTubeMusicPlaybackRepositoryTest.kt
@@ -4259,12 +4259,20 @@ class YouTubeMusicPlaybackRepositoryTest {
         assertNotNull(playableAudio)
         assertEquals("3", webRemixRequest.header("X-Goog-AuthUser"))
         assertTrue(webRemixRequest.header("Cookie").orEmpty().contains("refreshed-sap-value"))
+        val authorization = requireNotNull(webRemixRequest.header("Authorization"))
+        val authorizationEpochSeconds = Regex("^SAPISIDHASH (\\d+)_")
+            .find(authorization)
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.toLongOrNull()
+        assertNotNull(authorizationEpochSeconds)
         assertEquals(
             refreshedAuth.resolveAuthorizationHeader(
                 origin = YOUTUBE_MUSIC_ORIGIN,
+                nowEpochSeconds = authorizationEpochSeconds!!,
                 userSessionId = "user-session-123"
             ),
-            webRemixRequest.header("Authorization")
+            authorization
         )
     }
 

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProviderTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProviderTest.kt
@@ -1,6 +1,9 @@
 package moe.ouom.neriplayer.core.player.metadata
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import moe.ouom.neriplayer.core.api.lyrics.EditableLyricMatchCandidate
 import moe.ouom.neriplayer.core.api.lyrics.EditableLyricMatchConfidence
 import moe.ouom.neriplayer.core.api.lyrics.EditableLyricMatchRequest
@@ -19,6 +22,19 @@ import org.junit.Test
 import java.io.IOException
 
 class PlayerLyricsProviderTest {
+    private class TestLyricsCache : PlayerLyricsProvider.NeteaseLyricsCacheStore {
+        private val values = mutableMapOf<Long, NeteaseLyricsCacheEntry>()
+
+        override fun get(songId: Long): NeteaseLyricsCacheEntry? = values[songId]
+
+        override fun put(songId: Long, entry: NeteaseLyricsCacheEntry) {
+            values[songId] = entry
+        }
+
+        fun clear() {
+            values.clear()
+        }
+    }
 
     @Test
     fun `resolveLocalLyricOverrideState keeps blank local override as cleared`() {
@@ -242,6 +258,56 @@ class PlayerLyricsProviderTest {
         assertEquals("hard to forget", entry.translatedLyricEntries.single().text)
         assertEquals("[00:12.58]na n yi wang ji", entry.romanizedLyricText)
         assertEquals("na n yi wang ji", entry.romanizedLyricEntries.single().text)
+    }
+
+    @Test
+    fun `cold NetEase lyric loads are deduplicated per song`() = runTest {
+        val cache = TestLyricsCache()
+        val releaseLoader = CompletableDeferred<Unit>()
+        var loadCount = 0
+        val loader: suspend (Long) -> String = {
+            loadCount += 1
+            releaseLoader.await()
+            """{"lrc":{"lyric":"[00:01.00]line"}}"""
+        }
+
+        val first = async {
+            PlayerLyricsProvider.getOrLoadNeteaseLyricsCacheEntry(11L, cache, loader)
+        }
+        val second = async {
+            PlayerLyricsProvider.getOrLoadNeteaseLyricsCacheEntry(11L, cache, loader)
+        }
+        yield()
+
+        assertEquals(1, loadCount)
+        releaseLoader.complete(Unit)
+        val firstEntry = first.await()
+        assertNotNull(cache.get(11L))
+        assertEquals(firstEntry, second.await())
+        assertEquals(1, loadCount)
+    }
+
+    @Test
+    fun `cold NetEase lyric load does not repopulate cache after clearing`() = runTest {
+        val cache = TestLyricsCache()
+        val loaderStarted = CompletableDeferred<Unit>()
+        val releaseLoader = CompletableDeferred<Unit>()
+        val loader: suspend (Long) -> String = {
+            loaderStarted.complete(Unit)
+            releaseLoader.await()
+            """{"lrc":{"lyric":"[00:01.00]line"}}"""
+        }
+
+        val request = async {
+            PlayerLyricsProvider.getOrLoadNeteaseLyricsCacheEntry(12L, cache, loader)
+        }
+        loaderStarted.await()
+        cache.clear()
+        PlayerLyricsProvider.clearLyricsCaches()
+        releaseLoader.complete(Unit)
+        request.await()
+
+        assertNull(cache.get(12L))
     }
 
     @Test

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProviderTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/metadata/PlayerLyricsProviderTest.kt
@@ -2,6 +2,7 @@ package moe.ouom.neriplayer.core.player.metadata
 
 import moe.ouom.neriplayer.core.api.lyrics.EditableLyricMatchCandidate
 import moe.ouom.neriplayer.core.api.lyrics.EditableLyricMatchSource
+import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.ui.component.lyrics.LyricEntry
 import moe.ouom.neriplayer.ui.component.lyrics.parseNeteaseLyricsAuto
 import moe.ouom.neriplayer.util.network.isTransientHttp2StreamReset
@@ -57,6 +58,38 @@ class PlayerLyricsProviderTest {
                 downloadedLyric = "[00:01.00]downloaded"
             )
         )
+    }
+
+    @Test
+    fun `local songs never load remote lyrics`() {
+        val song = SongItem(
+            id = 1L,
+            name = "Local",
+            artist = "Artist",
+            album = "Local Files",
+            albumId = 0L,
+            durationMs = 180_000L,
+            coverUrl = null,
+            mediaUri = "/tmp/local.mp3"
+        )
+
+        assertFalse(shouldLoadRemoteLyrics(song))
+    }
+
+    @Test
+    fun `remote songs keep remote lyric loading enabled`() {
+        val song = SongItem(
+            id = 2L,
+            name = "Remote",
+            artist = "Artist",
+            album = "Album",
+            albumId = 1L,
+            durationMs = 180_000L,
+            coverUrl = null,
+            mediaUri = "https://example.com/audio.mp3"
+        )
+
+        assertTrue(shouldLoadRemoteLyrics(song))
     }
 
     @Test

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
@@ -397,6 +397,30 @@ class LocalAudioImportManagerTest {
     }
 
     @Test
+    fun `mergeImportedSongMetadata adopts cover discovered after a coverless quick scan`() {
+        val quickSong = LocalAudioImportManager.buildQuickImportedSong(
+            seed = QuickImportedSongSeed(
+                sourceRef = "content://tree/music/document/demo.flac",
+                displayName = "demo.flac",
+                title = "Demo",
+                artist = "Artist",
+                album = null,
+                durationMs = 180_000L
+            ),
+            unknownArtistLabel = "Unknown Artist"
+        )
+        val detailedSong = quickSong.copy(
+            coverUrl = "file:///data/local_audio_covers/demo.jpg",
+            originalCoverUrl = "file:///data/local_audio_covers/demo.jpg"
+        )
+
+        val merged = LocalAudioImportManager.mergeImportedSongMetadata(quickSong, detailedSong)
+
+        assertEquals("file:///data/local_audio_covers/demo.jpg", merged.coverUrl)
+        assertEquals("file:///data/local_audio_covers/demo.jpg", merged.originalCoverUrl)
+    }
+
+    @Test
     fun `mergeImportedSongMetadata adopts resolved local path when quick scan only had content uri`() {
         val resolvedFile = tempFolder.newFile("resolved_demo.mp3")
         val quickSong = LocalAudioImportManager.buildQuickImportedSong(

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/audioimport/LocalAudioImportManagerTest.kt
@@ -374,6 +374,29 @@ class LocalAudioImportManagerTest {
     }
 
     @Test
+    fun `mergeImportedSongMetadata keeps quick cover stable during background hydration`() {
+        val quickSong = LocalAudioImportManager.buildQuickImportedSong(
+            seed = QuickImportedSongSeed(
+                sourceRef = "/music/demo.flac",
+                displayName = "demo.flac",
+                title = "Demo",
+                artist = "Artist",
+                album = "Album",
+                durationMs = 180_000L,
+                nearbyCoverUri = "file:///music/demo.jpg"
+            ),
+            unknownArtistLabel = "Unknown Artist"
+        )
+        val detailedSong = quickSong.copy(
+            coverUrl = "file:///data/local_audio_covers/embedded.jpg"
+        )
+
+        val merged = LocalAudioImportManager.mergeImportedSongMetadata(quickSong, detailedSong)
+
+        assertEquals("file:///music/demo.jpg", merged.coverUrl)
+    }
+
+    @Test
     fun `mergeImportedSongMetadata adopts resolved local path when quick scan only had content uri`() {
         val resolvedFile = tempFolder.newFile("resolved_demo.mp3")
         val quickSong = LocalAudioImportManager.buildQuickImportedSong(

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
@@ -169,6 +169,36 @@ class LocalMediaSupportTest {
     }
 
     @Test
+    fun `fast lyric inspection reads direct file sidecars without content resolver`() {
+        val sourceDir = tempFolder.newFolder("fast-lyrics")
+        val audioFile = File(sourceDir, "song.flac").apply { writeText("audio") }
+        File(sourceDir, "song.lrc").writeText("[00:01.00]local")
+        val song = SongItem(
+            id = 7L,
+            name = "Song",
+            artist = "Artist",
+            album = "Local Files",
+            albumId = 0L,
+            durationMs = 120_000L,
+            coverUrl = null,
+            mediaUri = audioFile.toURI().toString(),
+            localFileName = audioFile.name,
+            localFilePath = audioFile.absolutePath,
+            channelId = "local"
+        )
+
+        val nearby = LocalMediaSupport.findNearbyLyricFiles(audioFile)
+        assertEquals(
+            File(sourceDir, "song.lrc").canonicalPath,
+            nearby.original?.canonicalPath
+        )
+        assertEquals("[00:01.00]local", LocalMediaSupport.readTextFile(nearby.original!!))
+        val lyrics = LocalMediaSupport.inspectLyricsFast(song)
+
+        assertEquals("[00:01.00]local", lyrics.lyric)
+    }
+
+    @Test
     fun `findNearbyLyricFiles keeps lrc txt compatibility for translated sidecars`() {
         val sourceDir = tempFolder.newFolder("nearby-lyrics-lrc-txt")
         val audioFile = File(sourceDir, "song.flac").apply { writeText("audio") }

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
@@ -199,6 +199,34 @@ class LocalMediaSupportTest {
     }
 
     @Test
+    fun `fast lyric inspection keeps stored text and fills missing sidecar variants`() {
+        val sourceDir = tempFolder.newFolder("fast-lyrics-variants")
+        val audioFile = File(sourceDir, "song.flac").apply { writeText("audio") }
+        File(sourceDir, "song_trans.lrc").writeText("[00:02.00]translated")
+        File(sourceDir, "song_roma.lrc").writeText("[00:03.00]romanized")
+        val song = SongItem(
+            id = 8L,
+            name = "Song",
+            artist = "Artist",
+            album = "Local Files",
+            albumId = 0L,
+            durationMs = 120_000L,
+            coverUrl = null,
+            mediaUri = audioFile.toURI().toString(),
+            localFileName = audioFile.name,
+            localFilePath = audioFile.absolutePath,
+            matchedLyric = "[00:01.00]stored",
+            channelId = "local"
+        )
+
+        val lyrics = LocalMediaSupport.inspectLyricsFast(song)
+
+        assertEquals("[00:01.00]stored", lyrics.lyric)
+        assertEquals("[00:02.00]translated", lyrics.translatedLyric)
+        assertEquals("[00:03.00]romanized", lyrics.romanizedLyric)
+    }
+
+    @Test
     fun `findNearbyLyricFiles keeps lrc txt compatibility for translated sidecars`() {
         val sourceDir = tempFolder.newFolder("nearby-lyrics-lrc-txt")
         val audioFile = File(sourceDir, "song.flac").apply { writeText("audio") }

--- a/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/local/media/LocalMediaSupportTest.kt
@@ -169,6 +169,20 @@ class LocalMediaSupportTest {
     }
 
     @Test
+    fun `findNearbyCover retries when artwork appears after an empty lookup`() {
+        val sourceDir = tempFolder.newFolder("nearby-cover-retry")
+        val audioFile = File(sourceDir, "song.flac").apply { writeText("audio") }
+        val originalDirectoryModified = sourceDir.lastModified()
+
+        assertNull(LocalMediaSupport.findNearbyCover(audioFile))
+
+        val coverFile = File(sourceDir, "song.jpg").apply { writeText("cover") }
+        sourceDir.setLastModified(originalDirectoryModified)
+
+        assertEquals(coverFile.canonicalPath, LocalMediaSupport.findNearbyCover(audioFile)?.canonicalPath)
+    }
+
+    @Test
     fun `fast lyric inspection reads direct file sidecars without content resolver`() {
         val sourceDir = tempFolder.newFolder("fast-lyrics")
         val audioFile = File(sourceDir, "song.flac").apply { writeText("audio") }

--- a/app/src/test/java/moe/ouom/neriplayer/ui/NeriAppPlaybackTransitionPolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/NeriAppPlaybackTransitionPolicyTest.kt
@@ -64,6 +64,19 @@ class NeriAppPlaybackTransitionPolicyTest {
     }
 
     @Test
+    fun `local playback keeps previous visual cover while its cover resolves`() {
+        assertEquals(
+            "remote-cover",
+            resolvePlaybackVisualCoverUrl(
+                currentCoverUrl = null,
+                previousVisualCoverUrl = "remote-cover",
+                hasCurrentSong = true,
+                clearDelayElapsed = false
+            )
+        )
+    }
+
+    @Test
     fun `visual cover clears after grace period or when playback stops`() {
         assertEquals(
             null,

--- a/app/src/test/java/moe/ouom/neriplayer/ui/NeriAppPlaybackTransitionPolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/NeriAppPlaybackTransitionPolicyTest.kt
@@ -1,5 +1,7 @@
 package moe.ouom.neriplayer.ui
 
+import moe.ouom.neriplayer.ui.component.playback.resolveMiniPlayerDisplayedCoverUrl
+import moe.ouom.neriplayer.ui.screen.resolveDisplayedNowPlayingCoverUrl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -107,6 +109,73 @@ class NeriAppPlaybackTransitionPolicyTest {
                 previousVisualCoverUrl = "old-cover",
                 hasCurrentSong = true,
                 clearDelayElapsed = false
+            )
+        )
+    }
+
+    @Test
+    fun `cover image keeps the displayed cover until the new request succeeds`() {
+        assertEquals(
+            "old-cover",
+            resolveDisplayedNowPlayingCoverUrl(
+                requestedCoverUrl = "new-cover",
+                displayedCoverUrl = "old-cover",
+                requestSucceeded = false
+            )
+        )
+        assertEquals(
+            "new-cover",
+            resolveDisplayedNowPlayingCoverUrl(
+                requestedCoverUrl = "new-cover",
+                displayedCoverUrl = "old-cover",
+                requestSucceeded = true
+            )
+        )
+    }
+
+    @Test
+    fun `cover image clears when the requested cover is absent`() {
+        assertNull(
+            resolveDisplayedNowPlayingCoverUrl(
+                requestedCoverUrl = "  ",
+                displayedCoverUrl = "old-cover",
+                requestSucceeded = false
+            )
+        )
+    }
+
+    @Test
+    fun `mini player keeps its cover while a newly resolved cover loads`() {
+        assertEquals(
+            "old-cover",
+            resolveMiniPlayerDisplayedCoverUrl(
+                requestedCoverUrl = "new-cover",
+                displayedCoverUrl = "old-cover",
+                requestSucceeded = false
+            )
+        )
+        assertEquals(
+            "new-cover",
+            resolveMiniPlayerDisplayedCoverUrl(
+                requestedCoverUrl = "new-cover",
+                displayedCoverUrl = "old-cover",
+                requestSucceeded = true
+            )
+        )
+        assertEquals(
+            "old-cover",
+            resolveMiniPlayerDisplayedCoverUrl(
+                requestedCoverUrl = null,
+                displayedCoverUrl = "old-cover",
+                requestSucceeded = false
+            )
+        )
+        assertNull(
+            resolveMiniPlayerDisplayedCoverUrl(
+                requestedCoverUrl = null,
+                displayedCoverUrl = "old-cover",
+                requestSucceeded = false,
+                clearDelayElapsed = true
             )
         )
     }

--- a/app/src/test/java/moe/ouom/neriplayer/ui/NeriAppPlaybackTransitionPolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/NeriAppPlaybackTransitionPolicyTest.kt
@@ -79,6 +79,19 @@ class NeriAppPlaybackTransitionPolicyTest {
     }
 
     @Test
+    fun `visual cover clears previous image when a new song cover is unresolved`() {
+        assertNull(
+            resolvePlaybackVisualCoverUrl(
+                currentCoverUrl = null,
+                previousVisualCoverUrl = "previous-song-cover",
+                hasCurrentSong = true,
+                clearDelayElapsed = false,
+                preservePreviousVisualCover = false
+            )
+        )
+    }
+
+    @Test
     fun `visual cover clears after grace period or when playback stops`() {
         assertEquals(
             null,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 用户可见变化

- 新增在线歌词持久化缓存，支持后台刷新、并发请求去重和缓存清理。
- 本地歌曲优先读取已有歌词及相邻歌词文件，不再触发在线歌词请求。
- 优化本地歌词检查，减少首屏读取开销。
- 存储设置新增在线歌词缓存的查看与清理选项。
- 优化本地歌曲封面显示，保留快速扫描结果并平滑切换封面。

## 兼容性影响

- `NowPlayingScreen` 新增可选参数，现有调用保持兼容。
- 本地歌曲缺少歌词文件时不再回退到在线歌词。
- 远程歌曲继续使用在线歌词加载。

## 测试

- 验证本地与远程歌曲的歌词加载策略。
- 验证本地 sidecar 歌词读取。
- 验证快速扫描阶段的封面保留。
- 验证本地播放解析封面期间继续显示上一张远程封面。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->