### PR TITLE
fix(search): preserve camel case boundaries during tokenization

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/util/search/SearchTextMatcher.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/util/search/SearchTextMatcher.kt
@@ -45,7 +45,7 @@ object SearchTextMatcher {
             if (queryTokens.isEmpty()) return items
 
             return items.mapIndexedNotNull { index, item ->
-                val score = SearchTextMatcher.scoreCandidates(queryTokens, candidates[index])
+                val score = scoreCandidates(queryTokens, candidates[index])
                     ?: return@mapIndexedNotNull null
                 RankedSearchItem(item = item, score = score, index = index)
             }
@@ -160,7 +160,7 @@ private fun String.candidateTokens(baseBias: Int): List<SearchCandidate> {
     val normalized = normalizeSearchText(this)
     if (normalized.isBlank()) return emptyList()
 
-    val splitTokens = normalized
+    val splitTokens = normalizeSearchTextPreservingCase(this)
         .split(SearchSeparatorRegex)
         .filter { it.isNotBlank() }
         .flatMap { splitCamelToken(it) }
@@ -261,13 +261,22 @@ private fun splitCamelToken(value: String): List<String> {
 }
 
 private fun normalizeSearchText(value: String): String {
+    return normalizeSearchText(value, lowercase = true)
+}
+
+private fun normalizeSearchTextPreservingCase(value: String): String {
+    return normalizeSearchText(value, lowercase = false)
+}
+
+private fun normalizeSearchText(value: String, lowercase: Boolean): String {
     val folded = Normalizer.normalize(value.trim(), Normalizer.Form.NFKD)
     return buildString(folded.length) {
         folded.forEach { char ->
             when {
                 char.category == CharCategory.NON_SPACING_MARK -> Unit
                 char == '\u3000' -> append(' ')
-                else -> append(char.lowercaseChar())
+                lowercase -> append(char.lowercaseChar())
+                else -> append(char)
             }
         }
     }

--- a/app/src/test/java/moe/ouom/neriplayer/util/search/SearchTextMatcherTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/util/search/SearchTextMatcherTest.kt
@@ -17,6 +17,23 @@ class SearchTextMatcherTest {
     }
 
     @Test
+    fun `tokensOf preserves camel case word boundaries`() {
+        assertTrue(SearchTextMatcher.matches("np", "NeriPlayer"))
+        assertEquals(
+            listOf("neriplayer", "neri", "player", "np"),
+            SearchTextMatcher.tokensOf("NeriPlayer")
+        )
+        assertEquals(
+            listOf("youtubemusic", "you", "tube", "music", "ytm"),
+            SearchTextMatcher.tokensOf("YouTubeMusic")
+        )
+        assertEquals(
+            listOf("audiodownloadmanager", "audio", "download", "manager", "adm"),
+            SearchTextMatcher.tokensOf("AudioDownloadManager")
+        )
+    }
+
+    @Test
     fun `matches Chinese title by full pinyin and initials`() {
         assertTrue(SearchTextMatcher.matches("qingtian", "晴天"))
         assertTrue(SearchTextMatcher.matches("qt", "晴天"))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## 用户可见行为
- 搜索分词保留驼峰边界。
- `NeriPlayer`、`YouTubeMusic` 和 `AudioDownloadManager` 可按预期拆分并匹配。
- 普通小写词、拆分词和首字母缩写的匹配行为保持支持。

## 测试
- 新增驼峰分词和匹配场景测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->