### PR TITLE
fix: restrict local cover replacement to non-remote songs

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
@@ -4601,6 +4601,7 @@ fun EditSongInfoSheet(
     var shouldClearMatchedMetadata by remember { mutableStateOf(false) }
     var showLocalMetadataWriteBackConfirm by remember { mutableStateOf(false) }
     var showLocalCoverSyncConfirm by remember { mutableStateOf(false) }
+    var pendingCoverReplacementSong by remember { mutableStateOf<SongItem?>(null) }
 
     // 标记用户是否手动编辑过, 避免自动重置
     var userHasEdited by remember { mutableStateOf(false) }
@@ -4608,22 +4609,29 @@ fun EditSongInfoSheet(
     val coverPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { sourceUri ->
-        if (sourceUri != null) {
-            coroutineScope.launch {
-                val importedCover = CustomSongCoverStorage.importFromUri(
-                    context = context,
-                    song = actualSong,
-                    sourceUri = sourceUri
+        val targetSong = pendingCoverReplacementSong
+        pendingCoverReplacementSong = null
+        sourceUri ?: return@rememberLauncherForActivityResult
+        val verifiedTargetSong = resolvePendingLocalCoverReplacementTarget(
+            pendingSong = targetSong,
+            currentSong = currentSong,
+            context = context
+        ) ?: return@rememberLauncherForActivityResult
+
+        coroutineScope.launch {
+            val importedCover = CustomSongCoverStorage.importFromUri(
+                context = context,
+                song = verifiedTargetSong,
+                sourceUri = sourceUri
+            )
+            if (importedCover == null) {
+                snackbarHostState.showNeriSnackbar(
+                    composeResources.getString(R.string.music_cover_import_failed)
                 )
-                if (importedCover == null) {
-                    snackbarHostState.showNeriSnackbar(
-                        composeResources.getString(R.string.music_cover_import_failed)
-                    )
-                } else {
-                    coverUrl = importedCover.toString()
-                    userHasEdited = true
-                    shouldRestoreCoverBase = false
-                }
+            } else {
+                coverUrl = importedCover.toString()
+                userHasEdited = true
+                shouldRestoreCoverBase = false
             }
         }
     }
@@ -5183,6 +5191,7 @@ fun EditSongInfoSheet(
             onConfirm = {
                 showLocalCoverSyncConfirm = false
                 if (shouldAllowLocalCoverReplacement(actualSong, context)) {
+                    pendingCoverReplacementSong = actualSong
                     clearEditSongInfoFocus()
                     coverPickerLauncher.launch("image/*")
                 }
@@ -5463,6 +5472,18 @@ internal fun shouldAllowLocalCoverReplacement(
     context: Context? = null
 ): Boolean {
     return !song.isSyncableRemoteSong(context)
+}
+
+internal fun resolvePendingLocalCoverReplacementTarget(
+    pendingSong: SongItem?,
+    currentSong: SongItem?,
+    context: Context? = null
+): SongItem? {
+    if (pendingSong == null || currentSong == null) return null
+    if (!pendingSong.sameIdentityAs(currentSong)) return null
+    if (!shouldAllowLocalCoverReplacement(pendingSong, context)) return null
+    if (!shouldAllowLocalCoverReplacement(currentSong, context)) return null
+    return pendingSong
 }
 
 @Composable

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
@@ -4583,6 +4583,7 @@ fun EditSongInfoSheet(
     } else {
         originalSong
     }
+    val canReplaceCoverFromLocalFile = shouldAllowLocalCoverReplacement(actualSong, context)
 
     var coverUrl by remember { mutableStateOf(actualSong.customCoverUrl ?: actualSong.coverUrl ?: "") }
     var songName by remember { mutableStateOf(actualSong.customName ?: actualSong.name) }
@@ -4599,6 +4600,7 @@ fun EditSongInfoSheet(
     var shouldRestoreArtistBase by remember { mutableStateOf(false) }
     var shouldClearMatchedMetadata by remember { mutableStateOf(false) }
     var showLocalMetadataWriteBackConfirm by remember { mutableStateOf(false) }
+    var showLocalCoverSyncConfirm by remember { mutableStateOf(false) }
 
     // 标记用户是否手动编辑过, 避免自动重置
     var userHasEdited by remember { mutableStateOf(false) }
@@ -4844,9 +4846,9 @@ fun EditSongInfoSheet(
                         .size(120.dp)
                         .clip(RoundedCornerShape(12.dp))
                         .background(MaterialTheme.colorScheme.surfaceVariant)
-                        .clickable {
+                        .clickable(enabled = canReplaceCoverFromLocalFile) {
                             clearEditSongInfoFocus()
-                            coverPickerLauncher.launch("image/*")
+                            showLocalCoverSyncConfirm = true
                         },
                     contentAlignment = Alignment.Center
                 ) {
@@ -4859,14 +4861,22 @@ fun EditSongInfoSheet(
                                 allowHardware = false,
                                 offlineMode = offlineMode
                             ),
-                            contentDescription = stringResource(R.string.music_edit_cover),
+                            contentDescription = if (canReplaceCoverFromLocalFile) {
+                                stringResource(R.string.music_edit_cover)
+                            } else {
+                                null
+                            },
                             modifier = Modifier.fillMaxSize(),
                             contentScale = ContentScale.Crop
                         )
                     } else {
                         Icon(
                             Icons.Outlined.Edit,
-                            contentDescription = stringResource(R.string.music_edit_cover)
+                            contentDescription = if (canReplaceCoverFromLocalFile) {
+                                stringResource(R.string.music_edit_cover)
+                            } else {
+                                null
+                            }
                         )
                     }
                 }
@@ -5167,6 +5177,20 @@ fun EditSongInfoSheet(
     }
     } // 关闭 AnimatedVisibility
 
+    if (showLocalCoverSyncConfirm) {
+        LocalSongSyncConfirmDialog(
+            actionLabel = composeResources.getString(R.string.music_edit_cover),
+            onConfirm = {
+                showLocalCoverSyncConfirm = false
+                if (shouldAllowLocalCoverReplacement(actualSong, context)) {
+                    clearEditSongInfoFocus()
+                    coverPickerLauncher.launch("image/*")
+                }
+            },
+            onDismiss = { showLocalCoverSyncConfirm = false }
+        )
+    }
+
     if (showLocalMetadataWriteBackConfirm) {
         AlertDialog(
             onDismissRequest = { showLocalMetadataWriteBackConfirm = false },
@@ -5432,6 +5456,13 @@ internal fun shouldConfirmLocalMetadataWriteBack(
     return !song.displayName().trim().equals(resolvedTitle, ignoreCase = false) ||
         !song.displayArtist().trim().equals(resolvedArtist, ignoreCase = false) ||
         currentCoverUrl?.trim() != resolvedCoverUrl
+}
+
+internal fun shouldAllowLocalCoverReplacement(
+    song: SongItem,
+    context: Context? = null
+): Boolean {
+    return !song.isSyncableRemoteSong(context)
 }
 
 @Composable

--- a/app/src/test/java/moe/ouom/neriplayer/ui/screen/LocalCoverReplacementPolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/screen/LocalCoverReplacementPolicyTest.kt
@@ -1,0 +1,62 @@
+package moe.ouom.neriplayer.ui.screen
+
+import moe.ouom.neriplayer.data.local.media.LocalSongSupport
+import moe.ouom.neriplayer.data.model.SongIdentity
+import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.model.stableKey
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalCoverReplacementPolicyTest {
+
+    @Test
+    fun `allows cover picker for pure local song`() {
+        assertTrue(shouldAllowLocalCoverReplacement(pureLocalSong()))
+    }
+
+    @Test
+    fun `rejects cover picker for remote song`() {
+        val remoteSong = pureLocalSong().copy(
+            album = "Netease",
+            albumId = 123L,
+            mediaUri = null,
+            localFilePath = null,
+            channelId = "netease",
+            sourceStableKey = null
+        )
+
+        assertFalse(shouldAllowLocalCoverReplacement(remoteSong))
+    }
+
+    @Test
+    fun `rejects cover picker for local copy with remote source identity`() {
+        val downloadedRemoteSong = pureLocalSong().copy(
+            channelId = "netease",
+            audioId = "42",
+            sourceStableKey = SongIdentity(
+                id = 42L,
+                album = "netease",
+                mediaUri = null
+            ).stableKey()
+        )
+
+        assertFalse(shouldAllowLocalCoverReplacement(downloadedRemoteSong))
+    }
+
+    private fun pureLocalSong(): SongItem {
+        return SongItem(
+            id = 42L,
+            name = "Song",
+            artist = "Artist",
+            album = LocalSongSupport.LOCAL_ALBUM_IDENTITY,
+            albumId = 0L,
+            durationMs = 180_000L,
+            coverUrl = null,
+            mediaUri = "content://media/external/audio/media/42",
+            localFilePath = null,
+            channelId = "local",
+            audioId = "42"
+        )
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/ui/screen/LocalCoverReplacementPolicyTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/screen/LocalCoverReplacementPolicyTest.kt
@@ -4,7 +4,9 @@ import moe.ouom.neriplayer.data.local.media.LocalSongSupport
 import moe.ouom.neriplayer.data.model.SongIdentity
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.data.model.stableKey
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -42,6 +44,64 @@ class LocalCoverReplacementPolicyTest {
         )
 
         assertFalse(shouldAllowLocalCoverReplacement(downloadedRemoteSong))
+    }
+
+    @Test
+    fun `keeps pending target when current song still matches`() {
+        val targetSong = pureLocalSong()
+        val currentSong = targetSong.copy(customCoverUrl = "content://cover/updated")
+
+        assertEquals(
+            targetSong,
+            resolvePendingLocalCoverReplacementTarget(targetSong, currentSong)
+        )
+    }
+
+    @Test
+    fun `drops pending target when current song changes`() {
+        val targetSong = pureLocalSong()
+        val currentSong = targetSong.copy(
+            id = 43L,
+            mediaUri = "content://media/external/audio/media/43",
+            audioId = "43"
+        )
+
+        assertNull(resolvePendingLocalCoverReplacementTarget(targetSong, currentSong))
+    }
+
+    @Test
+    fun `drops pending target when current song is remote`() {
+        val targetSong = pureLocalSong()
+        val currentSong = targetSong.copy(
+            album = "Netease",
+            albumId = 123L,
+            mediaUri = null,
+            localFilePath = null,
+            channelId = "netease",
+            sourceStableKey = null
+        )
+
+        assertNull(resolvePendingLocalCoverReplacementTarget(targetSong, currentSong))
+    }
+
+    @Test
+    fun `drops pending target when target has remote source identity`() {
+        val downloadedRemoteSong = pureLocalSong().copy(
+            channelId = "netease",
+            audioId = "42",
+            sourceStableKey = SongIdentity(
+                id = 42L,
+                album = "netease",
+                mediaUri = null
+            ).stableKey()
+        )
+
+        assertNull(
+            resolvePendingLocalCoverReplacementTarget(
+                downloadedRemoteSong,
+                downloadedRemoteSong
+            )
+        )
     }
 
     private fun pureLocalSong(): SongItem {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 仅允许非远程歌曲替换本地封面。
- 远程歌曲及带有远程来源标识的本地副本会禁用封面替换入口。
- 确认替换后会再次校验歌曲资格和当前歌曲，避免为不符合条件的歌曲打开图片选择器。
- 新增测试，覆盖纯本地歌曲、远程歌曲、带远程来源标识的本地副本，以及歌曲切换时的目标校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->