### PR TITLE
feat: implement auto-sizing and font-scale-aware text for MiniPlayer

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/ui/component/playback/NeriMiniPlayerLayoutTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/ui/component/playback/NeriMiniPlayerLayoutTest.kt
@@ -2,26 +2,38 @@ package moe.ouom.neriplayer.ui.component.playback
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import moe.ouom.neriplayer.testutil.assumeComposeHostAvailable
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicReference
 
 @RunWith(AndroidJUnit4::class)
 class NeriMiniPlayerLayoutTest {
@@ -64,6 +76,83 @@ class NeriMiniPlayerLayoutTest {
             .width
 
         assertTrue("MiniPlayer width collapsed to $width/$rootWidth", width > rootWidth * 0.8f)
+    }
+
+    @Test
+    fun miniPlayerKeepsContainedHeightForLargeSystemFontScale() {
+        composeRule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(density = 1f, fontScale = 2f)) {
+                MaterialTheme {
+                    Box(Modifier.fillMaxSize()) {
+                        NeriMiniPlayer(
+                            title = "Song",
+                            artist = "Artist",
+                            coverUrl = null,
+                            isPlaying = false,
+                            modifier = Modifier.testTag(MiniPlayerTag),
+                            onPlayPause = {},
+                            onPrevious = {},
+                            onNext = {},
+                            onExpand = {},
+                            enableBlur = false
+                        )
+                    }
+                }
+            }
+        }
+
+        val height = composeRule.onNodeWithTag(MiniPlayerTag)
+            .fetchSemanticsNode()
+            .boundsInRoot
+            .height
+
+        assertEquals(NeriMiniPlayerDefaults.Height.value, height, 0.5f)
+    }
+
+    @Test
+    fun miniPlayerLongTitleEllipsizesBeforeItBecomesSmallerThanArtist() {
+        val titleLayout = AtomicReference<TextLayoutResult?>()
+        val artistLayout = AtomicReference<TextLayoutResult?>()
+
+        composeRule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(density = 1f, fontScale = 2f)) {
+                MaterialTheme {
+                    Column(Modifier.width(120.dp)) {
+                        EllipsizingMiniPlayerText(
+                            text = "这是一个特别特别长的歌曲标题",
+                            style = TextStyle(fontSize = 16.sp, lineHeight = 24.sp),
+                            color = Color.Black,
+                            maxLineHeightDp = 24f,
+                            minVisualFontSizeSp = 10f,
+                            onTextLayout = titleLayout::set
+                        )
+                        AutoSizingMiniPlayerText(
+                            text = "Artist",
+                            style = TextStyle(fontSize = 14.sp, lineHeight = 20.sp),
+                            color = Color.Black,
+                            maxLineHeightDp = 20f,
+                            minVisualFontSizeSp = 9f,
+                            onTextLayout = artistLayout::set
+                        )
+                    }
+                }
+            }
+        }
+
+        val resolvedTitleLayout = titleLayout.get()
+        val resolvedArtistLayout = artistLayout.get()
+        assertNotNull("Title layout was not reported", resolvedTitleLayout)
+        assertNotNull("Artist layout was not reported", resolvedArtistLayout)
+        assertTrue(resolvedTitleLayout!!.isLineEllipsized(0))
+        assertFalse(resolvedArtistLayout!!.isLineEllipsized(0))
+        assertTrue(
+            resolvedTitleLayout.layoutInput.style.fontSize.value >=
+                resolvedArtistLayout.layoutInput.style.fontSize.value
+        )
+        assertTrue(resolvedTitleLayout.layoutInput.style.fontSize.value <= 8.1f)
+        assertTrue(resolvedArtistLayout.layoutInput.style.fontSize.value <= 7.1f)
+        assertTrue(resolvedTitleLayout.size.height <= 24)
+        assertTrue(resolvedArtistLayout.size.height <= 20)
     }
 
     @Test

--- a/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/NeriApp.kt
@@ -192,6 +192,7 @@ import moe.ouom.neriplayer.navigation.launcherShortcutMainTabRoute
 import moe.ouom.neriplayer.ui.component.navigation.NeriBottomBar
 import moe.ouom.neriplayer.ui.component.navigation.resolveBottomBarSelectionAlpha
 import moe.ouom.neriplayer.ui.component.playback.NeriMiniPlayer
+import moe.ouom.neriplayer.ui.component.playback.NeriMiniPlayerDefaults
 import moe.ouom.neriplayer.ui.component.playback.resolvePlaybackWaiting
 import moe.ouom.neriplayer.ui.component.common.ThemeRevealOverlay
 import moe.ouom.neriplayer.ui.component.common.blockUnderlyingTouches
@@ -3379,7 +3380,7 @@ private fun NeriAppContent(
                     usbPlaybackPreparing = usbPlaybackPreparing
                 )
                 val reservedMiniPlayerHeightDp = if (isMiniPlayerVisible) {
-                    moe.ouom.neriplayer.ui.component.playback.NeriMiniPlayerDefaults.Height
+                    NeriMiniPlayerDefaults.Height
                 } else {
                     0.dp
                 }

--- a/app/src/main/java/moe/ouom/neriplayer/ui/component/playback/NeriMiniPlayer.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/component/playback/NeriMiniPlayer.kt
@@ -24,11 +24,12 @@ package moe.ouom.neriplayer.ui.component.playback
  */
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -64,8 +65,12 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -81,9 +86,108 @@ import kotlin.math.sign
 
 object NeriMiniPlayerDefaults {
     val Height = 64.dp
+    internal val ContentVerticalPadding = 8.dp
 }
 
 private const val MINI_PLAYER_COVER_CLEAR_DELAY_MS = 900L
+private const val MINI_PLAYER_METADATA_LINE_HEIGHT_EM = 1.5f
+private const val MINI_PLAYER_TITLE_LINE_HEIGHT_DP = 24f
+private const val MINI_PLAYER_ARTIST_LINE_HEIGHT_DP = 20f
+private const val MINI_PLAYER_TITLE_MIN_VISUAL_FONT_SIZE_SP = 10f
+private const val MINI_PLAYER_ARTIST_MIN_VISUAL_FONT_SIZE_SP = 9f
+private const val MINI_PLAYER_METADATA_AUTO_SIZE_STEP_SP = 0.25f
+
+internal data class MiniPlayerTextAutoSizeRange(
+    val minFontSizeSp: Float,
+    val maxFontSizeSp: Float
+)
+
+internal fun resolveMiniPlayerTextAutoSizeRange(
+    baseFontSizeSp: Float,
+    maxLineHeightDp: Float,
+    fontScale: Float,
+    minVisualFontSizeSp: Float,
+    lineHeightEm: Float
+): MiniPlayerTextAutoSizeRange {
+    val safeFontScale = fontScale.coerceAtLeast(0.01f)
+    val safeLineHeightEm = lineHeightEm.coerceAtLeast(0.01f)
+    val maxFontSizeSp = minOf(
+        baseFontSizeSp,
+        maxLineHeightDp / safeLineHeightEm / safeFontScale
+    ).coerceAtLeast(0.1f)
+    val minFontSizeSp = minOf(
+        maxFontSizeSp,
+        minVisualFontSizeSp / safeFontScale
+    ).coerceAtLeast(0.1f)
+    return MiniPlayerTextAutoSizeRange(
+        minFontSizeSp = minFontSizeSp,
+        maxFontSizeSp = maxFontSizeSp
+    )
+}
+
+@Composable
+private fun rememberMiniPlayerTextAutoSizeRange(
+    style: TextStyle,
+    maxLineHeightDp: Float,
+    minVisualFontSizeSp: Float,
+    lineHeightEm: Float
+): MiniPlayerTextAutoSizeRange {
+    val fontScale = LocalDensity.current.fontScale
+    val baseFontSizeSp = style.fontSize.value.takeIf {
+        style.fontSize.isSp && it.isFinite() && it > 0f
+    } ?: 16f
+    val range = remember(
+        baseFontSizeSp,
+        maxLineHeightDp,
+        fontScale,
+        minVisualFontSizeSp,
+        lineHeightEm
+    ) {
+        resolveMiniPlayerTextAutoSizeRange(
+            baseFontSizeSp = baseFontSizeSp,
+            maxLineHeightDp = maxLineHeightDp,
+            fontScale = fontScale,
+            minVisualFontSizeSp = minVisualFontSizeSp,
+            lineHeightEm = lineHeightEm
+        )
+    }
+    return range
+}
+
+@Composable
+private fun rememberMiniPlayerTextAutoSize(
+    range: MiniPlayerTextAutoSizeRange
+): TextAutoSize {
+    val fontScale = LocalDensity.current.fontScale
+    return remember(range, fontScale) {
+        TextAutoSize.StepBased(
+            minFontSize = range.minFontSizeSp.sp,
+            maxFontSize = range.maxFontSizeSp.sp,
+            stepSize = (MINI_PLAYER_METADATA_AUTO_SIZE_STEP_SP / fontScale.coerceAtLeast(0.01f)).sp
+        )
+    }
+}
+
+private fun TextStyle.miniPlayerLineHeightEm(): Float {
+    val fontSizeUnit = fontSize
+    val lineHeightUnit = lineHeight
+    val fontSizeValue = fontSizeUnit.value
+    val lineHeightValue = lineHeightUnit.value
+    return if (
+        fontSizeUnit.isSp &&
+        lineHeightUnit.isSp &&
+        fontSizeValue > 0f &&
+        lineHeightValue > 0f
+    ) {
+        lineHeightValue / fontSizeValue
+    } else {
+        MINI_PLAYER_METADATA_LINE_HEIGHT_EM
+    }
+}
+
+private fun TextStyle.withMiniPlayerLineHeight(lineHeightEm: Float): TextStyle = copy(
+    lineHeight = lineHeightEm.em
+)
 
 internal fun resolveMiniPlayerDisplayedCoverUrl(
     requestedCoverUrl: String?,
@@ -99,6 +203,68 @@ internal fun resolveMiniPlayerDisplayedCoverUrl(
         requested == displayed || requestSucceeded -> requested
         else -> displayed
     }
+}
+
+@Composable
+internal fun AutoSizingMiniPlayerText(
+    text: String,
+    style: TextStyle,
+    color: Color,
+    maxLineHeightDp: Float,
+    minVisualFontSizeSp: Float,
+    modifier: Modifier = Modifier,
+    onTextLayout: (TextLayoutResult) -> Unit = {}
+) {
+    val lineHeightEm = style.miniPlayerLineHeightEm()
+    val range = rememberMiniPlayerTextAutoSizeRange(
+        style = style,
+        maxLineHeightDp = maxLineHeightDp,
+        minVisualFontSizeSp = minVisualFontSizeSp,
+        lineHeightEm = lineHeightEm
+    )
+    val autoSize = rememberMiniPlayerTextAutoSize(range)
+    Text(
+        text = text,
+        style = style.withMiniPlayerLineHeight(lineHeightEm),
+        autoSize = autoSize,
+        color = color,
+        maxLines = 1,
+        softWrap = false,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+        onTextLayout = onTextLayout
+    )
+}
+
+@Composable
+internal fun EllipsizingMiniPlayerText(
+    text: String,
+    style: TextStyle,
+    color: Color,
+    maxLineHeightDp: Float,
+    minVisualFontSizeSp: Float,
+    modifier: Modifier = Modifier,
+    onTextLayout: (TextLayoutResult) -> Unit = {}
+) {
+    val lineHeightEm = style.miniPlayerLineHeightEm()
+    val range = rememberMiniPlayerTextAutoSizeRange(
+        style = style,
+        maxLineHeightDp = maxLineHeightDp,
+        minVisualFontSizeSp = minVisualFontSizeSp,
+        lineHeightEm = lineHeightEm
+    )
+    Text(
+        text = text,
+        style = style
+            .withMiniPlayerLineHeight(lineHeightEm)
+            .copy(fontSize = range.maxFontSizeSp.sp),
+        color = color,
+        maxLines = 1,
+        softWrap = false,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+        onTextLayout = onTextLayout
+    )
 }
 
 @Composable
@@ -244,7 +410,10 @@ fun NeriMiniPlayer(
                         scaleX = 1f - offsetRatio * 0.025f
                         scaleY = 1f - offsetRatio * 0.025f
                     }
-                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                    .padding(
+                        horizontal = 12.dp,
+                        vertical = NeriMiniPlayerDefaults.ContentVerticalPadding
+                    )
             ) {
                 Box(
                     modifier = Modifier
@@ -315,19 +484,21 @@ fun NeriMiniPlayer(
                 }
 
                 Column(modifier = Modifier.weight(1f)) {
-                    Text(
+                    EllipsizingMiniPlayerText(
                         text = title,
                         style = MaterialTheme.typography.titleMedium,
                         color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        maxLineHeightDp = MINI_PLAYER_TITLE_LINE_HEIGHT_DP,
+                        minVisualFontSizeSp = MINI_PLAYER_TITLE_MIN_VISUAL_FONT_SIZE_SP,
+                        modifier = Modifier.fillMaxWidth()
                     )
-                    Text(
+                    AutoSizingMiniPlayerText(
                         text = artist,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.8f),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        maxLineHeightDp = MINI_PLAYER_ARTIST_LINE_HEIGHT_DP,
+                        minVisualFontSizeSp = MINI_PLAYER_ARTIST_MIN_VISUAL_FONT_SIZE_SP,
+                        modifier = Modifier.fillMaxWidth()
                     )
                 }
 

--- a/app/src/test/java/moe/ouom/neriplayer/ui/component/playback/NeriMiniPlayerDefaultsTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/component/playback/NeriMiniPlayerDefaultsTest.kt
@@ -1,0 +1,48 @@
+package moe.ouom.neriplayer.ui.component.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NeriMiniPlayerDefaultsTest {
+    @Test
+    fun normalFontScaleKeepsOriginalMetadataSizeRange() {
+        val range = resolveMiniPlayerTextAutoSizeRange(
+            baseFontSizeSp = 16f,
+            maxLineHeightDp = 24f,
+            fontScale = 1f,
+            minVisualFontSizeSp = 10f,
+            lineHeightEm = 1.5f
+        )
+
+        assertEquals(
+            16f,
+            range.maxFontSizeSp,
+            0.001f
+        )
+        assertEquals(10f, range.minFontSizeSp, 0.001f)
+    }
+
+    @Test
+    fun largeFontScaleReducesMaximumToTheAvailableLineHeight() {
+        val titleRange = resolveMiniPlayerTextAutoSizeRange(
+            baseFontSizeSp = 16f,
+            maxLineHeightDp = 24f,
+            fontScale = 2f,
+            minVisualFontSizeSp = 10f,
+            lineHeightEm = 1.5f
+        )
+        val artistRange = resolveMiniPlayerTextAutoSizeRange(
+            baseFontSizeSp = 14f,
+            maxLineHeightDp = 20f,
+            fontScale = 2f,
+            minVisualFontSizeSp = 9f,
+            lineHeightEm = 20f / 14f
+        )
+
+        assertEquals(8f, titleRange.maxFontSizeSp, 0.001f)
+        assertEquals(5f, titleRange.minFontSizeSp, 0.001f)
+        assertTrue(titleRange.maxFontSizeSp > artistRange.maxFontSizeSp)
+        assertTrue(titleRange.minFontSizeSp <= titleRange.maxFontSizeSp)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- MiniPlayer 支持字体缩放适配。
- 标题保持单行，并在过长时显示省略号。
- 艺术家名称会缩小到可用高度内。
- 切换封面时会保留旧封面，直到新封面加载成功。
- 新增字号计算和布局测试，覆盖正常及大字体缩放场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->