### PR TITLE
fix: optimize ExploreScreen pager and refine glass overscroll & refine Netease search availability and cookie usage

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscroll.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscroll.kt
@@ -168,7 +168,11 @@ private class AdvancedGlassOverscrollEffect : OverscrollEffect {
     }
 
     private fun applyDrag(delta: Float) {
-        rawDragY += delta
+        rawDragY = boundedAdvancedGlassOverscrollRawDrag(
+            rawDrag = rawDragY,
+            delta = delta,
+            resistanceScale = resistanceScalePx
+        )
         offsetY = dampedAdvancedGlassOverscrollOffset(rawDragY, resistanceScalePx)
     }
 
@@ -318,8 +322,24 @@ internal fun restoredAdvancedGlassOverscrollDrag(
     return sign(offset) * -resistanceScale * ln(1f - normalized)
 }
 
+internal fun boundedAdvancedGlassOverscrollRawDrag(
+    rawDrag: Float,
+    delta: Float,
+    resistanceScale: Float
+): Float {
+    val maxRawDrag = maxAdvancedGlassOverscrollRawDrag(resistanceScale)
+    return (rawDrag + delta).coerceIn(-maxRawDrag, maxRawDrag)
+}
+
 internal fun maxAdvancedGlassOverscrollOffset(resistanceScale: Float): Float =
     (resistanceScale * MAX_OVERSCROLL_OFFSET_RATIO).coerceAtLeast(0f)
+
+internal fun maxAdvancedGlassOverscrollRawDrag(resistanceScale: Float): Float =
+    if (resistanceScale <= 0f) {
+        0f
+    } else {
+        resistanceScale * -ln(INVERSE_EPSILON)
+    }
 
 internal fun advancedGlassOverscrollReturnPeriodSeconds(
     offset: Float,

--- a/app/src/main/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscroll.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscroll.kt
@@ -180,7 +180,12 @@ private class AdvancedGlassOverscrollEffect : OverscrollEffect {
         val launch = launchAnimation ?: return
         animationJob?.cancel()
         animationJob = launch {
-            val stiffness = springStiffness(STANDARD_SPRING_PERIOD_SECONDS)
+            val stiffness = springStiffness(
+                advancedGlassOverscrollReturnPeriodSeconds(
+                    offset = offsetY,
+                    resistanceScale = resistanceScalePx
+                )
+            )
             animate(
                 initialValue = offsetY,
                 targetValue = 0f,
@@ -194,7 +199,10 @@ private class AdvancedGlassOverscrollEffect : OverscrollEffect {
                     visibilityThreshold = OFFSET_THRESHOLD_PX
                 )
             ) { value, _ ->
-                offsetY = value
+                offsetY = value.coerceIn(
+                    -maxAdvancedGlassOverscrollOffset(resistanceScalePx),
+                    maxAdvancedGlassOverscrollOffset(resistanceScalePx)
+                )
                 rawDragY = restoredAdvancedGlassOverscrollDrag(offsetY, resistanceScalePx)
             }
             resetOffset()
@@ -296,7 +304,8 @@ internal fun dampedAdvancedGlassOverscrollOffset(
 ): Float {
     if (rawDrag == 0f || resistanceScale <= 0f) return 0f
     val normalized = abs(rawDrag) / resistanceScale
-    return sign(rawDrag) * resistanceScale * ln(1f + normalized)
+    val maxOffset = maxAdvancedGlassOverscrollOffset(resistanceScale)
+    return sign(rawDrag) * maxOffset * (1f - exp(-normalized))
 }
 
 internal fun restoredAdvancedGlassOverscrollDrag(
@@ -304,8 +313,24 @@ internal fun restoredAdvancedGlassOverscrollDrag(
     resistanceScale: Float
 ): Float {
     if (offset == 0f || resistanceScale <= 0f) return 0f
-    val normalized = abs(offset) / resistanceScale
-    return sign(offset) * resistanceScale * (exp(normalized) - 1f)
+    val maxOffset = maxAdvancedGlassOverscrollOffset(resistanceScale)
+    val normalized = (abs(offset) / maxOffset).coerceIn(0f, 1f - INVERSE_EPSILON)
+    return sign(offset) * -resistanceScale * ln(1f - normalized)
+}
+
+internal fun maxAdvancedGlassOverscrollOffset(resistanceScale: Float): Float =
+    (resistanceScale * MAX_OVERSCROLL_OFFSET_RATIO).coerceAtLeast(0f)
+
+internal fun advancedGlassOverscrollReturnPeriodSeconds(
+    offset: Float,
+    resistanceScale: Float
+): Float {
+    if (resistanceScale <= 0f) return MIN_RETURN_SPRING_PERIOD_SECONDS
+    val progress = (
+        abs(offset) / maxAdvancedGlassOverscrollOffset(resistanceScale)
+    ).coerceIn(0f, 1f)
+    return MIN_RETURN_SPRING_PERIOD_SECONDS +
+        (MAX_RETURN_SPRING_PERIOD_SECONDS - MIN_RETURN_SPRING_PERIOD_SECONDS) * progress
 }
 
 private fun springStiffness(periodSeconds: Float): Float =
@@ -314,7 +339,10 @@ private fun springStiffness(periodSeconds: Float): Float =
 private const val OVERSCROLL_RESISTANCE_SCALE_DP = 108f
 private const val OFFSET_THRESHOLD_PX = 1f
 private const val CRITICAL_DAMPING_RATIO = 1f
-private const val STANDARD_SPRING_PERIOD_SECONDS = 0.4f
+private const val MIN_RETURN_SPRING_PERIOD_SECONDS = 0.44f
+private const val MAX_RETURN_SPRING_PERIOD_SECONDS = 0.62f
 private const val MAX_INITIAL_VELOCITY_SCALE_MULTIPLIER = 18f
 private const val REVERSE_FLING_ATTENUATION = 2.13333f
 private const val POST_FLING_ATTENUATION = 1.53333f
+private const val MAX_OVERSCROLL_OFFSET_RATIO = 0.66f
+private const val INVERSE_EPSILON = 0.0001f

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/ExploreScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/tab/ExploreScreen.kt
@@ -278,6 +278,14 @@ internal fun shouldResetExploreSearchScroll(
     return currentContextKey != null && previousContextKey != currentContextKey
 }
 
+internal fun shouldRenderExploreSearchResults(
+    page: Int,
+    currentPage: Int
+): Boolean = page == currentPage
+
+internal fun exploreSearchResultsBottomPadding(miniPlayerHeight: Dp): Dp =
+    16.dp + miniPlayerHeight
+
 internal fun shouldShowBiliPartsPicker(song: SongItem): Boolean {
     return song.album == PlayerManager.BILI_SOURCE_TAG ||
         song.album.startsWith("${PlayerManager.BILI_SOURCE_TAG}|")
@@ -856,48 +864,51 @@ fun ExploreScreen(
 
             HorizontalPager(
                 state = pagerState,
-                modifier = Modifier.fillMaxSize()
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
             ) { page ->
                 val currentSource = orderedSearchSources[page]
                 if (searchQuery.isNotEmpty()) {
-                    when {
-                        ui.searching -> {
-                            Box(
-                                Modifier
-                                    .fillMaxSize()
-                                    .padding(bottom = miniPlayerHeight),
-                                Alignment.Center
-                            ) { CircularProgressIndicator() }
-                        }
-                        ui.searchError != null -> {
-                            Box(
-                                Modifier
-                                    .fillMaxSize()
-                                    .padding(bottom = miniPlayerHeight),
-                                Alignment.Center
-                            ) {
-                                Text(ui.searchError!!, color = MaterialTheme.colorScheme.error)
+                    if (shouldRenderExploreSearchResults(page, pagerState.currentPage)) {
+                        when {
+                            ui.searching -> {
+                                Box(
+                                    Modifier
+                                        .fillMaxSize()
+                                        .padding(bottom = miniPlayerHeight),
+                                    Alignment.Center
+                                ) { CircularProgressIndicator() }
                             }
-                        }
-                        ui.searchItems.isEmpty() -> {
-                            Box(
-                                Modifier
-                                    .fillMaxSize()
-                                    .padding(bottom = miniPlayerHeight),
-                                Alignment.Center
-                            ) { Text(stringResource(R.string.search_no_result)) }
-                        }
-                        else -> {
-                            LazyColumn(
-                                state = searchListState,
-                                contentPadding = PaddingValues(
-                                    start = searchResultHorizontalPadding,
-                                    end = searchResultHorizontalPadding,
-                                    top = 8.dp,
-                                    bottom = 16.dp + miniPlayerHeight
-                                ),
-                                modifier = Modifier.fillMaxSize()
-                            ) {
+                            ui.searchError != null -> {
+                                Box(
+                                    Modifier
+                                        .fillMaxSize()
+                                        .padding(bottom = miniPlayerHeight),
+                                    Alignment.Center
+                                ) {
+                                    Text(ui.searchError!!, color = MaterialTheme.colorScheme.error)
+                                }
+                            }
+                            ui.searchItems.isEmpty() -> {
+                                Box(
+                                    Modifier
+                                        .fillMaxSize()
+                                        .padding(bottom = miniPlayerHeight),
+                                    Alignment.Center
+                                ) { Text(stringResource(R.string.search_no_result)) }
+                            }
+                            else -> {
+                                LazyColumn(
+                                    state = searchListState,
+                                    contentPadding = PaddingValues(
+                                        start = searchResultHorizontalPadding,
+                                        end = searchResultHorizontalPadding,
+                                        top = 8.dp,
+                                        bottom = exploreSearchResultsBottomPadding(miniPlayerHeight)
+                                    ),
+                                    modifier = Modifier.fillMaxSize()
+                                ) {
                                 itemsIndexed(
                                     items = ui.searchItems,
                                     key = { _, item -> item.stableKey }
@@ -1021,8 +1032,11 @@ fun ExploreScreen(
                                         )
                                     }
                                 }
+                                }
                             }
                         }
+                    } else {
+                        Box(Modifier.fillMaxSize())
                     }
                 } else {
                     when (currentSource) {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/ExploreViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/ExploreViewModel.kt
@@ -42,19 +42,18 @@ import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicSearchFilter
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicSearchResult
 import moe.ouom.neriplayer.core.api.youtube.YouTubeMusicSearchResultType
 import moe.ouom.neriplayer.core.di.AppContainer
-import moe.ouom.neriplayer.core.player.PlayerManager
+import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.core.player.PlayerManager.biliClient
 import moe.ouom.neriplayer.core.player.PlayerManager.neteaseClient
 import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthState
 import moe.ouom.neriplayer.data.model.NeteaseArtistSummary
+import moe.ouom.neriplayer.data.model.SongItem
+import moe.ouom.neriplayer.data.platform.youtube.YouTubeFeatureGate
 import moe.ouom.neriplayer.data.platform.youtube.buildYouTubeMusicMediaUri
 import moe.ouom.neriplayer.data.platform.youtube.stableYouTubeMusicId
 import moe.ouom.neriplayer.data.platform.youtube.youtubeMusicThumbnailUrl
-import moe.ouom.neriplayer.data.platform.youtube.YouTubeFeatureGate
-import moe.ouom.neriplayer.core.logging.NPLogger
-import moe.ouom.neriplayer.data.model.SongItem
-import moe.ouom.neriplayer.util.search.searchValues
 import moe.ouom.neriplayer.util.search.SearchTextMatcher
+import moe.ouom.neriplayer.util.search.searchValues
 import org.json.JSONObject
 
 private const val TAG = "NERI-ExploreVM"

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/ExploreViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/ExploreViewModel.kt
@@ -194,6 +194,17 @@ internal fun isNeteaseExploreSearchAvailable(authState: SavedCookieAuthState): B
     return authState != SavedCookieAuthState.Missing
 }
 
+internal fun ExploreUiState.withNeteaseAuthRequired(error: String): ExploreUiState = copy(
+    searching = false,
+    searchError = error,
+    searchResults = emptyList(),
+    searchItems = emptyList(),
+    searchHasMore = false,
+    searchLoadingMore = false,
+    searchLoadMoreError = null,
+    searchPage = 0
+)
+
 internal fun ExploreUiState.withYouTubeDisabled(): ExploreUiState {
     val youtubeWasSelected = selectedSearchSource == SearchSource.YOUTUBE_MUSIC
     return copy(
@@ -327,6 +338,14 @@ class ExploreViewModel(application: Application) : AndroidViewModel(application)
         viewModelScope.launch {
             neteaseRepo.authHealthFlow.collect { health ->
                 val isLoggedIn = isNeteaseExploreSearchAvailable(health.state)
+                val currentState = _uiState.value
+                if (
+                    !isLoggedIn &&
+                    currentState.selectedSearchSource == SearchSource.NETEASE &&
+                    currentState.searchKeyword.isNotBlank()
+                ) {
+                    clearNeteaseSearchForAuthRequired()
+                }
                 _uiState.value = _uiState.value.copy(isNeteaseLoggedIn = isLoggedIn)
             }
         }
@@ -453,6 +472,11 @@ class ExploreViewModel(application: Application) : AndroidViewModel(application)
 
     fun loadMoreSearchResults() {
         val state = _uiState.value
+        val source = state.selectedSearchSource
+        if (source == SearchSource.NETEASE && !isNeteaseSearchAllowed()) {
+            clearNeteaseSearchForAuthRequired()
+            return
+        }
         if (
             state.searchKeyword.isBlank() ||
             !state.searchHasMore ||
@@ -463,7 +487,6 @@ class ExploreViewModel(application: Application) : AndroidViewModel(application)
             return
         }
 
-        val source = state.selectedSearchSource
         val neteaseType = state.selectedNeteaseSearchType
         val keyword = state.searchKeyword
         val matchQuery = state.searchDisplayQuery.ifBlank { keyword }
@@ -476,6 +499,10 @@ class ExploreViewModel(application: Application) : AndroidViewModel(application)
         )
         searchMoreJob = viewModelScope.launch {
             try {
+                if (source == SearchSource.NETEASE && !isNeteaseSearchAllowed()) {
+                    clearNeteaseSearchForAuthRequired()
+                    return@launch
+                }
                 val result = when (source) {
                     SearchSource.NETEASE -> fetchNeteaseSearchPage(
                         keyword = keyword,
@@ -490,6 +517,10 @@ class ExploreViewModel(application: Application) : AndroidViewModel(application)
                     )
                     SearchSource.YOUTUBE_MUSIC,
                     SearchSource.LINK_RECOGNITION -> return@launch
+                }
+                if (source == SearchSource.NETEASE && !isNeteaseSearchAllowed()) {
+                    clearNeteaseSearchForAuthRequired()
+                    return@launch
                 }
                 updateSearchStateIfCurrent(requestVersion, source) {
                     val merged = mergeExploreSearchResults(it.searchItems, result.items)
@@ -712,25 +743,22 @@ class ExploreViewModel(application: Application) : AndroidViewModel(application)
 
     /** 搜索网易云歌曲 */
     private fun searchNetease(keyword: String, matchQuery: String, requestVersion: Long) {
-        if (!isNeteaseExploreSearchAvailable(neteaseRepo.getAuthHealthOnce().state)) {
-            updateSearchStateIfCurrent(requestVersion, SearchSource.NETEASE) {
-                it.copy(
-                    searching = false,
-                    searchError = app.getString(R.string.netease_login_required_search),
-                    searchResults = emptyList(),
-                    searchItems = emptyList(),
-                    searchHasMore = false,
-                    searchLoadingMore = false,
-                    searchLoadMoreError = null,
-                    searchPage = 0
-                )
-            }
+        if (!isNeteaseSearchAllowed()) {
+            clearNeteaseSearchForAuthRequired()
             return
         }
         val type = _uiState.value.selectedNeteaseSearchType
         searchJob = viewModelScope.launch {
             try {
+                if (!isNeteaseSearchAllowed()) {
+                    clearNeteaseSearchForAuthRequired()
+                    return@launch
+                }
                 val result = fetchNeteaseSearchPage(keyword, matchQuery, page = 1, type = type)
+                if (!isNeteaseSearchAllowed()) {
+                    clearNeteaseSearchForAuthRequired()
+                    return@launch
+                }
                 NPLogger.d(
                     TAG,
                     "search Netease success: request=$requestVersion, keyword=$keyword, type=$type, count=${result.items.size}, hasMore=${result.hasMore}"
@@ -771,6 +799,19 @@ class ExploreViewModel(application: Application) : AndroidViewModel(application)
                 }
             }
         }
+    }
+
+    private fun isNeteaseSearchAllowed(): Boolean {
+        return isNeteaseExploreSearchAvailable(neteaseRepo.getAuthHealthOnce().state)
+    }
+
+    private fun clearNeteaseSearchForAuthRequired() {
+        searchJob?.cancel()
+        searchMoreJob?.cancel()
+        invalidateSearchRequest()
+        _uiState.value = _uiState.value.withNeteaseAuthRequired(
+            error = app.getString(R.string.netease_login_required_search)
+        )
     }
 
     private fun searchRecognizedLink(input: String, requestVersion: Long) {

--- a/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/ExploreViewModel.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/viewmodel/tab/ExploreViewModel.kt
@@ -45,7 +45,6 @@ import moe.ouom.neriplayer.core.di.AppContainer
 import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.core.player.PlayerManager.biliClient
 import moe.ouom.neriplayer.core.player.PlayerManager.neteaseClient
-import moe.ouom.neriplayer.data.auth.netease.NeteaseCookieRepository
 import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthState
 import moe.ouom.neriplayer.data.model.NeteaseArtistSummary
 import moe.ouom.neriplayer.data.platform.youtube.buildYouTubeMusicMediaUri
@@ -191,6 +190,10 @@ data class ExploreUiState(
     val ytMusicPlaylistsError: String? = null
 )
 
+internal fun isNeteaseExploreSearchAvailable(authState: SavedCookieAuthState): Boolean {
+    return authState != SavedCookieAuthState.Missing
+}
+
 internal fun ExploreUiState.withYouTubeDisabled(): ExploreUiState {
     val youtubeWasSelected = selectedSearchSource == SearchSource.YOUTUBE_MUSIC
     return copy(
@@ -308,7 +311,7 @@ private data class ExploreSearchFetchResult(
 
 class ExploreViewModel(application: Application) : AndroidViewModel(application) {
     private val app = application
-    private val neteaseRepo = NeteaseCookieRepository(application)
+    private val neteaseRepo = AppContainer.neteaseCookieRepo
     private var highQualityLoadJob: Job? = null
     private var searchJob: Job? = null
     private var searchMoreJob: Job? = null
@@ -323,7 +326,7 @@ class ExploreViewModel(application: Application) : AndroidViewModel(application)
     init {
         viewModelScope.launch {
             neteaseRepo.authHealthFlow.collect { health ->
-                val isLoggedIn = health.state != SavedCookieAuthState.Missing
+                val isLoggedIn = isNeteaseExploreSearchAvailable(health.state)
                 _uiState.value = _uiState.value.copy(isNeteaseLoggedIn = isLoggedIn)
             }
         }
@@ -709,7 +712,7 @@ class ExploreViewModel(application: Application) : AndroidViewModel(application)
 
     /** 搜索网易云歌曲 */
     private fun searchNetease(keyword: String, matchQuery: String, requestVersion: Long) {
-        if (neteaseRepo.getAuthHealthOnce().state == SavedCookieAuthState.Missing) {
+        if (!isNeteaseExploreSearchAvailable(neteaseRepo.getAuthHealthOnce().state)) {
             updateSearchStateIfCurrent(requestVersion, SearchSource.NETEASE) {
                 it.copy(
                     searching = false,
@@ -1189,7 +1192,7 @@ class ExploreViewModel(application: Application) : AndroidViewModel(application)
                 limit = NETEASE_SEARCH_PAGE_SIZE,
                 offset = offset,
                 type = type.apiType,
-                usePersistedCookies = false
+                usePersistedCookies = true
             )
         }
         val parsed = parseNeteaseSearchResults(raw, type)

--- a/app/src/test/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscrollTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscrollTest.kt
@@ -41,10 +41,24 @@ class AdvancedGlassOverscrollTest {
     fun dragDisplacementIsCappedWhileRemainingReversible() {
         val resistanceScale = 100f
         val maxOffset = maxAdvancedGlassOverscrollOffset(resistanceScale)
+        val maxRawDrag = maxAdvancedGlassOverscrollRawDrag(resistanceScale)
         val cappedOffset = dampedAdvancedGlassOverscrollOffset(10_000f, resistanceScale)
         val reversibleOffset = dampedAdvancedGlassOverscrollOffset(400f, resistanceScale)
+        val saturatedRawDrag = boundedAdvancedGlassOverscrollRawDrag(
+            rawDrag = 0f,
+            delta = 10_000f,
+            resistanceScale = resistanceScale
+        )
+        val reversedRawDrag = boundedAdvancedGlassOverscrollRawDrag(
+            rawDrag = saturatedRawDrag,
+            delta = -100f,
+            resistanceScale = resistanceScale
+        )
 
         assertEquals(maxOffset, cappedOffset, 0.001f)
+        assertEquals(maxRawDrag, saturatedRawDrag, 0.001f)
+        assertEquals(maxRawDrag - 100f, reversedRawDrag, 0.001f)
+        assertTrue(dampedAdvancedGlassOverscrollOffset(reversedRawDrag, resistanceScale) < cappedOffset)
         assertTrue(reversibleOffset < maxOffset)
         assertTrue(reversibleOffset > maxOffset * 0.98f)
         assertEquals(

--- a/app/src/test/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscrollTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/effect/glass/AdvancedGlassOverscrollTest.kt
@@ -26,10 +26,32 @@ class AdvancedGlassOverscrollTest {
         val second = dampedAdvancedGlassOverscrollOffset(200f, resistanceScale)
         val third = dampedAdvancedGlassOverscrollOffset(300f, resistanceScale)
 
-        assertEquals(100f * kotlin.math.ln(2f), first, 0.001f)
+        assertEquals(
+            maxAdvancedGlassOverscrollOffset(resistanceScale) *
+                (1f - kotlin.math.exp(-1f)),
+            first,
+            0.001f
+        )
         assertEquals(-third, dampedAdvancedGlassOverscrollOffset(-300f, resistanceScale), 0.001f)
         assertTrue(third > second)
         assertTrue(third - second < second - first)
+    }
+
+    @Test
+    fun dragDisplacementIsCappedWhileRemainingReversible() {
+        val resistanceScale = 100f
+        val maxOffset = maxAdvancedGlassOverscrollOffset(resistanceScale)
+        val cappedOffset = dampedAdvancedGlassOverscrollOffset(10_000f, resistanceScale)
+        val reversibleOffset = dampedAdvancedGlassOverscrollOffset(400f, resistanceScale)
+
+        assertEquals(maxOffset, cappedOffset, 0.001f)
+        assertTrue(reversibleOffset < maxOffset)
+        assertTrue(reversibleOffset > maxOffset * 0.98f)
+        assertEquals(
+            400f,
+            restoredAdvancedGlassOverscrollDrag(reversibleOffset, resistanceScale),
+            0.1f
+        )
     }
 
     @Test
@@ -83,5 +105,15 @@ class AdvancedGlassOverscrollTest {
                 viewportHeight = 320f
             )
         )
+    }
+
+    @Test
+    fun largerFingerDisplacementGetsASlowerReturnPeriod() {
+        val resistanceScale = 100f
+        val shortDrag = advancedGlassOverscrollReturnPeriodSeconds(10f, resistanceScale)
+        val longDrag = advancedGlassOverscrollReturnPeriodSeconds(60f, resistanceScale)
+
+        assertTrue(longDrag > shortDrag)
+        assertTrue(longDrag <= 0.62f)
     }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/ui/screen/tab/ExploreScreenYouTubeGateTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/screen/tab/ExploreScreenYouTubeGateTest.kt
@@ -1,5 +1,6 @@
 package moe.ouom.neriplayer.ui.screen.tab
 
+import androidx.compose.ui.unit.dp
 import moe.ouom.neriplayer.ui.viewmodel.tab.NeteaseExploreSearchType
 import moe.ouom.neriplayer.ui.viewmodel.tab.SearchSource
 import moe.ouom.neriplayer.ui.viewmodel.tab.YouTubeExploreSearchType
@@ -117,5 +118,18 @@ class ExploreScreenYouTubeGateTest {
         assertEquals("YOUTUBE_MUSIC|SONG|demo", songs)
         assertEquals("YOUTUBE_MUSIC|CREATOR|demo", creators)
         assertTrue(shouldResetExploreSearchScroll(songs, creators))
+    }
+
+    @Test
+    fun `only the active pager page owns the search list`() {
+        assertTrue(shouldRenderExploreSearchResults(page = 1, currentPage = 1))
+        assertFalse(shouldRenderExploreSearchResults(page = 0, currentPage = 1))
+        assertFalse(shouldRenderExploreSearchResults(page = 2, currentPage = 1))
+    }
+
+    @Test
+    fun `search results reserve the visible mini player height`() {
+        assertEquals(16.dp, exploreSearchResultsBottomPadding(0.dp))
+        assertEquals(80.dp, exploreSearchResultsBottomPadding(64.dp))
     }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/tab/ExploreViewModelYouTubeGateTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/tab/ExploreViewModelYouTubeGateTest.kt
@@ -31,6 +31,35 @@ class ExploreViewModelYouTubeGateTest {
     }
 
     @Test
+    fun `missing Netease auth clears stale paginated results`() {
+        val state = ExploreUiState(
+            selectedSearchSource = SearchSource.NETEASE,
+            searching = false,
+            searchResults = listOf(result),
+            searchItems = listOf(ExploreSearchResult.Song(result)),
+            searchHasMore = true,
+            searchLoadingMore = true,
+            searchLoadMoreError = "temporary error",
+            searchPage = 3,
+            searchKeyword = "song",
+            searchDisplayQuery = "song"
+        )
+
+        val blocked = state.withNeteaseAuthRequired("login required")
+
+        assertFalse(blocked.searching)
+        assertEquals("login required", blocked.searchError)
+        assertTrue(blocked.searchResults.isEmpty())
+        assertTrue(blocked.searchItems.isEmpty())
+        assertFalse(blocked.searchHasMore)
+        assertFalse(blocked.searchLoadingMore)
+        assertNull(blocked.searchLoadMoreError)
+        assertEquals(0, blocked.searchPage)
+        assertEquals("song", blocked.searchKeyword)
+        assertEquals("song", blocked.searchDisplayQuery)
+    }
+
+    @Test
     fun `disabling YouTube preserves another source search state`() {
         val state = ExploreUiState(
             selectedSearchSource = SearchSource.BILIBILI,

--- a/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/tab/ExploreViewModelYouTubeGateTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/viewmodel/tab/ExploreViewModelYouTubeGateTest.kt
@@ -1,5 +1,6 @@
 package moe.ouom.neriplayer.ui.viewmodel.tab
 
+import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthState
 import moe.ouom.neriplayer.data.model.SongItem
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -18,6 +19,16 @@ class ExploreViewModelYouTubeGateTest {
         coverUrl = "",
         durationMs = 1_000L
     )
+
+    @Test
+    fun `valid Netease auth keeps search available`() {
+        assertTrue(isNeteaseExploreSearchAvailable(SavedCookieAuthState.Valid))
+    }
+
+    @Test
+    fun `missing Netease auth blocks search`() {
+        assertFalse(isNeteaseExploreSearchAvailable(SavedCookieAuthState.Missing))
+    }
 
     @Test
     fun `disabling YouTube preserves another source search state`() {


### PR DESCRIPTION
fix #363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- 优化探索页分页器。搜索后仅渲染当前页面，避免搜索结果自动回弹，并支持正常滚动和选择较低位置的结果。
- 调整玻璃效果的过度滚动阻尼和回弹动画。限制最大偏移，并根据拖动距离调整回弹周期。
- 网易云搜索仅在认证有效时启用，并使用持久化 Cookie。认证失效时清除分页结果和加载状态，同时保留搜索关键词。
- 新增分页渲染、底部间距、网易云认证和过度滚动行为测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->