### PR TITLE
feat(ui): refine explore and library layout

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/tab/ExploreHorizontalEdgeFadeTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/ui/screen/tab/ExploreHorizontalEdgeFadeTest.kt
@@ -1,0 +1,79 @@
+package moe.ouom.neriplayer.ui.screen.tab
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlin.math.abs
+import moe.ouom.neriplayer.testutil.assumeComposeHostAvailable
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ExploreHorizontalEdgeFadeTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun assumeDeviceUnlocked() {
+        assumeComposeHostAvailable()
+    }
+
+    @Test
+    fun endFadeRevealsBackgroundInsteadOfPaintingThemeColor() {
+        composeRule.setContent {
+            Box(
+                modifier = Modifier
+                    .size(width = 240.dp, height = 48.dp)
+                    .background(BackgroundColor)
+                    .testTag(BackgroundTag)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .exploreHorizontalEdgeFade(
+                            showStartFade = false,
+                            showEndFade = true,
+                            fadeWidth = 48.dp
+                        )
+                        .background(ContentColor)
+                )
+            }
+        }
+
+        composeRule.waitForIdle()
+        val image = composeRule.onNodeWithTag(BackgroundTag).captureToImage().toPixelMap()
+        val sampleY = image.height / 2
+
+        assertColorClose(ContentColor, image[image.width / 2, sampleY])
+        assertColorClose(BackgroundColor, image[image.width - 2, sampleY])
+    }
+
+    private fun assertColorClose(expected: Color, actual: Color) {
+        assertTrue(
+            "Expected $expected but was $actual",
+            abs(expected.red - actual.red) <= ColorTolerance &&
+                abs(expected.green - actual.green) <= ColorTolerance &&
+                abs(expected.blue - actual.blue) <= ColorTolerance
+        )
+    }
+
+    private companion object {
+        const val BackgroundTag = "explore_edge_fade_background"
+        const val ColorTolerance = 0.04f
+        val BackgroundColor = Color(0xFF8E2842)
+        val ContentColor = Color(0xFF185FA5)
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/ExploreScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/ExploreScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -128,7 +129,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
@@ -1352,8 +1357,45 @@ private fun ExploreSearchHistoryRow(
                     }
                 }
             }
+            val historyListState = rememberLazyListState()
+            val showStartFade by remember(historyListState) {
+                derivedStateOf { historyListState.canScrollBackward }
+            }
+            val showEndFade by remember(historyListState) {
+                derivedStateOf { historyListState.canScrollForward }
+            }
+            val edgeFadeColor = MaterialTheme.colorScheme.background
             LazyRow(
-                modifier = Modifier.fillMaxWidth(),
+                state = historyListState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .drawWithContent {
+                        drawContent()
+                        val fadeWidth = 28.dp.toPx().coerceAtMost(size.width / 2f)
+                        if (fadeWidth <= 0f) return@drawWithContent
+                        if (showStartFade) {
+                            drawRect(
+                                brush = Brush.horizontalGradient(
+                                    colors = listOf(edgeFadeColor, edgeFadeColor.copy(alpha = 0f)),
+                                    startX = 0f,
+                                    endX = fadeWidth
+                                ),
+                                topLeft = Offset.Zero,
+                                size = Size(fadeWidth, size.height)
+                            )
+                        }
+                        if (showEndFade) {
+                            drawRect(
+                                brush = Brush.horizontalGradient(
+                                    colors = listOf(edgeFadeColor.copy(alpha = 0f), edgeFadeColor),
+                                    startX = size.width - fadeWidth,
+                                    endX = size.width
+                                ),
+                                topLeft = Offset(size.width - fadeWidth, 0f),
+                                size = Size(fadeWidth, size.height)
+                            )
+                        }
+                    },
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 itemsIndexed(history) { _, item ->

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/ExploreScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/ExploreScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -62,6 +61,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
@@ -597,8 +597,6 @@ fun ExploreScreen(
         ) {
             vm.search(effectiveSearchKeyword, displayQuery = displayQuery)
         }
-        delay(EXPLORE_HISTORY_RECORD_DEBOUNCE_MS - SEARCH_INPUT_DEBOUNCE_MS)
-        queueExploreSearchRecord(searchQuery)
     }
 
     LaunchedEffect(ui.selectedSearchSource) {
@@ -1354,11 +1352,11 @@ private fun ExploreSearchHistoryRow(
                     }
                 }
             }
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+            LazyRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                history.forEach { item ->
+                itemsIndexed(history) { _, item ->
                     ExploreSearchHistoryChip(
                         text = item,
                         onClick = { onHistoryClick(item) }
@@ -1532,15 +1530,14 @@ internal fun ExploreSearchTypeBar(
     ) { displayedSource ->
         when (displayedSource) {
             SearchSource.NETEASE -> {
-                FlowRow(
+                LazyRow(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = 8.dp)
                         .testTag(EXPLORE_NETEASE_SEARCH_TYPE_BAR_TAG),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    NeteaseExploreSearchType.entries.forEach { type ->
+                    itemsIndexed(NeteaseExploreSearchType.entries) { _, type ->
                         ExploreTagChip(
                             label = neteaseSearchTypeLabel(type),
                             icon = neteaseSearchTypeIcon(type),
@@ -1559,15 +1556,14 @@ internal fun ExploreSearchTypeBar(
             }
 
             SearchSource.YOUTUBE_MUSIC -> {
-                FlowRow(
+                LazyRow(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = 8.dp)
                         .testTag(EXPLORE_YOUTUBE_SEARCH_TYPE_BAR_TAG),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    YouTubeExploreSearchType.entries.forEach { type ->
+                    itemsIndexed(YouTubeExploreSearchType.entries) { _, type ->
                         ExploreTagChip(
                             label = youtubeSearchTypeLabel(type),
                             icon = youtubeSearchTypeIcon(type),
@@ -1591,7 +1587,6 @@ internal fun ExploreSearchTypeBar(
 }
 
 private const val EXPLORE_HISTORY_DISPLAY_LIMIT = 15
-private const val EXPLORE_HISTORY_RECORD_DEBOUNCE_MS = 1_200L
 private val EXPLORE_SEARCH_TYPE_BAR_SOURCES = setOf(
     SearchSource.NETEASE,
     SearchSource.YOUTUBE_MUSIC
@@ -1637,14 +1632,13 @@ private fun NeteaseDefaultContent(
     ) {
         item(span = { GridItemSpan(maxLineSpan) }) {
             Column(Modifier.fillMaxWidth()) {
-                val displayCount = if (ui.expanded) tagKeys.size else 12
-                val displayKeys = tagKeys.take(displayCount)
-                val displayLabels = tagLabels.take(displayCount)
-                FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                val displayKeys = tagKeys
+                val displayLabels = tagLabels
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    displayKeys.forEachIndexed { index, tagKey ->
+                    itemsIndexed(displayKeys) { index, tagKey ->
                         val selected = (ui.selectedTag == tagKey)
                         ExploreTagChip(
                             label = displayLabels[index],
@@ -1654,11 +1648,6 @@ private fun NeteaseDefaultContent(
                             unselectedAlpha = tagChipUnselectedAlpha,
                             borderAlpha = tagChipBorderAlpha
                         )
-                    }
-                }
-                Box(Modifier.fillMaxWidth(), Alignment.Center) {
-                    HapticTextButton(onClick = { vm.toggleExpanded() }) {
-                        Text(if (ui.expanded) stringResource(R.string.explore_collapse) else stringResource(R.string.explore_expand))
                     }
                 }
                 Box(

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/ExploreScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/ExploreScreen.kt
@@ -1676,6 +1676,13 @@ private fun NeteaseDefaultContent(
     val gridHorizontalPadding = if (isTabletLayout) 56.dp else 16.dp
     val gridMinCellSize = if (isTabletLayout) 170.dp else 150.dp
     val gridSpacing = if (isTabletLayout) 16.dp else 12.dp
+    val tagListState = rememberLazyListState()
+    val showTagStartFade by remember(tagListState) {
+        derivedStateOf { tagListState.canScrollBackward }
+    }
+    val showTagEndFade by remember(tagListState) {
+        derivedStateOf { tagListState.canScrollForward }
+    }
     LazyVerticalGrid(
         state = gridState,
         columns = GridCells.Adaptive(gridMinCellSize),
@@ -1693,7 +1700,13 @@ private fun NeteaseDefaultContent(
                 val displayKeys = tagKeys
                 val displayLabels = tagLabels
                 LazyRow(
-                    modifier = Modifier.fillMaxWidth(),
+                    state = tagListState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .exploreHorizontalEdgeFade(
+                            showStartFade = showTagStartFade,
+                            showEndFade = showTagEndFade
+                        ),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     itemsIndexed(displayKeys) { index, tagKey ->

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/ExploreScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/ExploreScreen.kt
@@ -130,10 +130,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
@@ -149,6 +152,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -1364,38 +1368,14 @@ private fun ExploreSearchHistoryRow(
             val showEndFade by remember(historyListState) {
                 derivedStateOf { historyListState.canScrollForward }
             }
-            val edgeFadeColor = MaterialTheme.colorScheme.background
             LazyRow(
                 state = historyListState,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .drawWithContent {
-                        drawContent()
-                        val fadeWidth = 28.dp.toPx().coerceAtMost(size.width / 2f)
-                        if (fadeWidth <= 0f) return@drawWithContent
-                        if (showStartFade) {
-                            drawRect(
-                                brush = Brush.horizontalGradient(
-                                    colors = listOf(edgeFadeColor, edgeFadeColor.copy(alpha = 0f)),
-                                    startX = 0f,
-                                    endX = fadeWidth
-                                ),
-                                topLeft = Offset.Zero,
-                                size = Size(fadeWidth, size.height)
-                            )
-                        }
-                        if (showEndFade) {
-                            drawRect(
-                                brush = Brush.horizontalGradient(
-                                    colors = listOf(edgeFadeColor.copy(alpha = 0f), edgeFadeColor),
-                                    startX = size.width - fadeWidth,
-                                    endX = size.width
-                                ),
-                                topLeft = Offset(size.width - fadeWidth, 0f),
-                                size = Size(fadeWidth, size.height)
-                            )
-                        }
-                    },
+                    .exploreHorizontalEdgeFade(
+                        showStartFade = showStartFade,
+                        showEndFade = showEndFade
+                    ),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 itemsIndexed(history) { _, item ->
@@ -1408,6 +1388,42 @@ private fun ExploreSearchHistoryRow(
         }
     }
 }
+
+internal fun Modifier.exploreHorizontalEdgeFade(
+    showStartFade: Boolean,
+    showEndFade: Boolean,
+    fadeWidth: Dp = 28.dp
+): Modifier = this
+    .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+    .drawWithContent {
+        drawContent()
+        val resolvedFadeWidth = fadeWidth.toPx().coerceAtMost(size.width / 2f)
+        if (resolvedFadeWidth <= 0f) return@drawWithContent
+        if (showStartFade) {
+            drawRect(
+                brush = Brush.horizontalGradient(
+                    colors = listOf(Color.Transparent, Color.Black),
+                    startX = 0f,
+                    endX = resolvedFadeWidth
+                ),
+                topLeft = Offset.Zero,
+                size = Size(resolvedFadeWidth, size.height),
+                blendMode = BlendMode.DstIn
+            )
+        }
+        if (showEndFade) {
+            drawRect(
+                brush = Brush.horizontalGradient(
+                    colors = listOf(Color.Black, Color.Transparent),
+                    startX = size.width - resolvedFadeWidth,
+                    endX = size.width
+                ),
+                topLeft = Offset(size.width - resolvedFadeWidth, 0f),
+                size = Size(resolvedFadeWidth, size.height),
+                blendMode = BlendMode.DstIn
+            )
+        }
+    }
 
 @Composable
 private fun ExploreSearchHistoryChip(

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/LibraryScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/LibraryScreen.kt
@@ -30,6 +30,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -47,6 +48,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -70,6 +72,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.ListItem
@@ -77,7 +80,6 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.PrimaryScrollableTabRow
-import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarState
@@ -99,6 +101,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -1958,57 +1961,57 @@ private fun LocalArtistSortMenuItem(
 }
 
 @Composable
+private fun LibraryCategoryFilterChip(
+    selected: Boolean,
+    onClick: () -> Unit,
+    icon: ImageVector,
+    label: String
+) {
+    FilterChip(
+        selected = selected,
+        onClick = onClick,
+        label = {
+            Text(
+                text = label,
+                maxLines = 1
+            )
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    )
+}
+
+@Composable
 private fun LocalCategoryTabs(
     selectedCategory: Int,
     onPlaylistSelected: () -> Unit,
     onArtistSelected: () -> Unit
 ) {
-    Card(
-        shape = RoundedCornerShape(24.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = Color.Transparent
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 6.dp)
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        AdvancedGlassSurface(
-            role = AdvancedGlassRole.ScreenTopTab,
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(24.dp),
-            fallbackColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.28f),
-            tintColor = MaterialTheme.colorScheme.surfaceVariant
-        ) {
-            PrimaryTabRow(
-                selectedTabIndex = selectedCategory,
-                containerColor = Color.Transparent,
-                contentColor = MaterialTheme.colorScheme.primary
-            ) {
-                Tab(
-                    selected = selectedCategory == LOCAL_CATEGORY_PLAYLIST,
-                    onClick = onPlaylistSelected,
-                    text = { Text(stringResource(R.string.library_favorite_tab_playlists)) },
-                    icon = {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.QueueMusic,
-                            contentDescription = null
-                        )
-                    }
-                )
-                Tab(
-                    selected = selectedCategory == LOCAL_CATEGORY_ARTIST,
-                    onClick = onArtistSelected,
-                    text = { Text(stringResource(R.string.library_favorite_tab_artists)) },
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Filled.AccountCircle,
-                            contentDescription = null
-                        )
-                    }
-                )
-            }
-        }
+        LibraryCategoryFilterChip(
+            selected = selectedCategory == LOCAL_CATEGORY_PLAYLIST,
+            onClick = onPlaylistSelected,
+            icon = Icons.AutoMirrored.Filled.QueueMusic,
+            label = stringResource(R.string.library_favorite_tab_playlists)
+        )
+        LibraryCategoryFilterChip(
+            selected = selectedCategory == LOCAL_CATEGORY_ARTIST,
+            onClick = onArtistSelected,
+            icon = Icons.Filled.AccountCircle,
+            label = stringResource(R.string.library_favorite_tab_artists)
+        )
     }
 }
 
@@ -2345,52 +2348,26 @@ private fun NeteaseCategoryTabs(
     selectedCategory: Int,
     onCategoryChange: (Int) -> Unit
 ) {
-    Card(
-        shape = RoundedCornerShape(24.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = Color.Transparent
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 6.dp)
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        AdvancedGlassSurface(
-            role = AdvancedGlassRole.ScreenTopTab,
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(24.dp),
-            fallbackColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.28f),
-            tintColor = MaterialTheme.colorScheme.surfaceVariant
-        ) {
-            PrimaryTabRow(
-                selectedTabIndex = selectedCategory,
-                containerColor = Color.Transparent,
-                contentColor = MaterialTheme.colorScheme.primary
-            ) {
-                Tab(
-                    selected = selectedCategory == NETEASE_CATEGORY_PLAYLIST,
-                    onClick = { onCategoryChange(NETEASE_CATEGORY_PLAYLIST) },
-                    text = { Text(stringResource(R.string.library_netease_tab_playlists)) },
-                    icon = {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.QueueMusic,
-                            contentDescription = null
-                        )
-                    }
-                )
-                Tab(
-                    selected = selectedCategory == NETEASE_CATEGORY_ALBUM,
-                    onClick = { onCategoryChange(NETEASE_CATEGORY_ALBUM) },
-                    text = { Text(stringResource(R.string.library_netease_tab_albums)) },
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Filled.Album,
-                            contentDescription = null
-                        )
-                    }
-                )
-            }
-        }
+        LibraryCategoryFilterChip(
+            selected = selectedCategory == NETEASE_CATEGORY_PLAYLIST,
+            onClick = { onCategoryChange(NETEASE_CATEGORY_PLAYLIST) },
+            icon = Icons.AutoMirrored.Filled.QueueMusic,
+            label = stringResource(R.string.library_netease_tab_playlists)
+        )
+        LibraryCategoryFilterChip(
+            selected = selectedCategory == NETEASE_CATEGORY_ALBUM,
+            onClick = { onCategoryChange(NETEASE_CATEGORY_ALBUM) },
+            icon = Icons.Filled.Album,
+            label = stringResource(R.string.library_netease_tab_albums)
+        )
     }
 }
 
@@ -2960,78 +2937,47 @@ private fun FavoritePlaylistList(
         val cardShape = RoundedCornerShape(12.dp)
         val displayedFavorites = filterFavoritePlaylists(reorderableFavorites, favoriteSearchQuery)
         item(key = "favorite_category_tabs") {
-            Card(
-                shape = RoundedCornerShape(24.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = Color.Transparent
-                ),
-                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 8.dp, vertical = 6.dp)
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                AdvancedGlassSurface(
-                    role = AdvancedGlassRole.ScreenTopTab,
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(24.dp),
-                    fallbackColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.28f),
-                    tintColor = MaterialTheme.colorScheme.surfaceVariant
-                ) {
-                    PrimaryTabRow(
-                        selectedTabIndex = selectedFavoriteCategory,
-                        containerColor = Color.Transparent,
-                        contentColor = MaterialTheme.colorScheme.primary
-                    ) {
-                        Tab(
-                            selected = selectedFavoriteCategory == FAVORITE_CATEGORY_PLAYLIST,
-                            onClick = {
-                                if (selectedFavoriteCategory != FAVORITE_CATEGORY_PLAYLIST) {
-                                    selectedFavoriteCategory = FAVORITE_CATEGORY_PLAYLIST
-                                    exitEditMode()
-                                }
-                            },
-                            text = { Text(stringResource(R.string.library_favorite_tab_playlists)) },
-                            icon = {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Filled.QueueMusic,
-                                    contentDescription = null
-                                )
-                            }
-                        )
-                        Tab(
-                            selected = selectedFavoriteCategory == FAVORITE_CATEGORY_ARTIST,
-                            onClick = {
-                                if (selectedFavoriteCategory != FAVORITE_CATEGORY_ARTIST) {
-                                    selectedFavoriteCategory = FAVORITE_CATEGORY_ARTIST
-                                    exitEditMode()
-                                }
-                            },
-                            text = { Text(stringResource(R.string.library_favorite_tab_artists)) },
-                            icon = {
-                                Icon(
-                                    imageVector = Icons.Filled.AccountCircle,
-                                    contentDescription = null
-                                )
-                            }
-                        )
-                        Tab(
-                            selected = selectedFavoriteCategory == FAVORITE_CATEGORY_HOT,
-                            onClick = {
-                                if (selectedFavoriteCategory != FAVORITE_CATEGORY_HOT) {
-                                    selectedFavoriteCategory = FAVORITE_CATEGORY_HOT
-                                    exitEditMode()
-                                }
-                            },
-                            text = { Text(stringResource(R.string.library_favorite_tab_hot)) },
-                            icon = {
-                                Icon(
-                                    imageVector = Icons.Outlined.Bolt,
-                                    contentDescription = null
-                                )
-                            }
-                        )
-                    }
-                }
+                LibraryCategoryFilterChip(
+                    selected = selectedFavoriteCategory == FAVORITE_CATEGORY_PLAYLIST,
+                    onClick = {
+                        if (selectedFavoriteCategory != FAVORITE_CATEGORY_PLAYLIST) {
+                            selectedFavoriteCategory = FAVORITE_CATEGORY_PLAYLIST
+                            exitEditMode()
+                        }
+                    },
+                    icon = Icons.AutoMirrored.Filled.QueueMusic,
+                    label = stringResource(R.string.library_favorite_tab_playlists)
+                )
+                LibraryCategoryFilterChip(
+                    selected = selectedFavoriteCategory == FAVORITE_CATEGORY_ARTIST,
+                    onClick = {
+                        if (selectedFavoriteCategory != FAVORITE_CATEGORY_ARTIST) {
+                            selectedFavoriteCategory = FAVORITE_CATEGORY_ARTIST
+                            exitEditMode()
+                        }
+                    },
+                    icon = Icons.Filled.AccountCircle,
+                    label = stringResource(R.string.library_favorite_tab_artists)
+                )
+                LibraryCategoryFilterChip(
+                    selected = selectedFavoriteCategory == FAVORITE_CATEGORY_HOT,
+                    onClick = {
+                        if (selectedFavoriteCategory != FAVORITE_CATEGORY_HOT) {
+                            selectedFavoriteCategory = FAVORITE_CATEGORY_HOT
+                            exitEditMode()
+                        }
+                    },
+                    icon = Icons.Outlined.Bolt,
+                    label = stringResource(R.string.library_favorite_tab_hot)
+                )
             }
         }
         if (!sortMode && !isHotCategory) {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/LibraryScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/LibraryScreen.kt
@@ -30,7 +30,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -48,7 +47,6 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -72,7 +70,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.ListItem
@@ -80,6 +77,7 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.PrimaryScrollableTabRow
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarState
@@ -101,7 +99,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -1961,57 +1958,57 @@ private fun LocalArtistSortMenuItem(
 }
 
 @Composable
-private fun LibraryCategoryFilterChip(
-    selected: Boolean,
-    onClick: () -> Unit,
-    icon: ImageVector,
-    label: String
-) {
-    FilterChip(
-        selected = selected,
-        onClick = onClick,
-        label = {
-            Text(
-                text = label,
-                maxLines = 1
-            )
-        },
-        leadingIcon = {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                modifier = Modifier.size(18.dp)
-            )
-        }
-    )
-}
-
-@Composable
 private fun LocalCategoryTabs(
     selectedCategory: Int,
     onPlaylistSelected: () -> Unit,
     onArtistSelected: () -> Unit
 ) {
-    Row(
+    Card(
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = Color.Transparent
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         modifier = Modifier
             .fillMaxWidth()
-            .horizontalScroll(rememberScrollState())
-            .padding(horizontal = 8.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .padding(horizontal = 8.dp, vertical = 6.dp)
     ) {
-        LibraryCategoryFilterChip(
-            selected = selectedCategory == LOCAL_CATEGORY_PLAYLIST,
-            onClick = onPlaylistSelected,
-            icon = Icons.AutoMirrored.Filled.QueueMusic,
-            label = stringResource(R.string.library_favorite_tab_playlists)
-        )
-        LibraryCategoryFilterChip(
-            selected = selectedCategory == LOCAL_CATEGORY_ARTIST,
-            onClick = onArtistSelected,
-            icon = Icons.Filled.AccountCircle,
-            label = stringResource(R.string.library_favorite_tab_artists)
-        )
+        AdvancedGlassSurface(
+            role = AdvancedGlassRole.ScreenTopTab,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(24.dp),
+            fallbackColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.28f),
+            tintColor = MaterialTheme.colorScheme.surfaceVariant
+        ) {
+            PrimaryTabRow(
+                selectedTabIndex = selectedCategory,
+                containerColor = Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.primary
+            ) {
+                Tab(
+                    selected = selectedCategory == LOCAL_CATEGORY_PLAYLIST,
+                    onClick = onPlaylistSelected,
+                    text = { Text(stringResource(R.string.library_favorite_tab_playlists)) },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.QueueMusic,
+                            contentDescription = null
+                        )
+                    }
+                )
+                Tab(
+                    selected = selectedCategory == LOCAL_CATEGORY_ARTIST,
+                    onClick = onArtistSelected,
+                    text = { Text(stringResource(R.string.library_favorite_tab_artists)) },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.AccountCircle,
+                            contentDescription = null
+                        )
+                    }
+                )
+            }
+        }
     }
 }
 
@@ -2348,26 +2345,52 @@ private fun NeteaseCategoryTabs(
     selectedCategory: Int,
     onCategoryChange: (Int) -> Unit
 ) {
-    Row(
+    Card(
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = Color.Transparent
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
         modifier = Modifier
             .fillMaxWidth()
-            .horizontalScroll(rememberScrollState())
-            .padding(horizontal = 8.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .padding(horizontal = 8.dp, vertical = 6.dp)
     ) {
-        LibraryCategoryFilterChip(
-            selected = selectedCategory == NETEASE_CATEGORY_PLAYLIST,
-            onClick = { onCategoryChange(NETEASE_CATEGORY_PLAYLIST) },
-            icon = Icons.AutoMirrored.Filled.QueueMusic,
-            label = stringResource(R.string.library_netease_tab_playlists)
-        )
-        LibraryCategoryFilterChip(
-            selected = selectedCategory == NETEASE_CATEGORY_ALBUM,
-            onClick = { onCategoryChange(NETEASE_CATEGORY_ALBUM) },
-            icon = Icons.Filled.Album,
-            label = stringResource(R.string.library_netease_tab_albums)
-        )
+        AdvancedGlassSurface(
+            role = AdvancedGlassRole.ScreenTopTab,
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(24.dp),
+            fallbackColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.28f),
+            tintColor = MaterialTheme.colorScheme.surfaceVariant
+        ) {
+            PrimaryTabRow(
+                selectedTabIndex = selectedCategory,
+                containerColor = Color.Transparent,
+                contentColor = MaterialTheme.colorScheme.primary
+            ) {
+                Tab(
+                    selected = selectedCategory == NETEASE_CATEGORY_PLAYLIST,
+                    onClick = { onCategoryChange(NETEASE_CATEGORY_PLAYLIST) },
+                    text = { Text(stringResource(R.string.library_netease_tab_playlists)) },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.QueueMusic,
+                            contentDescription = null
+                        )
+                    }
+                )
+                Tab(
+                    selected = selectedCategory == NETEASE_CATEGORY_ALBUM,
+                    onClick = { onCategoryChange(NETEASE_CATEGORY_ALBUM) },
+                    text = { Text(stringResource(R.string.library_netease_tab_albums)) },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.Album,
+                            contentDescription = null
+                        )
+                    }
+                )
+            }
+        }
     }
 }
 
@@ -2937,47 +2960,78 @@ private fun FavoritePlaylistList(
         val cardShape = RoundedCornerShape(12.dp)
         val displayedFavorites = filterFavoritePlaylists(reorderableFavorites, favoriteSearchQuery)
         item(key = "favorite_category_tabs") {
-            Row(
+            Card(
+                shape = RoundedCornerShape(24.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = Color.Transparent
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .horizontalScroll(rememberScrollState())
-                    .padding(horizontal = 8.dp, vertical = 4.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically
+                    .padding(horizontal = 8.dp, vertical = 6.dp)
             ) {
-                LibraryCategoryFilterChip(
-                    selected = selectedFavoriteCategory == FAVORITE_CATEGORY_PLAYLIST,
-                    onClick = {
-                        if (selectedFavoriteCategory != FAVORITE_CATEGORY_PLAYLIST) {
-                            selectedFavoriteCategory = FAVORITE_CATEGORY_PLAYLIST
-                            exitEditMode()
-                        }
-                    },
-                    icon = Icons.AutoMirrored.Filled.QueueMusic,
-                    label = stringResource(R.string.library_favorite_tab_playlists)
-                )
-                LibraryCategoryFilterChip(
-                    selected = selectedFavoriteCategory == FAVORITE_CATEGORY_ARTIST,
-                    onClick = {
-                        if (selectedFavoriteCategory != FAVORITE_CATEGORY_ARTIST) {
-                            selectedFavoriteCategory = FAVORITE_CATEGORY_ARTIST
-                            exitEditMode()
-                        }
-                    },
-                    icon = Icons.Filled.AccountCircle,
-                    label = stringResource(R.string.library_favorite_tab_artists)
-                )
-                LibraryCategoryFilterChip(
-                    selected = selectedFavoriteCategory == FAVORITE_CATEGORY_HOT,
-                    onClick = {
-                        if (selectedFavoriteCategory != FAVORITE_CATEGORY_HOT) {
-                            selectedFavoriteCategory = FAVORITE_CATEGORY_HOT
-                            exitEditMode()
-                        }
-                    },
-                    icon = Icons.Outlined.Bolt,
-                    label = stringResource(R.string.library_favorite_tab_hot)
-                )
+                AdvancedGlassSurface(
+                    role = AdvancedGlassRole.ScreenTopTab,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(24.dp),
+                    fallbackColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.28f),
+                    tintColor = MaterialTheme.colorScheme.surfaceVariant
+                ) {
+                    PrimaryTabRow(
+                        selectedTabIndex = selectedFavoriteCategory,
+                        containerColor = Color.Transparent,
+                        contentColor = MaterialTheme.colorScheme.primary
+                    ) {
+                        Tab(
+                            selected = selectedFavoriteCategory == FAVORITE_CATEGORY_PLAYLIST,
+                            onClick = {
+                                if (selectedFavoriteCategory != FAVORITE_CATEGORY_PLAYLIST) {
+                                    selectedFavoriteCategory = FAVORITE_CATEGORY_PLAYLIST
+                                    exitEditMode()
+                                }
+                            },
+                            text = { Text(stringResource(R.string.library_favorite_tab_playlists)) },
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.QueueMusic,
+                                    contentDescription = null
+                                )
+                            }
+                        )
+                        Tab(
+                            selected = selectedFavoriteCategory == FAVORITE_CATEGORY_ARTIST,
+                            onClick = {
+                                if (selectedFavoriteCategory != FAVORITE_CATEGORY_ARTIST) {
+                                    selectedFavoriteCategory = FAVORITE_CATEGORY_ARTIST
+                                    exitEditMode()
+                                }
+                            },
+                            text = { Text(stringResource(R.string.library_favorite_tab_artists)) },
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.Filled.AccountCircle,
+                                    contentDescription = null
+                                )
+                            }
+                        )
+                        Tab(
+                            selected = selectedFavoriteCategory == FAVORITE_CATEGORY_HOT,
+                            onClick = {
+                                if (selectedFavoriteCategory != FAVORITE_CATEGORY_HOT) {
+                                    selectedFavoriteCategory = FAVORITE_CATEGORY_HOT
+                                    exitEditMode()
+                                }
+                            },
+                            text = { Text(stringResource(R.string.library_favorite_tab_hot)) },
+                            icon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.Bolt,
+                                    contentDescription = null
+                                )
+                            }
+                        )
+                    }
+                }
             }
         }
         if (!sortMode && !isHotCategory) {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/ExploreViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/ExploreViewModel.kt
@@ -168,7 +168,6 @@ sealed class ExploreSearchResult {
 }
 
 data class ExploreUiState(
-    val expanded: Boolean = false,
     val loading: Boolean = false,
     val error: String? = null,
     val playlists: List<PlaylistSummary> = emptyList(),
@@ -630,10 +629,6 @@ class ExploreViewModel(application: Application) : AndroidViewModel(application)
             return
         }
         _uiState.value = transform(_uiState.value)
-    }
-
-    fun toggleExpanded() {
-        _uiState.value = _uiState.value.copy(expanded = !_uiState.value.expanded)
     }
 
     fun loadHighQuality(cat: String? = null) {

--- a/app/src/main/java/moe/ouom/neriplayer/util/media/ImageUtil.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/util/media/ImageUtil.kt
@@ -32,6 +32,7 @@ import coil.transform.Transformation
 import moe.ouom.neriplayer.data.traffic.isOfflineModeNow
 
 private const val DEFAULT_LOCAL_IMAGE_REQUEST_SIZE_PX = 512
+private const val DEFAULT_IMAGE_CROSSFADE_DURATION_MILLIS = 180
 
 /**
  * 创建支持离线缓存的图片请求
@@ -41,7 +42,7 @@ fun offlineCachedImageRequest(
     data: Any?,
     sizePx: Int? = null,
     allowHardware: Boolean = true,
-    crossfade: Boolean = false,
+    crossfade: Boolean = true,
     offlineMode: Boolean = context.isOfflineModeNow(),
     transformations: List<Transformation> = emptyList()
 ): ImageRequest {
@@ -52,7 +53,6 @@ fun offlineCachedImageRequest(
     val builder = ImageRequest.Builder(context)
         .data(data)
         .allowHardware(resolvedAllowHardware)
-        .crossfade(crossfade)
         .diskCachePolicy(CachePolicy.ENABLED)
         .memoryCachePolicy(CachePolicy.ENABLED)
         .networkCachePolicy(if (offlineMode && remoteSource) CachePolicy.DISABLED else CachePolicy.ENABLED)
@@ -66,6 +66,11 @@ fun offlineCachedImageRequest(
     }
     if (transformations.isNotEmpty()) {
         builder.transformations(transformations)
+    }
+    if (crossfade) {
+        builder.crossfade(DEFAULT_IMAGE_CROSSFADE_DURATION_MILLIS)
+    } else {
+        builder.crossfade(false)
     }
     return builder.build()
 }
@@ -82,7 +87,6 @@ fun fastScrollableImageRequest(
         .data(data)
         .size(sizePx)
         .precision(Precision.INEXACT)
-        .crossfade(crossfade)
         .diskCachePolicy(CachePolicy.ENABLED)
         .memoryCachePolicy(CachePolicy.ENABLED)
         .networkCachePolicy(if (offlineMode && remoteSource) CachePolicy.DISABLED else CachePolicy.ENABLED)
@@ -90,6 +94,11 @@ fun fastScrollableImageRequest(
         builder
             .allowHardware(false)
             .bitmapConfig(Bitmap.Config.RGB_565)
+    }
+    if (crossfade) {
+        builder.crossfade(DEFAULT_IMAGE_CROSSFADE_DURATION_MILLIS)
+    } else {
+        builder.crossfade(false)
     }
     return builder.build()
 }


### PR DESCRIPTION
## 描述 / Description

本 PR 聚焦探索页与媒体库的 UI 层级和拥挤问题，并改善图片加载反馈。

探索页的搜索历史、网易云/YouTube 搜索类型筛选以及网易云内容标签统一改为单行横向滚动；实时搜索仍保持不变，但只有提交搜索（回车或点击历史项）才会写入搜索历史。网易云内容标签移除不再需要的“展开更多”状态。

媒体库保留平台级 Tab，将本地、收藏、网易云的二级分类改为紧凑的单行 FilterChip，避免两个层级都呈现为大型 Tab。

图片请求默认增加 180ms 淡入，缓存命中时不会人为延迟；显式关闭 crossfade 的调用方行为保持不变。

## 类型 / Type

- [ ] Bug 修复 / Bug Fix
- [ ] 新功能 / New Feature
- [ ] 文档更新 / Documentation Update
- [x] 其他（请描述）/ Other (please describe): UI 层级与可读性提升 / UI hierarchy and readability improvement

## 修复或解决的问题 / Issues Fixed or Closed by This PR

- 搜索历史和搜索类型标签在窄屏上换行、挤占探索内容。
- 网易云内容标签多行排列并配有不再必要的“展开更多”。
- 媒体库平台 Tab 与二级分类视觉层级不清、分类区域拥挤。
- 图片加载完成时缺少轻量的视觉过渡。

## 清单 / Checklist

- [x] 我已阅读并遵循贡献指南 / I have read and followed the contribution guidelines
- [x] 我已在本地测试这些更改 / I have tested these changes locally
- [ ] 我已更新相关文档或注释（如适用） / I have updated relevant documentation or comments (if applicable)
- [x] 我确认本次更改没有破坏任何原有逻辑 / I confirm this change does not break existing behavior
- [x] 我确认本次更改保持向下兼容（如适用） / I confirm this change remains backward compatible (if applicable)
- [x] 我已运行必要的构建、测试或静态检查 / I have run the required build, tests, or static checks
- [x] 我确认没有提交密钥、Token 或其他敏感信息 / I confirm no secrets, tokens, or other sensitive information were committed
- [x] 涉及 UI 变更时，我已补充截图或录屏（如适用） / I have added screenshots or recordings for UI changes (see below)

## 截图与录屏 / Screenshots and Recording

### 官方原版 / Official baseline

探索页 / Explore

<img width="1216" height="2688" alt="Screenshot_20260815_124305" src="https://github.com/user-attachments/assets/51c27d52-2545-4312-9793-4ac29964e651" />

媒体库 / Library

<img width="1216" height="2688" alt="Screenshot_20260815_124308" src="https://github.com/user-attachments/assets/18d1734a-8ef1-445f-a9f9-c9c069dd3c5b" />

### 修改版 / Updated build

探索页 / Explore

<img width="1216" height="2688" alt="Screenshot_20260815_181105" src="https://github.com/user-attachments/assets/6c689283-511e-4a1c-baf6-5dd284c9a6a1" />

媒体库 / Library

<img width="1216" height="2688" alt="Screenshot_20260815_181107" src="https://github.com/user-attachments/assets/c42469f5-feca-4295-946b-adbe3abbcda6" />

### 修改版录屏 / Updated build recording

[查看录屏 / View recording](https://drive.hyzvo.com/f/VZue/Screenrecorder-20260815-181132.mp4)

录屏展示图片加载淡入，以及探索页和媒体库的布局变化；视频保留在作者网盘，未作为仓库文件提交。

## 验证 / Validation

- `.\gradlew.bat -Pkotlin.compiler.execution.strategy=in-process :app:testDebugUnitTest --tests moe.ouom.neriplayer.ui.screen.tab.ExploreSearchHistoryDisplayTest --tests moe.ouom.neriplayer.data.search.ExploreSearchHistoryPolicyTest --offline --no-daemon --max-workers=1`
- Debug APK 构建成功并通过 ADB 安装验证。
- `git diff --check` 通过。

## 其他信息 / Additional Information

本分支基于官方 `master`，未引入图片或录屏作为仓库文件；对比素材仅作为 PR 描述附件提供。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## 用户可见变化

- 搜索历史、搜索来源、搜索类型和内容标签改为单行横向滚动。
- 搜索历史仅在提交搜索或选择历史项后更新。
- 网易云内容标签始终显示全部标签，并移除展开按钮。
- 媒体库保留平台级标签，次级分类改为紧凑的单行筛选项。
- 图片默认使用 180 ms 淡入效果。命中缓存时不延迟加载。显式禁用时保持无淡入效果。

## 兼容性影响

- `offlineCachedImageRequest` 和 `fastScrollableImageRequest` 的默认 `crossfade` 值由 `false` 改为 `true`。
- 调用方显式传入 `crossfade = false` 时，行为不变。

## 验证

- 已完成单元测试。
- 已成功构建并安装 Debug APK。
- 已通过 `git diff --check`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->