### PR TITLE
feat(playlist): implement persistent usage deletions and stabilize sync merging

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
@@ -179,6 +179,8 @@ class PlaylistUsageRepository internal constructor(
     private val mutationLock = Any()
     private val persistenceMutex = Mutex()
     private var persistenceGeneration = 0L
+    private val manuallyRemovedUsageKeys = mutableMapOf<String, Long>()
+    private var manuallyRemovedUsageKeysLoaded = false
     @Volatile
     private var roomStorageEnabled = roomStore != null
     private val initialEntries = load()
@@ -311,6 +313,7 @@ class PlaylistUsageRepository internal constructor(
         val out = synchronized(mutationLock) {
             val data = _flow.value.toMutableList()
             val targetKey = playlistUsageKey(source, id, subtype)
+            clearManualRemovalLocked(targetKey)
             val idx = data.indexOfFirst { it.usageKey() == targetKey }
             val updated = if (idx >= 0) {
                 data[idx].copy(
@@ -362,9 +365,18 @@ class PlaylistUsageRepository internal constructor(
 
     fun applyMergedStats(stats: List<SyncPlaylistUsageStat>) {
         val out = synchronized(mutationLock) {
+            val manualRemovals = manualRemovalTimestampsLocked()
+            val localStats = _flow.value
+                .filter { entry ->
+                    !isManuallyRemoved(entry.usageKey(), entry.lastOpened, manualRemovals)
+                }
+                .map(UsageEntry::toSyncPlaylistUsageStat)
+            val remoteStats = stats.filter { stat ->
+                !isManuallyRemoved(stat.playlistKey.trim(), stat.lastOpenedAt, manualRemovals)
+            }
             val merged = SyncPlaylistUsageStatsMergePolicy.mergePlaylistUsageStats(
-                local = _flow.value.map(UsageEntry::toSyncPlaylistUsageStat),
-                remote = stats
+                local = localStats,
+                remote = remoteStats
             )
             normalizeUsageEntries(merged.map(SyncPlaylistUsageStat::toUsageEntry))
                 .also { _flow.value = it }
@@ -396,6 +408,7 @@ class PlaylistUsageRepository internal constructor(
         val out = synchronized(mutationLock) {
             val data = _flow.value.toMutableList()
             val targetKey = playlistUsageKey(source, id, subtype)
+            clearManualRemovalLocked(targetKey)
             val idx = data.indexOfFirst { it.usageKey() == targetKey }
             if (idx >= 0) {
                 val old = data[idx]
@@ -546,7 +559,18 @@ class PlaylistUsageRepository internal constructor(
 
     /** 从继续播放列表中移除指定项 */
     fun removeEntry(id: Long, source: String, subtype: String? = null) {
-        removeEntryIfPresent(id, source, subtype)
+        val targetKey = playlistUsageKey(source, id, subtype)
+        val out = synchronized(mutationLock) {
+            rememberManualRemovalLocked(targetKey)
+            val data = _flow.value.toMutableList()
+            val removed = data.removeAll { it.usageKey() == targetKey }
+            if (!removed) {
+                return@synchronized null
+            }
+            normalizeUsageEntries(data).also { _flow.value = it }
+        }
+        out?.let(::saveAsync)
+        triggerSync()
     }
 
     private fun removeEntryIfPresent(id: Long, source: String, subtype: String? = null) {
@@ -563,6 +587,62 @@ class PlaylistUsageRepository internal constructor(
     private fun syncCounterDeviceId(): String {
         return runCatching { syncStorage.getOrCreateDeviceId() }
             .getOrDefault(fallbackCounterDeviceId)
+    }
+
+    private fun manualRemovalTimestampsLocked(): MutableMap<String, Long> {
+        if (!manuallyRemovedUsageKeysLoaded) {
+            val persisted = runCatching { syncStorage.getPlaylistUsageDeletions() }
+                .getOrDefault(emptyMap())
+            manuallyRemovedUsageKeys.putAll(persisted)
+            manuallyRemovedUsageKeysLoaded = true
+        }
+        return manuallyRemovedUsageKeys
+    }
+
+    private fun rememberManualRemovalLocked(
+        playlistKey: String,
+        deletedAt: Long = System.currentTimeMillis()
+    ) {
+        val removals = manualRemovalTimestampsLocked()
+        val normalizedTimestamp = deletedAt.coerceAtLeast(1L)
+        if (normalizedTimestamp <= (removals[playlistKey] ?: 0L)) {
+            return
+        }
+        removals[playlistKey] = normalizedTimestamp
+        runCatching {
+            syncStorage.addPlaylistUsageDeletion(playlistKey, normalizedTimestamp)
+        }.onFailure { error ->
+            NPLogger.w(
+                "PlaylistUsageRepo",
+                "Failed to persist manually removed playlist usage",
+                error
+            )
+        }
+    }
+
+    private fun clearManualRemovalLocked(playlistKey: String) {
+        val removals = manualRemovalTimestampsLocked()
+        if (removals.remove(playlistKey) == null) {
+            return
+        }
+        runCatching {
+            syncStorage.removePlaylistUsageDeletion(playlistKey)
+        }.onFailure { error ->
+            NPLogger.w(
+                "PlaylistUsageRepo",
+                "Failed to clear manually removed playlist usage",
+                error
+            )
+        }
+    }
+
+    private fun isManuallyRemoved(
+        playlistKey: String,
+        openedAt: Long,
+        removals: Map<String, Long>
+    ): Boolean {
+        val removedAt = removals[playlistKey] ?: return false
+        return openedAt <= removedAt
     }
 
     private fun triggerSync() {

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SecureTokenStorage.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SecureTokenStorage.kt
@@ -65,12 +65,14 @@ class SecureTokenStorage(private val context: Context) {
         private const val KEY_DELETED_PLAYLIST_IDS = "deleted_playlist_ids"
         private const val KEY_DELETED_PLAYLIST_TIMESTAMPS = "deleted_playlist_timestamps"
         private const val KEY_RECENT_PLAY_DELETIONS = "recent_play_deletions"
+        private const val KEY_PLAYLIST_USAGE_DELETIONS = "playlist_usage_deletions"
         private const val KEY_PLAYLIST_SONG_DELETIONS = "playlist_song_deletions"
         private const val KEY_TOKEN_WARNING_DISMISSED = "token_warning_dismissed"
         private const val KEY_DATA_SAVER_MODE = "data_saver_mode"
         private const val KEY_SYNC_MUTATION_VERSION = "sync_mutation_version"
         private const val KEY_SYNC_CAUSAL_COUNTER = "sync_causal_counter"
         private const val MAX_RECENT_PLAY_DELETIONS = 500
+        private const val MAX_PLAYLIST_USAGE_DELETIONS = 500
         private val syncMutationLock = Any()
         private val syncCausalTokenLock = Any()
     }
@@ -479,6 +481,51 @@ class SecureTokenStorage(private val context: Context) {
         }
     }
 
+    fun getPlaylistUsageDeletions(): Map<String, Long> {
+        return synchronized(syncMutationLock) {
+            val raw = encryptedPrefs.getString(KEY_PLAYLIST_USAGE_DELETIONS, null).orEmpty()
+            if (raw.isBlank()) {
+                return@synchronized emptyMap()
+            }
+            val parsed = runCatching {
+                val type = object : TypeToken<Map<String?, Long?>>() {}.type
+                gson.fromJson<Map<String?, Long?>>(raw, type).orEmpty()
+            }.getOrElse { emptyMap() }
+            val parsedWithNonNullKeys = parsed.mapNotNull { (key, value) ->
+                key?.let { it to value }
+            }.toMap()
+            runCatching { normalizePlaylistUsageDeletions(parsedWithNonNullKeys) }
+                .getOrDefault(emptyMap())
+        }
+    }
+
+    fun addPlaylistUsageDeletion(playlistKey: String, deletedAt: Long = System.currentTimeMillis()) {
+        val normalizedKey = playlistKey.trim()
+        if (normalizedKey.isEmpty()) {
+            return
+        }
+        synchronized(syncMutationLock) {
+            val current = getPlaylistUsageDeletions().toMutableMap()
+            val normalizedTimestamp = deletedAt.coerceAtLeast(1L)
+            current[normalizedKey] = maxOf(current[normalizedKey] ?: 0L, normalizedTimestamp)
+            persistPlaylistUsageDeletionsLocked(current, bumpVersion = true)
+        }
+    }
+
+    fun removePlaylistUsageDeletion(playlistKey: String, bumpVersion: Boolean = true) {
+        val normalizedKey = playlistKey.trim()
+        if (normalizedKey.isEmpty()) {
+            return
+        }
+        synchronized(syncMutationLock) {
+            val current = getPlaylistUsageDeletions().toMutableMap()
+            if (current.remove(normalizedKey) == null) {
+                return
+            }
+            persistPlaylistUsageDeletionsLocked(current, bumpVersion)
+        }
+    }
+
     fun getPlaylistSongDeletions(): List<SyncPlaylistSongDeletion> {
         return synchronized(syncMutationLock) {
             val raw = encryptedPrefs.getString(KEY_PLAYLIST_SONG_DELETIONS, null).orEmpty()
@@ -655,6 +702,25 @@ class SecureTokenStorage(private val context: Context) {
         ) { "Failed to persist playlist deletion state" }
     }
 
+    private fun persistPlaylistUsageDeletionsLocked(
+        deletions: Map<String, Long>,
+        bumpVersion: Boolean
+    ) {
+        val normalized = normalizePlaylistUsageDeletions(deletions)
+        check(
+            encryptedPrefs.commitEdit {
+                if (normalized.isEmpty()) {
+                    remove(KEY_PLAYLIST_USAGE_DELETIONS)
+                } else {
+                    putString(KEY_PLAYLIST_USAGE_DELETIONS, gson.toJson(normalized))
+                }
+                if (bumpVersion) {
+                    bumpSyncMutationVersion(this)
+                }
+            }
+        ) { "Failed to persist playlist usage deletion state" }
+    }
+
     fun snapshot(): GitHubSyncConfigSnapshot {
         return GitHubSyncConfigSnapshot(
             token = getToken().orEmpty(),
@@ -702,6 +768,27 @@ class SecureTokenStorage(private val context: Context) {
         deletions: List<SyncPlaylistSongDeletion>
     ): List<SyncPlaylistSongDeletion> {
         return SyncPlaylistDeletionPolicy.limitDeletions(deletions)
+    }
+
+    private fun normalizePlaylistUsageDeletions(
+        deletions: Map<String, Long?>
+    ): Map<String, Long> {
+        val normalized = mutableMapOf<String, Long>()
+        deletions.forEach { (key, timestamp) ->
+            val normalizedKey = key.trim()
+            if (normalizedKey.isNullOrEmpty() || timestamp == null) {
+                return@forEach
+            }
+            val normalizedTimestamp = timestamp.coerceAtLeast(1L)
+            normalized[normalizedKey] = maxOf(
+                normalized[normalizedKey] ?: 0L,
+                normalizedTimestamp
+            )
+        }
+        return normalized.entries
+            .sortedByDescending { it.value }
+            .take(MAX_PLAYLIST_USAGE_DELETIONS)
+            .associate { it.key to it.value }
     }
 }
 

--- a/app/src/test/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepositoryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepositoryTest.kt
@@ -12,6 +12,7 @@ import moe.ouom.neriplayer.data.local.playlist.system.FavoritesPlaylist
 import moe.ouom.neriplayer.data.local.playlist.system.LocalFilesPlaylist
 import moe.ouom.neriplayer.data.model.displayCoverUrl
 import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.sync.model.SyncPlaylistUsageStat
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -200,6 +201,63 @@ class PlaylistUsageRepositoryTest {
         assertEquals("已加载歌单", entry.name)
         assertEquals(8, entry.trackCount)
         assertEquals(200L, entry.lastOpened)
+    }
+
+    @Test
+    fun `manual removal stays hidden when stale usage stats are merged`() {
+        val repo = PlaylistUsageRepository(mockContext())
+
+        repo.recordOpen(
+            id = 42L,
+            name = "歌单",
+            picUrl = null,
+            trackCount = 3,
+            source = "netease",
+            now = 100L
+        )
+        repo.removeEntry(id = 42L, source = "netease")
+        repo.applyMergedStats(
+            listOf(
+                SyncPlaylistUsageStat(
+                    playlistKey = "netease:42",
+                    source = "netease",
+                    id = 42L,
+                    name = "歌单",
+                    trackCount = 3,
+                    lastOpenedAt = 100L,
+                    firstOpenedAt = 100L,
+                    openCount = 1
+                )
+            )
+        )
+
+        assertTrue(repo.frequentPlaylistsFlow.value.isEmpty())
+    }
+
+    @Test
+    fun `opening a manually removed playlist clears its hidden state`() {
+        val repo = PlaylistUsageRepository(mockContext())
+
+        repo.recordOpen(
+            id = 42L,
+            name = "歌单",
+            picUrl = null,
+            trackCount = 3,
+            source = "netease",
+            now = 100L
+        )
+        repo.removeEntry(id = 42L, source = "netease")
+        repo.recordOpen(
+            id = 42L,
+            name = "歌单",
+            picUrl = null,
+            trackCount = 3,
+            source = "netease",
+            now = 300L
+        )
+
+        assertEquals(1, repo.frequentPlaylistsFlow.value.size)
+        assertEquals(300L, repo.frequentPlaylistsFlow.value.single().lastOpened)
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 持久化歌单使用记录的手动删除状态，防止过期同步数据重新显示已删除记录。
- 重新打开或更新歌单后，清除对应删除状态并显示最新使用时间。
- 新增删除记录的安全存储、时间比较、规范化和最多 500 条限制。
- 新增测试，覆盖过期同步合并和重新打开已删除歌单的场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->