### PR TITLE
feat: implement causal token range compaction and optimize sync storage

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/github/GitHubSyncManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/github/GitHubSyncManager.kt
@@ -1232,7 +1232,7 @@ class GitHubSyncManager private constructor(context: Context) {
         val content = SyncDataSerializer.serialize(data, useDataSaver)
         NPLogger.d(
             TAG,
-            "Upload data size: ${SyncDataSerializer.getDataSize(data, useDataSaver)} bytes (DataSaver: $useDataSaver, File: $fileName)"
+            "Upload data size: ${content.size} bytes (DataSaver: $useDataSaver, File: $fileName)"
         )
 
         val uploadResult = apiClient.updateFileContent(owner, repo, content, sha, fileName)

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SyncDataChangeDetector.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SyncDataChangeDetector.kt
@@ -8,6 +8,7 @@ import moe.ouom.neriplayer.data.sync.model.SyncPlaylistSongDeletion
 import moe.ouom.neriplayer.data.sync.model.SyncRecentPlay
 import moe.ouom.neriplayer.data.sync.model.SyncRecentPlayDeletion
 import moe.ouom.neriplayer.data.sync.model.SyncSong
+import moe.ouom.neriplayer.data.sync.model.compactedSyncCausalTokens
 
 internal object SyncDataChangeDetector {
     fun hasDataChanged(remote: SyncData, merged: SyncData): Boolean {
@@ -139,8 +140,10 @@ internal object SyncDataChangeDetector {
             if (remotePlaylistDeletions[i].deletedAt != mergedPlaylistDeletions[i].deletedAt) return true
             if (remotePlaylistDeletions[i].deviceId != mergedPlaylistDeletions[i].deviceId) return true
             if (
-                remotePlaylistDeletions[i].removedMembershipTokens.orEmpty().toSet() !=
-                mergedPlaylistDeletions[i].removedMembershipTokens.orEmpty().toSet()
+                remotePlaylistDeletions[i].removedMembershipTokens.orEmpty()
+                    .compactedSyncCausalTokens() !=
+                mergedPlaylistDeletions[i].removedMembershipTokens.orEmpty()
+                    .compactedSyncCausalTokens()
             ) return true
         }
         return false
@@ -173,6 +176,7 @@ internal object SyncDataChangeDetector {
             a.subAudioId == b.subAudioId &&
             a.playlistContextId == b.playlistContextId &&
             a.syncMetadataVersion == b.syncMetadataVersion &&
-            a.syncMembershipTokens.toSet() == b.syncMembershipTokens.toSet()
+            a.syncMembershipTokens.compactedSyncCausalTokens() ==
+                b.syncMembershipTokens.compactedSyncCausalTokens()
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SyncDataSerializer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SyncDataSerializer.kt
@@ -37,6 +37,8 @@ import moe.ouom.neriplayer.data.sync.model.SyncLogEntry
 import moe.ouom.neriplayer.data.sync.model.SyncPlaylist
 import moe.ouom.neriplayer.data.sync.model.SyncRecentPlay
 import moe.ouom.neriplayer.data.sync.model.SyncSong
+import moe.ouom.neriplayer.data.sync.model.compactedSyncCausalTokens
+import moe.ouom.neriplayer.data.sync.model.requireCausalTokenRangeCapacity
 import moe.ouom.neriplayer.data.sync.model.sanitizeLocalCoverUrls
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -78,7 +80,8 @@ object SyncDataSerializer {
      * @return useDataSaver=true 时为原始 GZIP(ProtoBuf) 字节; 否则为 UTF-8 JSON 字节
      */
     fun serialize(data: SyncData, useDataSaver: Boolean): ByteArray {
-        val sanitizedData = data.sanitizeLocalCoverUrls()
+        val sanitizedData = data.sanitizeLocalCoverUrls().compactCausalTokenRanges()
+        ensureCausalTokenCapacity(sanitizedData)
         val content = if (useDataSaver) {
             val protoBytes = protoBuf.encodeToByteArray(sanitizedData)
             require(protoBytes.size <= MAX_DECOMPRESSED_BYTES) {
@@ -90,6 +93,62 @@ object SyncDataSerializer {
         }
         ensureUploadContentSize(content, useDataSaver)
         return content
+    }
+
+    private fun ensureCausalTokenCapacity(data: SyncData) {
+        data.playlists.forEach { playlist ->
+            playlist.songs.forEach { song ->
+                requireCausalTokenRangeCapacity(song.syncMembershipTokens)
+            }
+        }
+        data.favoritePlaylists.forEach { playlist ->
+            playlist.songs.forEach { song ->
+                requireCausalTokenRangeCapacity(song.syncMembershipTokens)
+            }
+        }
+        data.recentPlays.forEach { recentPlay ->
+            requireCausalTokenRangeCapacity(recentPlay.song.syncMembershipTokens)
+        }
+        data.playlistSongDeletions.forEach { deletion ->
+            requireCausalTokenRangeCapacity(deletion.removedMembershipTokens)
+        }
+    }
+
+    private fun SyncData.compactCausalTokenRanges(): SyncData {
+        return copy(
+            playlists = playlists.map { playlist ->
+                playlist.copy(
+                    songs = playlist.songs.map { song ->
+                        song.copy(
+                            syncMembershipTokens = song.syncMembershipTokens.compactedSyncCausalTokens()
+                        )
+                    }
+                )
+            },
+            favoritePlaylists = favoritePlaylists.map { playlist ->
+                playlist.copy(
+                    songs = playlist.songs.map { song ->
+                        song.copy(
+                            syncMembershipTokens = song.syncMembershipTokens.compactedSyncCausalTokens()
+                        )
+                    }
+                )
+            },
+            recentPlays = recentPlays.map { recentPlay ->
+                recentPlay.copy(
+                    song = recentPlay.song.copy(
+                        syncMembershipTokens = recentPlay.song.syncMembershipTokens
+                            .compactedSyncCausalTokens()
+                    )
+                )
+            },
+            playlistSongDeletions = playlistSongDeletions.map { deletion ->
+                deletion.copy(
+                    removedMembershipTokens = deletion.removedMembershipTokens
+                        .compactedSyncCausalTokens()
+                )
+            }.let { SyncPlaylistDeletionPolicy.limitDeletions(it) }
+        )
     }
 
     private fun ensureUploadContentSize(content: ByteArray, useDataSaver: Boolean) {
@@ -107,6 +166,7 @@ object SyncDataSerializer {
      * 3. 旧 Base64(GZIP(ProtoBuf)) 文本 (旧 backup.bin)
      */
     fun deserialize(content: ByteArray): SyncData {
+        ensureRemoteContentSize(content)
         if (looksLikeGzip(content)) {
             return decodeGzipProto(content)
         }
@@ -138,10 +198,11 @@ object SyncDataSerializer {
      * JSON反序列化
      */
     private fun deserializeJson(content: String): SyncData {
-        require(content.toByteArray(Charsets.UTF_8).size <= MAX_JSON_BYTES) {
+        val normalizedContent = content.removePrefix("\uFEFF")
+        require(normalizedContent.toByteArray(Charsets.UTF_8).size <= MAX_JSON_BYTES) {
             "JSON sync data is too large"
         }
-        return json.decodeFromString(content)
+        return json.decodeFromString(normalizedContent)
     }
 
     /**

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SyncDataSerializer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SyncDataSerializer.kt
@@ -38,13 +38,27 @@ import moe.ouom.neriplayer.data.sync.model.SyncPlaylist
 import moe.ouom.neriplayer.data.sync.model.SyncRecentPlay
 import moe.ouom.neriplayer.data.sync.model.SyncSong
 import moe.ouom.neriplayer.data.sync.model.compactedSyncCausalTokens
+import moe.ouom.neriplayer.data.sync.model.expandedLegacyCompatibleSyncCausalTokens
 import moe.ouom.neriplayer.data.sync.model.requireCausalTokenRangeCapacity
 import moe.ouom.neriplayer.data.sync.model.sanitizeLocalCoverUrls
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.OutputStream
 import java.util.Base64
+import java.util.zip.Deflater
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
+
+/**
+ * 共享快照的写入能力
+ *
+ * LEGACY_SAFE 是默认值, 因为旧 Android 和旧 Desktop 会忽略 counterEnd,
+ * 但不会理解它代表的完整区间。RANGE_V1 只能在显式能力协商后使用。
+ */
+enum class SyncSerializationCompatibility {
+    LEGACY_SAFE,
+    RANGE_V1
+}
 
 /**
  * 同步数据序列化工具
@@ -79,9 +93,17 @@ object SyncDataSerializer {
      * @param useDataSaver 是否使用省流模式
      * @return useDataSaver=true 时为原始 GZIP(ProtoBuf) 字节; 否则为 UTF-8 JSON 字节
      */
-    fun serialize(data: SyncData, useDataSaver: Boolean): ByteArray {
-        val sanitizedData = data.sanitizeLocalCoverUrls().compactCausalTokenRanges()
-        ensureCausalTokenCapacity(sanitizedData)
+    fun serialize(
+        data: SyncData,
+        useDataSaver: Boolean,
+        compatibility: SyncSerializationCompatibility = SyncSerializationCompatibility.LEGACY_SAFE
+    ): ByteArray {
+        val compactedData = data.sanitizeLocalCoverUrls().compactCausalTokenRanges()
+        ensureCausalTokenCapacity(compactedData)
+        val sanitizedData = when (compatibility) {
+            SyncSerializationCompatibility.LEGACY_SAFE -> compactedData.expandCausalTokenRanges()
+            SyncSerializationCompatibility.RANGE_V1 -> compactedData
+        }
         val content = if (useDataSaver) {
             val protoBytes = protoBuf.encodeToByteArray(sanitizedData)
             require(protoBytes.size <= MAX_DECOMPRESSED_BYTES) {
@@ -148,6 +170,45 @@ object SyncDataSerializer {
                         .compactedSyncCausalTokens()
                 )
             }.let { SyncPlaylistDeletionPolicy.limitDeletions(it) }
+        )
+    }
+
+    private fun SyncData.expandCausalTokenRanges(): SyncData {
+        return copy(
+            playlists = playlists.map { playlist ->
+                playlist.copy(
+                    songs = playlist.songs.map { song ->
+                        song.copy(
+                            syncMembershipTokens = song.syncMembershipTokens
+                                .expandedLegacyCompatibleSyncCausalTokens()
+                        )
+                    }
+                )
+            },
+            favoritePlaylists = favoritePlaylists.map { playlist ->
+                playlist.copy(
+                    songs = playlist.songs.map { song ->
+                        song.copy(
+                            syncMembershipTokens = song.syncMembershipTokens
+                                .expandedLegacyCompatibleSyncCausalTokens()
+                        )
+                    }
+                )
+            },
+            recentPlays = recentPlays.map { recentPlay ->
+                recentPlay.copy(
+                    song = recentPlay.song.copy(
+                        syncMembershipTokens = recentPlay.song.syncMembershipTokens
+                            .expandedLegacyCompatibleSyncCausalTokens()
+                    )
+                )
+            },
+            playlistSongDeletions = playlistSongDeletions.map { deletion ->
+                deletion.copy(
+                    removedMembershipTokens = deletion.removedMembershipTokens
+                        .expandedLegacyCompatibleSyncCausalTokens()
+                )
+            }
         )
     }
 
@@ -257,10 +318,24 @@ object SyncDataSerializer {
      */
     private fun compress(data: ByteArray): ByteArray {
         val outputStream = ByteArrayOutputStream()
-        GZIPOutputStream(outputStream).use { gzip ->
+        val level = if (data.size >= BEST_COMPRESSION_THRESHOLD_BYTES) {
+            Deflater.BEST_COMPRESSION
+        } else {
+            Deflater.DEFAULT_COMPRESSION
+        }
+        TunedGzipOutputStream(outputStream, level).use { gzip ->
             gzip.write(data)
         }
         return outputStream.toByteArray()
+    }
+
+    private class TunedGzipOutputStream(
+        outputStream: OutputStream,
+        level: Int
+    ) : GZIPOutputStream(outputStream) {
+        init {
+            def.setLevel(level)
+        }
     }
 
     /**
@@ -338,6 +413,7 @@ object SyncDataSerializer {
     private const val RAW_BINARY_FILE_NAME = "backup-raw.bin"
     private const val LEGACY_BINARY_FILE_NAME = "backup.bin"
     private const val JSON_FILE_NAME = "backup.json"
+    private const val BEST_COMPRESSION_THRESHOLD_BYTES = 256 * 1024
 
     /**
      * 兼容旧/错误字段编号的 schema (mediaUri 插入到 addedAt 之前的版本)

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SyncDataSerializer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SyncDataSerializer.kt
@@ -31,6 +31,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.protobuf.ProtoBuf
 import kotlinx.serialization.protobuf.ProtoNumber
 import moe.ouom.neriplayer.data.sync.model.SyncAction
+import moe.ouom.neriplayer.data.sync.model.SyncCausalToken
 import moe.ouom.neriplayer.data.sync.model.SyncData
 import moe.ouom.neriplayer.data.sync.model.SyncFavoritePlaylist
 import moe.ouom.neriplayer.data.sync.model.SyncLogEntry
@@ -39,6 +40,7 @@ import moe.ouom.neriplayer.data.sync.model.SyncRecentPlay
 import moe.ouom.neriplayer.data.sync.model.SyncSong
 import moe.ouom.neriplayer.data.sync.model.compactedSyncCausalTokens
 import moe.ouom.neriplayer.data.sync.model.expandedLegacyCompatibleSyncCausalTokens
+import moe.ouom.neriplayer.data.sync.model.legacyCompatibleSyncCausalTokenPointCount
 import moe.ouom.neriplayer.data.sync.model.requireCausalTokenRangeCapacity
 import moe.ouom.neriplayer.data.sync.model.sanitizeLocalCoverUrls
 import java.io.ByteArrayInputStream
@@ -99,7 +101,10 @@ object SyncDataSerializer {
         compatibility: SyncSerializationCompatibility = SyncSerializationCompatibility.LEGACY_SAFE
     ): ByteArray {
         val compactedData = data.sanitizeLocalCoverUrls().compactCausalTokenRanges()
-        ensureCausalTokenCapacity(compactedData)
+        ensureCausalTokenCapacity(
+            data = compactedData,
+            requireLegacyExpansionBudget = compatibility == SyncSerializationCompatibility.LEGACY_SAFE
+        )
         val sanitizedData = when (compatibility) {
             SyncSerializationCompatibility.LEGACY_SAFE -> compactedData.expandCausalTokenRanges()
             SyncSerializationCompatibility.RANGE_V1 -> compactedData
@@ -117,22 +122,43 @@ object SyncDataSerializer {
         return content
     }
 
-    private fun ensureCausalTokenCapacity(data: SyncData) {
+    private fun ensureCausalTokenCapacity(
+        data: SyncData,
+        requireLegacyExpansionBudget: Boolean
+    ) {
+        var legacyPointCount = 0L
+
+        fun checkTokens(tokens: Iterable<SyncCausalToken>) {
+            requireCausalTokenRangeCapacity(tokens)
+            if (!requireLegacyExpansionBudget) return
+
+            val points = tokens.legacyCompatibleSyncCausalTokenPointCount()
+            legacyPointCount = if (points > Long.MAX_VALUE - legacyPointCount) {
+                Long.MAX_VALUE
+            } else {
+                legacyPointCount + points
+            }
+            require(legacyPointCount <= MAX_LEGACY_TOKEN_POINTS_PER_SNAPSHOT) {
+                "Legacy token snapshot budget exceeded: " +
+                    "$legacyPointCount > $MAX_LEGACY_TOKEN_POINTS_PER_SNAPSHOT"
+            }
+        }
+
         data.playlists.forEach { playlist ->
             playlist.songs.forEach { song ->
-                requireCausalTokenRangeCapacity(song.syncMembershipTokens)
+                checkTokens(song.syncMembershipTokens)
             }
         }
         data.favoritePlaylists.forEach { playlist ->
             playlist.songs.forEach { song ->
-                requireCausalTokenRangeCapacity(song.syncMembershipTokens)
+                checkTokens(song.syncMembershipTokens)
             }
         }
         data.recentPlays.forEach { recentPlay ->
-            requireCausalTokenRangeCapacity(recentPlay.song.syncMembershipTokens)
+            checkTokens(recentPlay.song.syncMembershipTokens)
         }
         data.playlistSongDeletions.forEach { deletion ->
-            requireCausalTokenRangeCapacity(deletion.removedMembershipTokens)
+            checkTokens(deletion.removedMembershipTokens)
         }
     }
 
@@ -369,8 +395,12 @@ object SyncDataSerializer {
     /**
      * 获取数据大小 (用于统计) , 返回实际上传的原始字节数
      */
-    fun getDataSize(data: SyncData, useDataSaver: Boolean): Int {
-        return serialize(data, useDataSaver).size
+    fun getDataSize(
+        data: SyncData,
+        useDataSaver: Boolean,
+        compatibility: SyncSerializationCompatibility = SyncSerializationCompatibility.LEGACY_SAFE
+    ): Int {
+        return serialize(data, useDataSaver, compatibility).size
     }
 
     /**
@@ -414,6 +444,7 @@ object SyncDataSerializer {
     private const val LEGACY_BINARY_FILE_NAME = "backup.bin"
     private const val JSON_FILE_NAME = "backup.json"
     private const val BEST_COMPRESSION_THRESHOLD_BYTES = 256 * 1024
+    private const val MAX_LEGACY_TOKEN_POINTS_PER_SNAPSHOT = 262_144L
 
     /**
      * 兼容旧/错误字段编号的 schema (mediaUri 插入到 addedAt 之前的版本)

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SyncPlaylistDeletionPolicy.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SyncPlaylistDeletionPolicy.kt
@@ -8,7 +8,9 @@ import moe.ouom.neriplayer.data.sync.model.SyncFavoritePlaylist
 import moe.ouom.neriplayer.data.sync.model.SyncPlaylist
 import moe.ouom.neriplayer.data.sync.model.SyncPlaylistSongDeletion
 import moe.ouom.neriplayer.data.sync.model.SyncSong
+import moe.ouom.neriplayer.data.sync.model.compactedSyncCausalTokens
 import moe.ouom.neriplayer.data.sync.model.normalizedSyncCausalTokens
+import moe.ouom.neriplayer.data.sync.model.requireCausalTokenRangeCapacity
 
 internal object SyncPlaylistDeletionPolicy {
     internal const val MAX_PLAYLIST_SONG_DELETIONS = 5_000
@@ -33,43 +35,45 @@ internal object SyncPlaylistDeletionPolicy {
             .sortedWith(deletionOrderComparator)
     }
 
-    /** 在有限容量内保留两类墓碑，避免 causal 墓碑无限增长或挤掉全部 legacy 墓碑 */
+    /** 压缩可合并的因果墓碑, 超出容量时拒绝而不是静默丢弃 */
     fun limitDeletions(
         deletions: List<SyncPlaylistSongDeletion>,
         maxCount: Int = MAX_PLAYLIST_SONG_DELETIONS
     ): List<SyncPlaylistSongDeletion> {
         require(maxCount >= 0) { "Deletion capacity must not be negative" }
-        if (deletions.isEmpty() || maxCount == 0) {
+        if (deletions.isEmpty()) {
             return emptyList()
         }
 
         val merged = mergeDeletions(deletions, emptyList())
-        if (merged.size <= maxCount) {
-            return merged
+        val compacted = compactCausalDeletions(merged)
+        require(compacted.size <= maxCount) {
+            "Playlist deletion capacity exceeded: ${compacted.size} > $maxCount"
         }
+        return compacted.sortedWith(deletionOrderComparator)
+    }
 
-        val causal = merged.filter { it.removedMembershipTokens.orEmpty().isNotEmpty() }
-        val legacy = merged.filter { it.removedMembershipTokens.orEmpty().isEmpty() }
-        val preferredLegacyCapacity = when {
-            causal.isEmpty() -> maxCount
-            legacy.isEmpty() -> 0
-            else -> maxCount / 2
-        }
-        var legacyCapacity = minOf(legacy.size, preferredLegacyCapacity)
-        var causalCapacity = minOf(causal.size, maxCount - legacyCapacity)
-
-        var remainingCapacity = maxCount - legacyCapacity - causalCapacity
-        if (remainingCapacity > 0) {
-            val extraLegacy = minOf(legacy.size - legacyCapacity, remainingCapacity)
-            legacyCapacity += extraLegacy
-            remainingCapacity -= extraLegacy
-        }
-        if (remainingCapacity > 0) {
-            causalCapacity += minOf(causal.size - causalCapacity, remainingCapacity)
-        }
-
-        return (causal.take(causalCapacity) + legacy.take(legacyCapacity))
-            .sortedWith(deletionOrderComparator)
+    private fun compactCausalDeletions(
+        deletions: List<SyncPlaylistSongDeletion>
+    ): List<SyncPlaylistSongDeletion> {
+        val legacy = deletions.filter { it.removedMembershipTokens.orEmpty().isEmpty() }
+        val causal = deletions
+            .filter { it.removedMembershipTokens.orEmpty().isNotEmpty() }
+            .groupBy(SyncPlaylistSongDeletion::playlistId)
+            .values
+            .map { snapshots ->
+                val mirror = snapshots.maxWithOrNull(
+                    compareBy<SyncPlaylistSongDeletion> { it.deletedAt }
+                        .thenBy { it.deviceId }
+                        .thenBy(SyncPlaylistSongDeletion::stableKey)
+                ) ?: error("Causal deletion snapshot must exist")
+                val tokens = snapshots
+                    .flatMap { it.removedMembershipTokens.orEmpty() }
+                    .compactedSyncCausalTokens()
+                requireCausalTokenRangeCapacity(tokens)
+                mirror.copy(removedMembershipTokens = tokens)
+            }
+        return legacy + causal
     }
 
     fun applyDeletions(
@@ -92,7 +96,8 @@ internal object SyncPlaylistDeletionPolicy {
         val causalRemovedTokens = relevantDeletions
             .asSequence()
             .flatMap { deletion -> deletion.removedMembershipTokens.orEmpty().asSequence() }
-            .toHashSet()
+            .toList()
+            .compactedSyncCausalTokens()
         val deletionsByIdentity = relevantDeletions.groupBy { deletion ->
             deletion.identity().stableKey()
         }
@@ -233,8 +238,9 @@ internal object SyncPlaylistDeletionPolicy {
         val causalMirror = causalSnapshots.maxWithOrNull(deletionMirrorComparator)
         val removedTokens = causalSnapshots
             .flatMap { it.removedMembershipTokens.orEmpty() }
-            .normalizedSyncCausalTokens()
+            .compactedSyncCausalTokens()
         val mergedCausal = causalMirror?.let { mirror ->
+            requireCausalTokenRangeCapacity(removedTokens)
             if (removedTokens == mirror.removedMembershipTokens) {
                 mirror
             } else {
@@ -251,7 +257,7 @@ internal object SyncPlaylistDeletionPolicy {
 
     private fun applyDeletionsToSong(
         song: SyncSong,
-        causalRemovedTokens: Set<SyncCausalToken>,
+        causalRemovedTokens: List<SyncCausalToken>,
         identityDeletions: List<SyncPlaylistSongDeletion>
     ): SyncSong? {
         val songTokens = song.syncMembershipTokens.orEmpty().normalizedSyncCausalTokens()
@@ -265,7 +271,9 @@ internal object SyncPlaylistDeletionPolicy {
         }
 
         val remainingTokens = songTokens
-            .filterNot(causalRemovedTokens::contains)
+            .filterNot { songToken ->
+                causalRemovedTokens.any { removedToken -> removedToken.overlaps(songToken) }
+            }
             .normalizedSyncCausalTokens()
         if (remainingTokens.isEmpty()) return null
         val survivingSong = if (remainingTokens == song.syncMembershipTokens.orEmpty()) {

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SyncPlaylistSongMergePolicy.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/github/SyncPlaylistSongMergePolicy.kt
@@ -185,7 +185,7 @@ internal object SyncPlaylistSongMergePolicy {
     )
 
     private class SongMergeIndex {
-        private val membershipTokenIndices = mutableMapOf<SyncCausalToken, Int>()
+        private val membershipTokenIndices = mutableListOf<Pair<SyncCausalToken, Int>>()
         private val identityIndices = mutableMapOf<SongIdentity, Int>()
         private val channelAudioIndices = mutableMapOf<String, Int>()
         private val fallbackSourcesByKey = mutableMapOf<FallbackKey, SourceBucket>()
@@ -194,7 +194,10 @@ internal object SyncPlaylistSongMergePolicy {
             val candidate = song.toMergeCandidate()
             return buildSet {
                 song.syncMembershipTokens.orEmpty().forEach { token ->
-                    membershipTokenIndices[token]?.let(::add)
+                    membershipTokenIndices
+                        .asSequence()
+                        .filter { (indexedToken, _) -> indexedToken.overlaps(token) }
+                        .forEach { (_, index) -> add(index) }
                 }
                 identityIndices[candidate.identity]?.let(::add)
 
@@ -214,7 +217,12 @@ internal object SyncPlaylistSongMergePolicy {
         fun register(song: SyncSong, index: Int) {
             val candidate = song.toMergeCandidate()
             song.syncMembershipTokens.orEmpty().forEach { token ->
-                membershipTokenIndices.putIfAbsent(token, index)
+                if (membershipTokenIndices.none { (indexedToken, indexedIndex) ->
+                        indexedIndex == index && indexedToken == token
+                    }
+                ) {
+                    membershipTokenIndices += token to index
+                }
             }
             identityIndices.putIfAbsent(candidate.identity, index)
             candidate.channelAudioKey?.let { channelAudioKey ->

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/model/SyncCausalToken.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/model/SyncCausalToken.kt
@@ -119,6 +119,24 @@ internal fun Iterable<SyncCausalToken>?.expandedLegacyCompatibleSyncCausalTokens
     return expanded
 }
 
+internal fun Iterable<SyncCausalToken>?.legacyCompatibleSyncCausalTokenPointCount(): Long {
+    var total = 0L
+    compactedSyncCausalTokens().forEach { token ->
+        val end = token.endCounter()
+        val count = if (end == Long.MAX_VALUE) {
+            Long.MAX_VALUE
+        } else {
+            end - token.counter + 1L
+        }
+        total = if (count > Long.MAX_VALUE - total) {
+            Long.MAX_VALUE
+        } else {
+            total + count
+        }
+    }
+    return total
+}
+
 internal fun requireCausalTokenRangeCapacity(
     tokens: Iterable<SyncCausalToken>,
     maxRanges: Int = MAX_CAUSAL_TOKEN_RANGES_PER_ENTITY

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/model/SyncCausalToken.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/model/SyncCausalToken.kt
@@ -47,6 +47,7 @@ data class SyncCausalToken(
 }
 
 internal const val MAX_CAUSAL_TOKEN_RANGES_PER_ENTITY = 64
+internal const val MAX_LEGACY_TOKEN_POINTS_PER_ENTITY = 8_192
 
 /**
  * 归一化 token 列表: 先丢弃非法 token (空 deviceId 或 counter<=0) , 再去重并按确定性顺序排序
@@ -85,6 +86,37 @@ internal fun Iterable<SyncCausalToken>?.compactedSyncCausalTokens(): List<SyncCa
         }
     }
     return compacted
+}
+
+/**
+ * 展开为旧客户端可理解的单点令牌, 不改变区间代表的计数集合
+ *
+ * 旧客户端会忽略 counterEnd, 所以共享快照默认不能只写区间起点
+ */
+internal fun Iterable<SyncCausalToken>?.expandedLegacyCompatibleSyncCausalTokens(
+    maxPoints: Int = MAX_LEGACY_TOKEN_POINTS_PER_ENTITY
+): List<SyncCausalToken> {
+    require(maxPoints >= 0) { "Legacy token point capacity must not be negative" }
+    val compacted = compactedSyncCausalTokens()
+    val expanded = ArrayList<SyncCausalToken>(minOf(compacted.size, maxPoints))
+    compacted.forEach { token ->
+        val end = token.endCounter()
+        val count = if (end == Long.MAX_VALUE) {
+            Long.MAX_VALUE
+        } else {
+            end - token.counter + 1L
+        }
+        require(count <= maxPoints.toLong() - expanded.size) {
+            "Legacy token expansion capacity exceeded: ${expanded.size + count} > $maxPoints"
+        }
+        var counter = token.counter
+        while (true) {
+            expanded += token.copy(counter = counter, counterEnd = 0L)
+            if (counter == end) break
+            counter++
+        }
+    }
+    return expanded
 }
 
 internal fun requireCausalTokenRangeCapacity(

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/model/SyncCausalToken.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/model/SyncCausalToken.kt
@@ -13,17 +13,40 @@ data class SyncCausalToken(
     // proto3/桌面对默认值(空 deviceId, counter=0)会省略 tag, 解码侧必须提供默认值
     // 且不能在构造期硬校验, 否则含非法 token 的报文会整份解码失败 (MissingFieldException / IllegalArgumentException) , 导致 restore 变砖
     @ProtoNumber(1) val deviceId: String = "",
-    @ProtoNumber(2) val counter: Long = 0L
+    @ProtoNumber(2) val counter: Long = 0L,
+    // 可选的闭区间终点, 0 表示旧格式单点令牌
+    @ProtoNumber(3) val counterEnd: Long = 0L
 ) : Parcelable {
     // 合法性判定与桌面 normalize_sync_causal_tokens 对齐; 非法 token 在归一化阶段被丢弃而非在构造期抛异常
-    fun isValid(): Boolean = deviceId.isNotBlank() && counter > 0L
+    fun isValid(): Boolean = deviceId.isNotBlank() &&
+        counter > 0L &&
+        (counterEnd == 0L || counterEnd >= counter)
+
+    fun endCounter(): Long = if (counterEnd == 0L) counter else counterEnd
+
+    fun contains(other: SyncCausalToken): Boolean {
+        return isValid() && other.isValid() &&
+            deviceId == other.deviceId &&
+            counter <= other.counter &&
+            endCounter() >= other.endCounter()
+    }
+
+    fun overlaps(other: SyncCausalToken): Boolean {
+        return isValid() && other.isValid() &&
+            deviceId == other.deviceId &&
+            counter <= other.endCounter() &&
+            other.counter <= endCounter()
+    }
 
     companion object {
         val DETERMINISTIC_COMPARATOR: Comparator<SyncCausalToken> =
             compareBy<SyncCausalToken>(SyncCausalToken::deviceId)
                 .thenBy(SyncCausalToken::counter)
+                .thenBy(SyncCausalToken::endCounter)
     }
 }
+
+internal const val MAX_CAUSAL_TOKEN_RANGES_PER_ENTITY = 64
 
 /**
  * 归一化 token 列表: 先丢弃非法 token (空 deviceId 或 counter<=0) , 再去重并按确定性顺序排序
@@ -32,7 +55,45 @@ data class SyncCausalToken(
 internal fun Iterable<SyncCausalToken>?.normalizedSyncCausalTokens(): List<SyncCausalToken> {
     return this
         ?.filter { it.isValid() }
-        ?.distinct()
+        ?.map { token ->
+            token.copy(counterEnd = token.endCounter().takeIf { it > token.counter } ?: 0L)
+        }
         ?.sortedWith(SyncCausalToken.DETERMINISTIC_COMPARATOR)
+        ?.distinct()
         .orEmpty()
+}
+
+internal fun Iterable<SyncCausalToken>?.compactedSyncCausalTokens(): List<SyncCausalToken> {
+    val sorted = normalizedSyncCausalTokens()
+    if (sorted.isEmpty()) return emptyList()
+
+    val compacted = ArrayList<SyncCausalToken>(sorted.size)
+    sorted.forEach { candidate ->
+        val previous = compacted.lastOrNull()
+        if (previous != null &&
+            previous.deviceId == candidate.deviceId &&
+            candidate.counter <= previous.endCounter().let { end ->
+                if (end == Long.MAX_VALUE) Long.MAX_VALUE else end + 1L
+            }
+        ) {
+            val end = maxOf(previous.endCounter(), candidate.endCounter())
+            compacted[compacted.lastIndex] = previous.copy(
+                counterEnd = end.takeIf { it > previous.counter } ?: 0L
+            )
+        } else {
+            compacted += candidate
+        }
+    }
+    return compacted
+}
+
+internal fun requireCausalTokenRangeCapacity(
+    tokens: Iterable<SyncCausalToken>,
+    maxRanges: Int = MAX_CAUSAL_TOKEN_RANGES_PER_ENTITY
+) {
+    require(maxRanges >= 0) { "Causal token range capacity must not be negative" }
+    val normalized = tokens.compactedSyncCausalTokens()
+    require(normalized.size <= maxRanges) {
+        "Causal token range capacity exceeded: ${normalized.size} > $maxRanges"
+    }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/data/sync/webdav/WebDavSyncManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/sync/webdav/WebDavSyncManager.kt
@@ -1193,7 +1193,7 @@ class WebDavSyncManager private constructor(context: Context) {
         }
         NPLogger.d(
             TAG,
-            "Upload data size: ${SyncDataSerializer.getDataSize(data, useDataSaver)} bytes (DataSaver: $useDataSaver, WebDAV)"
+            "Upload data size: ${content.size} bytes (DataSaver: $useDataSaver, WebDAV)"
         )
 
         val uploadResult = uploadFileWithConcurrencyFallback(

--- a/app/src/test/java/moe/ouom/neriplayer/data/sync/github/SyncDataChangeDetectorTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/sync/github/SyncDataChangeDetectorTest.kt
@@ -94,6 +94,54 @@ class SyncDataChangeDetectorTest {
     }
 
     @Test
+    fun `equivalent causal range does not trigger a sync echo`() {
+        val remote = syncData(
+            playlists = listOf(
+                playlist(
+                    song(1).copy(
+                        syncMembershipTokens = listOf(token(1L), token(2L), token(3L))
+                    )
+                )
+            )
+        )
+        val merged = syncData(
+            playlists = listOf(
+                playlist(
+                    song(1).copy(
+                        syncMembershipTokens = listOf(
+                            SyncCausalToken("device", 1L, counterEnd = 3L)
+                        )
+                    )
+                )
+            )
+        )
+
+        assertFalse(SyncDataChangeDetector.hasDataChanged(remote, merged))
+    }
+
+    @Test
+    fun `equivalent deletion range does not trigger a sync echo`() {
+        val remote = syncData(
+            playlistSongDeletions = listOf(
+                playlistSongDeletion(1).copy(
+                    removedMembershipTokens = listOf(token(1L), token(2L), token(3L))
+                )
+            )
+        )
+        val merged = syncData(
+            playlistSongDeletions = listOf(
+                playlistSongDeletion(1).copy(
+                    removedMembershipTokens = listOf(
+                        SyncCausalToken("device", 1L, counterEnd = 3L)
+                    )
+                )
+            )
+        )
+
+        assertFalse(SyncDataChangeDetector.hasDataChanged(remote, merged))
+    }
+
+    @Test
     fun `detects sync metadata version upgrade`() {
         val remote = syncData(
             playlists = listOf(

--- a/app/src/test/java/moe/ouom/neriplayer/data/sync/github/SyncDataSerializerBinaryStreamTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/sync/github/SyncDataSerializerBinaryStreamTest.kt
@@ -101,7 +101,7 @@ class SyncDataSerializerBinaryStreamTest {
     }
 
     @Test
-    fun `causal ranges round trip in both transports`() {
+    fun `legacy safe serialization expands ranges for old clients`() {
         val data = SyncData(
             deviceId = "device",
             deviceName = "test",
@@ -129,10 +129,50 @@ class SyncDataSerializerBinaryStreamTest {
                 SyncDataSerializer.serialize(data, useDataSaver)
             )
             assertEquals(
-                listOf(SyncCausalToken("device", 1L, counterEnd = 3L)),
+                listOf(
+                    SyncCausalToken("device", 1L),
+                    SyncCausalToken("device", 2L),
+                    SyncCausalToken("device", 3L)
+                ),
                 decoded.playlists.single().songs.single().syncMembershipTokens
             )
         }
+    }
+
+    @Test
+    fun `range capable serialization keeps compact range explicitly`() {
+        val data = SyncData(
+            deviceId = "device",
+            deviceName = "test",
+            playlists = listOf(
+                SyncPlaylist(
+                    id = 1L,
+                    songs = listOf(
+                        SyncSong(
+                            id = 1L,
+                            syncMembershipTokens = listOf(
+                                SyncCausalToken("device", 1L),
+                                SyncCausalToken("device", 2L),
+                                SyncCausalToken("device", 3L)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val decoded = SyncDataSerializer.deserialize(
+            SyncDataSerializer.serialize(
+                data,
+                useDataSaver = true,
+                compatibility = SyncSerializationCompatibility.RANGE_V1
+            )
+        )
+
+        assertEquals(
+            listOf(SyncCausalToken("device", 1L, counterEnd = 3L)),
+            decoded.playlists.single().songs.single().syncMembershipTokens
+        )
     }
 
     @Test
@@ -172,6 +212,37 @@ class SyncDataSerializerBinaryStreamTest {
                     song = SyncSong(id = 1L, syncMembershipTokens = tokens),
                     playedAt = 1L,
                     deviceId = "device"
+                )
+            )
+        )
+
+        listOf(false, true).forEach { useDataSaver ->
+            assertThrowsAny {
+                SyncDataSerializer.serialize(data, useDataSaver)
+            }
+        }
+    }
+
+    @Test
+    fun `legacy expansion rejects an unbounded range before either upload format`() {
+        val data = SyncData(
+            deviceId = "device",
+            deviceName = "test",
+            playlists = listOf(
+                SyncPlaylist(
+                    id = 1L,
+                    songs = listOf(
+                        SyncSong(
+                            id = 1L,
+                            syncMembershipTokens = listOf(
+                                SyncCausalToken(
+                                    deviceId = "device",
+                                    counter = 1L,
+                                    counterEnd = 8_193L
+                                )
+                            )
+                        )
+                    )
                 )
             )
         )

--- a/app/src/test/java/moe/ouom/neriplayer/data/sync/github/SyncDataSerializerBinaryStreamTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/sync/github/SyncDataSerializerBinaryStreamTest.kt
@@ -176,6 +176,65 @@ class SyncDataSerializerBinaryStreamTest {
     }
 
     @Test
+    fun `legacy expansion rejects a snapshot over the global point budget`() {
+        val data = largeContiguousTokenSnapshot()
+
+        listOf(false, true).forEach { useDataSaver ->
+            assertThrowsAny {
+                SyncDataSerializer.serialize(data, useDataSaver)
+            }
+        }
+    }
+
+    @Test
+    fun `range mode bypasses the legacy point budget without expansion`() {
+        val body = SyncDataSerializer.serialize(
+            largeContiguousTokenSnapshot(),
+            useDataSaver = true,
+            compatibility = SyncSerializationCompatibility.RANGE_V1
+        )
+
+        assertEquals(
+            33,
+            SyncDataSerializer.deserialize(body).playlists.single().songs.size
+        )
+    }
+
+    @Test
+    fun `explicit range size audit reports compact output`() {
+        val data = SyncData(
+            deviceId = "device",
+            deviceName = "test",
+            playlists = listOf(
+                SyncPlaylist(
+                    id = 1L,
+                    songs = listOf(
+                        SyncSong(
+                            id = 1L,
+                            syncMembershipTokens = (1L..256L).map { counter ->
+                                SyncCausalToken("device", counter)
+                            }
+                        )
+                    )
+                )
+            )
+        )
+
+        val legacySize = SyncDataSerializer.getDataSize(
+            data,
+            useDataSaver = true,
+            compatibility = SyncSerializationCompatibility.LEGACY_SAFE
+        )
+        val compactSize = SyncDataSerializer.getDataSize(
+            data,
+            useDataSaver = true,
+            compatibility = SyncSerializationCompatibility.RANGE_V1
+        )
+
+        assertTrue("explicit range output should be smaller", compactSize < legacySize)
+    }
+
+    @Test
     fun `fragmented causal ranges fail before either upload format`() {
         val tokens = (1L..65L).map { counter ->
             SyncCausalToken("device", counter * 2L)
@@ -338,6 +397,28 @@ class SyncDataSerializerBinaryStreamTest {
 
     private fun isGzip(bytes: ByteArray): Boolean =
         bytes.size >= 2 && bytes[0] == gzipMagic0 && bytes[1] == gzipMagic1
+
+    private fun largeContiguousTokenSnapshot(): SyncData = SyncData(
+        deviceId = "device",
+        deviceName = "test",
+        playlists = listOf(
+            SyncPlaylist(
+                id = 1L,
+                songs = (1..33).map { songId ->
+                    SyncSong(
+                        id = songId.toLong(),
+                        syncMembershipTokens = listOf(
+                            SyncCausalToken(
+                                deviceId = "device",
+                                counter = 1L,
+                                counterEnd = 8_192L
+                            )
+                        )
+                    )
+                }
+            )
+        )
+    )
 
     private fun assertThrowsAny(block: () -> Unit) {
         var threw = false

--- a/app/src/test/java/moe/ouom/neriplayer/data/sync/github/SyncDataSerializerBinaryStreamTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/sync/github/SyncDataSerializerBinaryStreamTest.kt
@@ -1,7 +1,9 @@
 package moe.ouom.neriplayer.data.sync.github
 
 import moe.ouom.neriplayer.data.sync.model.SyncData
+import moe.ouom.neriplayer.data.sync.model.SyncCausalToken
 import moe.ouom.neriplayer.data.sync.model.SyncPlaylist
+import moe.ouom.neriplayer.data.sync.model.SyncPlaylistSongDeletion
 import moe.ouom.neriplayer.data.sync.model.SyncRecentPlay
 import moe.ouom.neriplayer.data.sync.model.SyncSong
 import org.junit.Assert.assertArrayEquals
@@ -96,6 +98,130 @@ class SyncDataSerializerBinaryStreamTest {
         assertThrowsAny {
             SyncDataSerializer.serialize(data, useDataSaver = true)
         }
+    }
+
+    @Test
+    fun `causal ranges round trip in both transports`() {
+        val data = SyncData(
+            deviceId = "device",
+            deviceName = "test",
+            playlists = listOf(
+                SyncPlaylist(
+                    id = 1L,
+                    name = "playlist",
+                    songs = listOf(
+                        SyncSong(
+                            id = 1L,
+                            name = "song",
+                            syncMembershipTokens = listOf(
+                                SyncCausalToken("device", 1L),
+                                SyncCausalToken("device", 2L),
+                                SyncCausalToken("device", 3L)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        listOf(false, true).forEach { useDataSaver ->
+            val decoded = SyncDataSerializer.deserialize(
+                SyncDataSerializer.serialize(data, useDataSaver)
+            )
+            assertEquals(
+                listOf(SyncCausalToken("device", 1L, counterEnd = 3L)),
+                decoded.playlists.single().songs.single().syncMembershipTokens
+            )
+        }
+    }
+
+    @Test
+    fun `fragmented causal ranges fail before either upload format`() {
+        val tokens = (1L..65L).map { counter ->
+            SyncCausalToken("device", counter * 2L)
+        }
+        val data = SyncData(
+            deviceId = "device",
+            deviceName = "test",
+            playlists = listOf(
+                SyncPlaylist(
+                    id = 1L,
+                    songs = listOf(SyncSong(id = 1L, syncMembershipTokens = tokens))
+                )
+            )
+        )
+
+        listOf(false, true).forEach { useDataSaver ->
+            assertThrowsAny {
+                SyncDataSerializer.serialize(data, useDataSaver)
+            }
+        }
+    }
+
+    @Test
+    fun `fragmented recent play causal ranges fail before either upload format`() {
+        val tokens = (1L..65L).map { counter ->
+            SyncCausalToken("device", counter * 2L)
+        }
+        val data = SyncData(
+            deviceId = "device",
+            deviceName = "test",
+            recentPlays = listOf(
+                SyncRecentPlay(
+                    songId = 1L,
+                    song = SyncSong(id = 1L, syncMembershipTokens = tokens),
+                    playedAt = 1L,
+                    deviceId = "device"
+                )
+            )
+        )
+
+        listOf(false, true).forEach { useDataSaver ->
+            assertThrowsAny {
+                SyncDataSerializer.serialize(data, useDataSaver)
+            }
+        }
+    }
+
+    @Test
+    fun `too many playlist deletion records fail before either upload format`() {
+        val data = SyncData(
+            deviceId = "device",
+            deviceName = "test",
+            playlistSongDeletions = (0L..5_000L).map { songId ->
+                SyncPlaylistSongDeletion(
+                    playlistId = 1L,
+                    songId = songId,
+                    album = "netease",
+                    deletedAt = songId,
+                    deviceId = "device"
+                )
+            }
+        )
+
+        listOf(false, true).forEach { useDataSaver ->
+            assertThrowsAny {
+                SyncDataSerializer.serialize(data, useDataSaver)
+            }
+        }
+    }
+
+    @Test
+    fun `oversized remote body fails before parsing`() {
+        val oversizedJson = ("{" + "x".repeat(8 * 1024 * 1024) + "}")
+            .toByteArray(Charsets.UTF_8)
+
+        assertThrowsAny {
+            SyncDataSerializer.deserialize(oversizedJson)
+        }
+    }
+
+    @Test
+    fun `json with utf8 bom is decoded after format detection`() {
+        val json = SyncDataSerializer.serialize(sampleData(), useDataSaver = false)
+        val withBom = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte()) + json
+
+        assertMatchesSample(SyncDataSerializer.deserialize(withBom))
     }
 
     // 二进制通道必须保留原始 GZIP 字节, 不能将其转成 UTF-8 文本

--- a/app/src/test/java/moe/ouom/neriplayer/data/sync/github/SyncPlaylistDeletionPolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/sync/github/SyncPlaylistDeletionPolicyTest.kt
@@ -10,6 +10,7 @@ import moe.ouom.neriplayer.data.sync.model.SyncSong
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class SyncPlaylistDeletionPolicyTest {
@@ -44,8 +45,7 @@ class SyncPlaylistDeletionPolicyTest {
         )
         val expected = latest.copy(
             removedMembershipTokens = listOf(
-                token("a", 1L),
-                token("a", 2L),
+                token("a", 1L, counterEnd = 2L),
                 token("b", 1L)
             )
         )
@@ -55,6 +55,33 @@ class SyncPlaylistDeletionPolicyTest {
 
         assertEquals(listOf(expected), localFirst)
         assertEquals(localFirst, remoteFirst)
+    }
+
+    @Test
+    fun `causal range merge is commutative and idempotent`() {
+        val local = deletion(
+            playlistId = 7L,
+            songId = 11L,
+            deletedAt = 100L,
+            removedTokens = listOf(token("device", 1L, counterEnd = 3L))
+        )
+        val remote = deletion(
+            playlistId = 7L,
+            songId = 11L,
+            deletedAt = 200L,
+            removedTokens = listOf(token("device", 4L, counterEnd = 6L))
+        )
+
+        val first = SyncPlaylistDeletionPolicy.mergeDeletions(listOf(local), listOf(remote))
+        val reverse = SyncPlaylistDeletionPolicy.mergeDeletions(listOf(remote), listOf(local))
+        val replayed = SyncPlaylistDeletionPolicy.mergeDeletions(first, first)
+
+        assertEquals(first, reverse)
+        assertEquals(first, replayed)
+        assertEquals(
+            listOf(remote.copy(removedMembershipTokens = listOf(token("device", 1L, counterEnd = 6L)))),
+            first
+        )
     }
 
     @Test
@@ -548,7 +575,7 @@ class SyncPlaylistDeletionPolicyTest {
     }
 
     @Test
-    fun `bounded deletion retention keeps recent legacy and causal tombstones`() {
+    fun `deletion capacity preserves all tombstone classes when within capacity`() {
         val legacy = (1L..6L).map { id ->
             deletion(playlistId = 7L, songId = id, deletedAt = id, deviceId = "legacy")
         }
@@ -564,22 +591,24 @@ class SyncPlaylistDeletionPolicyTest {
 
         val retained = SyncPlaylistDeletionPolicy.limitDeletions(
             deletions = legacy + causal,
-            maxCount = 6
+            maxCount = 12
         )
 
-        assertEquals(6, retained.size)
-        assertEquals(3, retained.count { it.removedMembershipTokens.isEmpty() })
-        assertEquals(3, retained.count { it.removedMembershipTokens.isNotEmpty() })
-        assertEquals(setOf(4L, 5L, 6L), retained.filter {
+        assertEquals(7, retained.size)
+        assertEquals(6, retained.count { it.removedMembershipTokens.isEmpty() })
+        assertEquals(1, retained.count { it.removedMembershipTokens.isNotEmpty() })
+        assertEquals(setOf(1L, 2L, 3L, 4L, 5L, 6L), retained.filter {
             it.removedMembershipTokens.isEmpty()
         }.map { it.songId }.toSet())
-        assertEquals(setOf(14L, 15L, 16L), retained.filter {
-            it.removedMembershipTokens.isNotEmpty()
-        }.map { it.songId }.toSet())
+        assertEquals(
+            listOf(token("causal", 11L, counterEnd = 16L)),
+            retained.single { it.removedMembershipTokens.isNotEmpty() }
+                .removedMembershipTokens
+        )
     }
 
     @Test
-    fun `bounded deletion retention fills unused class capacity`() {
+    fun `deletion capacity keeps unused capacity available without truncation`() {
         val legacy = (1L..2L).map { id ->
             deletion(playlistId = 7L, songId = id, deletedAt = id, deviceId = "legacy")
         }
@@ -595,12 +624,100 @@ class SyncPlaylistDeletionPolicyTest {
 
         val retained = SyncPlaylistDeletionPolicy.limitDeletions(
             deletions = legacy + causal,
-            maxCount = 6
+            maxCount = 8
         )
 
-        assertEquals(6, retained.size)
+        assertEquals(3, retained.size)
         assertEquals(2, retained.count { it.removedMembershipTokens.isEmpty() })
-        assertEquals(4, retained.count { it.removedMembershipTokens.isNotEmpty() })
+        assertEquals(1, retained.count { it.removedMembershipTokens.isNotEmpty() })
+    }
+
+    @Test
+    fun `causal tombstones across songs collapse into one playlist record`() {
+        val deletions = (1L..3L).map { id ->
+            deletion(
+                playlistId = 7L,
+                songId = id,
+                deletedAt = id,
+                removedTokens = listOf(token("device", id))
+            )
+        }
+
+        val retained = SyncPlaylistDeletionPolicy.limitDeletions(
+            deletions = deletions,
+            maxCount = 1
+        )
+
+        assertEquals(1, retained.size)
+        assertEquals(
+            listOf(token("device", 1L, counterEnd = 3L)),
+            retained.single().removedMembershipTokens
+        )
+    }
+
+    @Test
+    fun `deletion capacity overflow is rejected instead of dropping tombstones`() {
+        val deletions = (1L..2L).map { id ->
+            deletion(playlistId = 7L, songId = id, deletedAt = id)
+        }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            SyncPlaylistDeletionPolicy.limitDeletions(deletions, maxCount = 1)
+        }
+    }
+
+    @Test
+    fun `range tombstone removes only observed memberships`() {
+        val observed = token("device", 11L)
+        val concurrent = token("device", 13L)
+        val deletion = deletion(
+            playlistId = 7L,
+            songId = 11L,
+            deletedAt = 200L,
+            removedTokens = listOf(token("device", 10L, counterEnd = 12L))
+        )
+
+        val merged = SyncPlaylistDeletionPolicy.applyDeletions(
+            playlistId = 7L,
+            songs = listOf(
+                syncSong(
+                    id = 11L,
+                    addedAt = 100L,
+                    membershipTokens = listOf(observed, concurrent)
+                )
+            ),
+            deletions = listOf(deletion)
+        )
+
+        assertEquals(
+            listOf(
+                syncSong(
+                    id = 11L,
+                    addedAt = 100L,
+                    membershipTokens = listOf(concurrent)
+                )
+            ),
+            merged
+        )
+    }
+
+    @Test
+    fun `fragmented causal ranges are rejected instead of truncated`() {
+        val fragmented = (1L..65L).map { counter ->
+            deletion(
+                playlistId = 7L,
+                songId = 11L,
+                deletedAt = 200L,
+                removedTokens = listOf(token("device", counter * 2L))
+            )
+        }
+
+        assertThrows(IllegalArgumentException::class.java) {
+            SyncPlaylistDeletionPolicy.limitDeletions(
+                deletions = fragmented,
+                maxCount = 1
+            )
+        }
     }
 
     private fun syncSong(
@@ -641,7 +758,15 @@ class SyncPlaylistDeletionPolicyTest {
         )
     }
 
-    private fun token(deviceId: String, counter: Long): SyncCausalToken {
-        return SyncCausalToken(deviceId = deviceId, counter = counter)
+    private fun token(
+        deviceId: String,
+        counter: Long,
+        counterEnd: Long = 0L
+    ): SyncCausalToken {
+        return SyncCausalToken(
+            deviceId = deviceId,
+            counter = counter,
+            counterEnd = counterEnd
+        )
     }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/data/sync/model/SyncCausalTokenTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/sync/model/SyncCausalTokenTest.kt
@@ -83,4 +83,31 @@ class SyncCausalTokenTest {
         assertFalse(range.contains(SyncCausalToken("device", 13L)))
         assertFalse(range.contains(SyncCausalToken("other", 11L)))
     }
+
+    @Test
+    fun `legacy expansion preserves every observed counter`() {
+        val tokens = listOf(
+            SyncCausalToken("device", 1L, counterEnd = 3L),
+            SyncCausalToken("device", 7L)
+        )
+
+        assertEquals(
+            listOf(
+                SyncCausalToken("device", 1L),
+                SyncCausalToken("device", 2L),
+                SyncCausalToken("device", 3L),
+                SyncCausalToken("device", 7L)
+            ),
+            tokens.expandedLegacyCompatibleSyncCausalTokens()
+        )
+    }
+
+    @Test
+    fun `legacy expansion rejects a range beyond the compatibility budget`() {
+        val tokens = listOf(SyncCausalToken("device", 1L, counterEnd = 8_193L))
+
+        assertFalse(runCatching {
+            tokens.expandedLegacyCompatibleSyncCausalTokens()
+        }.isSuccess)
+    }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/data/sync/model/SyncCausalTokenTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/sync/model/SyncCausalTokenTest.kt
@@ -53,4 +53,34 @@ class SyncCausalTokenTest {
             tokens.normalizedSyncCausalTokens()
         )
     }
+
+    @Test
+    fun `normalization compacts contiguous counters without widening gaps`() {
+        val tokens = listOf(
+            SyncCausalToken("device", 4L),
+            SyncCausalToken("device", 1L),
+            SyncCausalToken("device", 2L),
+            SyncCausalToken("device", 3L),
+            SyncCausalToken("device", 7L),
+            SyncCausalToken("device", 5L)
+        )
+
+        assertEquals(
+            listOf(
+                SyncCausalToken("device", 1L, counterEnd = 5L),
+                SyncCausalToken("device", 7L)
+            ),
+            tokens.compactedSyncCausalTokens()
+        )
+    }
+
+    @Test
+    fun `range containment preserves exact observed remove semantics`() {
+        val range = SyncCausalToken("device", 10L, counterEnd = 12L)
+
+        assertTrue(range.contains(SyncCausalToken("device", 10L)))
+        assertTrue(range.contains(SyncCausalToken("device", 12L)))
+        assertFalse(range.contains(SyncCausalToken("device", 13L)))
+        assertFalse(range.contains(SyncCausalToken("other", 11L)))
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 用户可见行为

- 同步数据支持因果令牌范围压缩，减少重复令牌和存储空间。
- 删除记录在容量不足时不再静默丢弃，而是合并可压缩范围；压缩后仍超限时报告错误。
- 删除和歌曲合并支持令牌范围重叠判断。
- 上传日志记录实际序列化后的字节数。

## 兼容性影响

- 默认使用 `LEGACY_SAFE` 模式，将范围令牌展开为旧客户端可识别的单点令牌。
- `RANGE_V1` 模式保留压缩范围。
- 反序列化拒绝超出限制的远端数据，并支持移除 UTF-8 BOM。
- `serialize` 和 `getDataSize` 新增可选的兼容性参数，默认行为保持旧格式兼容。

## 测试

- 新增因果令牌范围压缩、包含、重叠、展开和容量限制测试。
- 新增同步回声避免测试。
- 新增删除墓碑合并、容量溢出和范围删除测试。
- 新增二进制序列化兼容性、超限校验和 UTF-8 BOM 解码测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->