### PR TITLE
fix: improve local playlist cover resolution and persistence in "Continue" section

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepository.kt
@@ -318,7 +318,7 @@ class PlaylistUsageRepository internal constructor(
             val updated = if (idx >= 0) {
                 data[idx].copy(
                     name = name,
-                    picUrl = picUrl,
+                    picUrl = picUrl?.takeIf { it.isNotBlank() } ?: data[idx].picUrl,
                     trackCount = trackCount,
                     fid = fid,
                     mid = mid,
@@ -365,8 +365,9 @@ class PlaylistUsageRepository internal constructor(
 
     fun applyMergedStats(stats: List<SyncPlaylistUsageStat>) {
         val out = synchronized(mutationLock) {
+            val current = _flow.value
             val manualRemovals = manualRemovalTimestampsLocked()
-            val localStats = _flow.value
+            val localStats = current
                 .filter { entry ->
                     !isManuallyRemoved(entry.usageKey(), entry.lastOpened, manualRemovals)
                 }
@@ -378,7 +379,14 @@ class PlaylistUsageRepository internal constructor(
                 local = localStats,
                 remote = remoteStats
             )
-            normalizeUsageEntries(merged.map(SyncPlaylistUsageStat::toUsageEntry))
+            val previousByKey = current.associateBy(UsageEntry::usageKey)
+            val mergedEntries = merged.map(SyncPlaylistUsageStat::toUsageEntry).map { entry ->
+                val previousCover = previousByKey[entry.usageKey()]?.picUrl
+                    ?.takeIf { it.isNotBlank() }
+                val stableCover = entry.picUrl?.takeIf { it.isNotBlank() } ?: previousCover
+                if (stableCover == entry.picUrl) entry else entry.copy(picUrl = stableCover)
+            }
+            normalizeUsageEntries(mergedEntries)
                 .also { _flow.value = it }
         }
         saveAsync(out)
@@ -414,7 +422,7 @@ class PlaylistUsageRepository internal constructor(
                 val old = data[idx]
                 data[idx] = old.copy(
                     name = name,
-                    picUrl = picUrl,
+                    picUrl = picUrl?.takeIf { it.isNotBlank() } ?: old.picUrl,
                     trackCount = trackCount,
                     fid = fid,
                     mid = mid,
@@ -456,105 +464,111 @@ class PlaylistUsageRepository internal constructor(
         playlists: List<LocalPlaylist>,
         localFilesCoverCandidates: List<SongItem> = emptyList()
     ) {
-        val current = _flow.value
-        if (current.none { it.source == SOURCE_LOCAL }) return
-
-        val localizedContext = LanguageManager.applyLanguage(app)
-        val localPlaylistLookup = buildLocalPlaylistUsageLookup(playlists, localizedContext)
-        var changed = false
-        val updated = current.mapNotNull { entry ->
-            if (entry.source != SOURCE_LOCAL) return@mapNotNull entry
-
-            val playlist = localPlaylistLookup[entry.id] ?: run {
-                changed = true
-                return@mapNotNull null
+        val out = synchronized(mutationLock) {
+            val current = _flow.value
+            if (current.none { it.source == SOURCE_LOCAL }) {
+                return@synchronized null
             }
 
-            val refreshedName = SystemLocalPlaylists.resolve(
-                playlistId = playlist.id,
-                playlistName = playlist.name,
-                context = localizedContext
-            )?.currentName ?: playlist.name
-            val refreshedPicUrl = playlist.displayCoverUrl(
-                context = localizedContext,
-                resolveLocalMetadataFallback = true,
-                additionalCoverCandidates = if (LocalFilesPlaylist.isSystemPlaylist(
-                        playlist,
-                        localizedContext
-                    )
-                ) {
-                    localFilesCoverCandidates
-                } else {
-                    emptyList()
+            val localizedContext = LanguageManager.applyLanguage(app)
+            val localPlaylistLookup = buildLocalPlaylistUsageLookup(playlists, localizedContext)
+            var changed = false
+            val updated = current.mapNotNull { entry ->
+                if (entry.source != SOURCE_LOCAL) return@mapNotNull entry
+
+                val playlist = localPlaylistLookup[entry.id] ?: run {
+                    changed = true
+                    return@mapNotNull null
                 }
-            )
-            val refreshedTrackCount = playlist.songs.size
-            if (
-                entry.name == refreshedName &&
-                entry.picUrl == refreshedPicUrl &&
-                entry.trackCount == refreshedTrackCount
-            ) {
-                entry
-            } else {
-                changed = true
-                entry.copy(
-                    name = refreshedName,
-                    picUrl = refreshedPicUrl,
-                    trackCount = refreshedTrackCount
-                )
+
+                val refreshedName = SystemLocalPlaylists.resolve(
+                    playlistId = playlist.id,
+                    playlistName = playlist.name,
+                    context = localizedContext
+                )?.currentName ?: playlist.name
+                val refreshedPicUrl = playlist.displayCoverUrl(
+                    context = localizedContext,
+                    resolveLocalMetadataFallback = true,
+                    additionalCoverCandidates = if (LocalFilesPlaylist.isSystemPlaylist(
+                            playlist,
+                            localizedContext
+                        )
+                    ) {
+                        localFilesCoverCandidates
+                    } else {
+                        emptyList()
+                    }
+                )?.takeIf { it.isNotBlank() } ?: entry.picUrl
+                val refreshedTrackCount = playlist.songs.size
+                if (
+                    entry.name == refreshedName &&
+                    entry.picUrl == refreshedPicUrl &&
+                    entry.trackCount == refreshedTrackCount
+                ) {
+                    entry
+                } else {
+                    changed = true
+                    entry.copy(
+                        name = refreshedName,
+                        picUrl = refreshedPicUrl,
+                        trackCount = refreshedTrackCount
+                    )
+                }
             }
+
+            if (!changed) return@synchronized null
+
+            normalizeUsageEntries(updated).also { _flow.value = it }
         }
-
-        if (!changed) return
-
-        val out = normalizeUsageEntries(updated)
-        _flow.value = out
-        saveAsync(out)
+        out?.let(::saveAsync)
     }
 
     /** 同步本地歌手虚拟歌单卡片信息 */
     fun syncLocalArtistEntries(playlists: List<LocalPlaylist>) {
-        val current = _flow.value
-        if (current.none { it.source == SOURCE_LOCAL_ARTIST }) return
-
-        val localizedContext = LanguageManager.applyLanguage(app)
-        val artistsById = buildLocalArtistSummaries(playlists, localizedContext)
-            .associateBy { artist -> artist.id }
-        var changed = false
-        val updated = current.mapNotNull { entry ->
-            if (entry.source != SOURCE_LOCAL_ARTIST) return@mapNotNull entry
-
-            val artist = artistsById[entry.id] ?: run {
-                changed = true
-                return@mapNotNull null
+        val out = synchronized(mutationLock) {
+            val current = _flow.value
+            if (current.none { it.source == SOURCE_LOCAL_ARTIST }) {
+                return@synchronized null
             }
 
-            val refreshedPicUrl = artist.displayCoverUrl(
-                context = localizedContext,
-                resolveLocalMetadataFallback = true
-            )
-            val refreshedTrackCount = artist.songs.size
-            if (
-                entry.name == artist.name &&
-                entry.picUrl == refreshedPicUrl &&
-                entry.trackCount == refreshedTrackCount
-            ) {
-                entry
-            } else {
-                changed = true
-                entry.copy(
-                    name = artist.name,
-                    picUrl = refreshedPicUrl,
-                    trackCount = refreshedTrackCount
-                )
+            val localizedContext = LanguageManager.applyLanguage(app)
+            val artistsById = buildLocalArtistSummaries(playlists, localizedContext)
+                .associateBy { artist -> artist.id }
+            var changed = false
+            val updated = current.mapNotNull { entry ->
+                if (entry.source != SOURCE_LOCAL_ARTIST) return@mapNotNull entry
+
+                val artist = artistsById[entry.id] ?: run {
+                    changed = true
+                    return@mapNotNull null
+                }
+
+                val refreshedPicUrl = artist.displayCoverUrl(
+                    context = localizedContext,
+                    resolveLocalMetadataFallback = true
+                )?.takeIf { it.isNotBlank() } ?: entry.picUrl
+                val refreshedTrackCount = artist.songs.size
+                if (
+                    entry.name == artist.name &&
+                    entry.picUrl == refreshedPicUrl &&
+                    entry.trackCount == refreshedTrackCount
+                ) {
+                    entry
+                } else {
+                    changed = true
+                    entry.copy(
+                        name = artist.name,
+                        picUrl = refreshedPicUrl,
+                        trackCount = refreshedTrackCount
+                    )
+                }
             }
+
+            if (!changed) return@synchronized null
+
+            normalizeUsageEntries(updated).also { _flow.value = it }
         }
-
-        if (!changed) return
-
-        val out = normalizeUsageEntries(updated)
-        _flow.value = out
-        saveAsync(out)
+        out?.let(::saveAsync)
     }
 
     /** 从继续播放列表中移除指定项 */

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/HomeScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/HomeScreen.kt
@@ -127,8 +127,10 @@ import moe.ouom.neriplayer.data.local.playlist.LocalPlaylistRepository
 import moe.ouom.neriplayer.data.local.playlist.model.LocalPlaylist
 import moe.ouom.neriplayer.data.playlist.usage.PlaylistUsageRepository
 import moe.ouom.neriplayer.data.local.playlist.system.FavoritesPlaylist
+import moe.ouom.neriplayer.data.local.playlist.system.LocalFilesPlaylist
 import moe.ouom.neriplayer.data.local.playlist.system.SystemLocalPlaylists
 import moe.ouom.neriplayer.data.playlist.usage.UsageEntry
+import moe.ouom.neriplayer.data.playlist.usage.buildLocalPlaylistUsageLookup
 import moe.ouom.neriplayer.data.platform.youtube.buildYouTubeMusicMediaUri
 import moe.ouom.neriplayer.data.local.media.displayAlbum
 import moe.ouom.neriplayer.ui.util.shouldAllowCollapsingTopAppBar
@@ -147,6 +149,7 @@ import moe.ouom.neriplayer.ui.viewmodel.tab.NeteaseHomeSongSource
 import moe.ouom.neriplayer.ui.viewmodel.tab.PlaylistSummary
 import moe.ouom.neriplayer.ui.viewmodel.tab.YouTubeMusicPlaylist
 import moe.ouom.neriplayer.ui.viewmodel.tab.favoriteId
+import moe.ouom.neriplayer.ui.util.rememberPlaylistDisplayCoverUrl
 import moe.ouom.neriplayer.ui.util.rememberSongDisplayCoverUrl
 import moe.ouom.neriplayer.ui.util.currentWindowWidthDp
 import moe.ouom.neriplayer.ui.feedback.NeriOverlaySnackbarHost
@@ -278,6 +281,9 @@ fun HomeScreen(
             .firstOrNull { FavoritesPlaylist.isSystemPlaylist(it, context) }
             ?.songs
             .orEmpty()
+    }
+    val localPlaylistUsageLookup = remember(localPlaylists, context) {
+        buildLocalPlaylistUsageLookup(localPlaylists, context)
     }
 
     val hasLocalUsage = remember(usageEntries) {
@@ -497,6 +503,8 @@ fun HomeScreen(
                             if (usageLoaded) {
                                 ContinueSection(
                                     items = usageEntries.take(12),
+                                    localPlaylistLookup = localPlaylistUsageLookup,
+                                    localFilesCoverCandidates = downloadedPlaybackCoverCandidates,
                                     onClick = { entry -> onOpenRecent(entry) },
                                     offlineMode = offlineMode
                                 )
@@ -1895,6 +1903,8 @@ private fun LazyGridScope.addYouTubeMusicSongShelfSection(
 @Composable
 private fun ContinueSection(
     items: List<UsageEntry>,
+    localPlaylistLookup: Map<Long, LocalPlaylist>,
+    localFilesCoverCandidates: List<SongItem>,
     onClick: (UsageEntry) -> Unit,
     offlineMode: Boolean,
     modifier: Modifier = Modifier
@@ -1932,8 +1942,17 @@ private fun ContinueSection(
                         if (entry == null) {
                             Spacer(Modifier.width(cardWidth))
                         } else {
+                            val localPlaylist = if (
+                                entry.source == PlaylistUsageRepository.SOURCE_LOCAL
+                            ) {
+                                localPlaylistLookup[entry.id]
+                            } else {
+                                null
+                            }
                             ContinueCard(
                                 entry = entry,
+                                localPlaylist = localPlaylist,
+                                localFilesCoverCandidates = localFilesCoverCandidates,
                                 onClick = { onClick(entry) },
                                 onRemove = {
                                     AppContainer.launchBackgroundIo {
@@ -1959,6 +1978,8 @@ private fun ContinueSection(
 @Composable
 private fun ContinueCard(
     entry: UsageEntry,
+    localPlaylist: LocalPlaylist?,
+    localFilesCoverCandidates: List<SongItem>,
     onClick: () -> Unit,
     onRemove: () -> Unit,
     offlineMode: Boolean,
@@ -1971,6 +1992,19 @@ private fun ContinueCard(
     val displayName = remember(entry.id, entry.name, entry.source, configuration) {
         SystemLocalPlaylists.resolve(entry.id, entry.name, context)?.currentName ?: entry.name
     }
+    val resolvedLocalCoverUrl = if (localPlaylist != null) {
+        rememberPlaylistDisplayCoverUrl(
+            playlist = localPlaylist,
+            additionalCoverCandidates = if (localPlaylist.id == LocalFilesPlaylist.SYSTEM_ID) {
+                localFilesCoverCandidates
+            } else {
+                emptyList()
+            }
+        )
+    } else {
+        null
+    }
+    val coverUrl = resolvedLocalCoverUrl ?: entry.picUrl
 
     Column(
         modifier = modifier
@@ -1986,7 +2020,7 @@ private fun ContinueCard(
         AsyncImage(
             model = fastScrollableImageRequest(
                 context = context,
-                data = entry.picUrl,
+                data = coverUrl,
                 sizePx = 384,
                 offlineMode = offlineMode
             ),

--- a/app/src/main/java/moe/ouom/neriplayer/ui/util/CoverUrlState.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/util/CoverUrlState.kt
@@ -87,25 +87,35 @@ fun rememberSongDisplayCoverUrl(
 @Composable
 fun rememberPlaylistDisplayCoverUrl(
     playlist: LocalPlaylist?,
-    resolveLocalFallback: Boolean = true
+    resolveLocalFallback: Boolean = true,
+    additionalCoverCandidates: List<SongItem> = emptyList()
 ): String? {
     val context = LocalContext.current
     val appContext = remember(context) { context.applicationContext }
     val downloadPresenceVersion by GlobalDownloadManager.downloadPresenceVersion.collectAsStateWithLifecycle()
-    val playlistKey = remember(playlist, resolveLocalFallback) {
+    val playlistKey = remember(playlist, resolveLocalFallback, additionalCoverCandidates) {
         playlist?.coverResolutionKey(resolveLocalFallback)
     }
     var coverUrl by remember(playlistKey, downloadPresenceVersion) {
-        mutableStateOf(cachedResolvedCover(playlistKey) ?: playlist?.displayCoverUrl())
+        mutableStateOf(
+            cachedResolvedCover(playlistKey)
+                ?: playlist?.displayCoverUrl(additionalCoverCandidates)
+        )
     }
 
-    LaunchedEffect(playlistKey, appContext, downloadPresenceVersion, resolveLocalFallback) {
+    LaunchedEffect(
+        playlistKey,
+        appContext,
+        downloadPresenceVersion,
+        resolveLocalFallback,
+        additionalCoverCandidates
+    ) {
         if (playlist == null) {
             coverUrl = null
             return@LaunchedEffect
         }
 
-        val immediateCover = playlist.displayCoverUrl()
+        val immediateCover = playlist.displayCoverUrl(additionalCoverCandidates)
         cachedResolvedCover(playlistKey)?.let { cachedCover ->
             coverUrl = cachedCover
         }
@@ -120,7 +130,11 @@ fun rememberPlaylistDisplayCoverUrl(
         }
 
         val resolvedCover = withContext(coverResolutionDispatcher) {
-            playlist.displayCoverUrl(appContext, resolveLocalFallback)
+            playlist.displayCoverUrl(
+                context = appContext,
+                resolveLocalMetadataFallback = resolveLocalFallback,
+                additionalCoverCandidates = additionalCoverCandidates
+            )
         }
         if (!resolvedCover.isNullOrBlank()) {
             rememberResolvedCover(playlistKey, resolvedCover)

--- a/app/src/test/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepositoryTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/playlist/usage/PlaylistUsageRepositoryTest.kt
@@ -400,6 +400,87 @@ class PlaylistUsageRepositoryTest {
         assertEquals(1, entry.trackCount)
     }
 
+    @Test
+    fun `sync local entries keeps last known cover when fallback is temporarily blank`() {
+        val context = mockLocalizedContext()
+        val repo = PlaylistUsageRepository(context)
+        val knownCoverUrl = "file:///covers/known-local.jpg"
+        val localFiles = LocalPlaylist(
+            id = LocalFilesPlaylist.SYSTEM_ID,
+            name = "本地文件",
+            songs = mutableListOf(localSong(coverUrl = null))
+        )
+
+        repo.recordOpen(
+            id = LocalFilesPlaylist.SYSTEM_ID,
+            name = "本地文件",
+            picUrl = knownCoverUrl,
+            trackCount = 1,
+            source = PlaylistUsageRepository.SOURCE_LOCAL,
+            now = 100L
+        )
+        repo.syncLocalEntries(playlists = listOf(localFiles))
+
+        assertEquals(knownCoverUrl, repo.frequentPlaylistsFlow.value.single().picUrl)
+    }
+
+    @Test
+    fun `opening local playlist without cover does not clear known cover`() {
+        val repo = PlaylistUsageRepository(mockContext())
+        val knownCoverUrl = "file:///covers/known-local.jpg"
+
+        repo.recordOpen(
+            id = LocalFilesPlaylist.SYSTEM_ID,
+            name = "本地文件",
+            picUrl = knownCoverUrl,
+            trackCount = 1,
+            source = PlaylistUsageRepository.SOURCE_LOCAL,
+            now = 100L
+        )
+        repo.recordOpen(
+            id = LocalFilesPlaylist.SYSTEM_ID,
+            name = "本地文件",
+            picUrl = null,
+            trackCount = 1,
+            source = PlaylistUsageRepository.SOURCE_LOCAL,
+            now = 200L
+        )
+
+        assertEquals(knownCoverUrl, repo.frequentPlaylistsFlow.value.single().picUrl)
+    }
+
+    @Test
+    fun `merged usage stats keep local cover when sync omits local file cover`() {
+        val repo = PlaylistUsageRepository(mockContext())
+        val knownCoverUrl = "file:///covers/known-local.jpg"
+
+        repo.recordOpen(
+            id = LocalFilesPlaylist.SYSTEM_ID,
+            name = "本地文件",
+            picUrl = knownCoverUrl,
+            trackCount = 1,
+            source = PlaylistUsageRepository.SOURCE_LOCAL,
+            now = 100L
+        )
+        repo.applyMergedStats(
+            listOf(
+                SyncPlaylistUsageStat(
+                    playlistKey = "local:${LocalFilesPlaylist.SYSTEM_ID}",
+                    source = PlaylistUsageRepository.SOURCE_LOCAL,
+                    id = LocalFilesPlaylist.SYSTEM_ID,
+                    name = "本地文件",
+                    coverUrl = null,
+                    trackCount = 1,
+                    lastOpenedAt = 200L,
+                    firstOpenedAt = 100L,
+                    openCount = 2
+                )
+            )
+        )
+
+        assertEquals(knownCoverUrl, repo.frequentPlaylistsFlow.value.single().picUrl)
+    }
+
     private fun usageEntry(
         id: Long,
         subtype: String?,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 用户可见变化

- “继续”区域可继续显示本地歌单的封面。
- 当封面解析暂时为空时，系统保留已知封面，不再清除封面。
- 本地文件歌单可使用已下载歌曲的封面作为候选来源。
- 已不存在的本地条目会从使用记录中移除。

## 测试

- 新增测试，验证临时封面解析为空时保留最近封面。
- 新增测试，验证无封面重新打开歌单时不清除已知封面。
- 新增测试，验证合并使用记录时保留本地封面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->