### PR TITLE
fix: check USB device availability in `UsbExclusiveAudioSink`

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/usb/device/UsbExclusiveDeviceAccess.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/usb/device/UsbExclusiveDeviceAccess.kt
@@ -5,10 +5,42 @@ import android.hardware.usb.UsbConstants
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbDeviceConnection
 import android.hardware.usb.UsbManager
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
 import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.settings.DEFAULT_USB_EXCLUSIVE_DEVICE_KEY
 
 private const val TAG = "UsbExclusiveDeviceAccess"
+
+internal fun hasPermittedUsbAudioOutput(
+    context: Context,
+    selectedDeviceKey: String = DEFAULT_USB_EXCLUSIVE_DEVICE_KEY
+): Boolean {
+    val appContext = context.applicationContext
+    val usbManager = appContext.getSystemService(Context.USB_SERVICE) as? UsbManager
+        ?: return false
+    if (selectPermittedUsbAudioDevice(usbManager, selectedDeviceKey).outcome !=
+        UsbExclusiveDeviceSelectionOutcome.SELECTED
+    ) {
+        return false
+    }
+    val audioManager = appContext.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+        ?: return false
+    val outputs = runCatching {
+        audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+            .filter { it.isSink && it.isUsbExclusiveOutput() }
+            .sortedBy(AudioDeviceInfo::getId)
+            .groupBy { normalizeUsbExclusiveDeviceLabel(it.productName?.toString().orEmpty()) }
+            .values
+            .map { it.first() }
+    }.getOrElse { emptyList() }
+    return selectUsbExclusiveDevice(
+        candidates = outputs,
+        selectedDeviceKey = selectedDeviceKey,
+        allowSingleFallback = true
+    ) { device -> device.matchesUsbExclusiveDeviceKey(selectedDeviceKey) }.outcome ==
+        UsbExclusiveDeviceSelectionOutcome.SELECTED
+}
 
 internal fun openPermittedUsbAudioDevice(
     context: Context,
@@ -16,18 +48,7 @@ internal fun openPermittedUsbAudioDevice(
 ): Pair<UsbDevice, UsbDeviceConnection>? {
     val usbManager = context.applicationContext.getSystemService(Context.USB_SERVICE) as? UsbManager
         ?: return null
-    val candidates = usbManager.deviceList.values
-        .sortedBy { it.deviceName }
-        .filter { device ->
-            runCatching { usbManager.hasPermission(device) }.getOrDefault(false) &&
-                device.hasAudioStreamingInterface()
-        }
-    // host 侧持 VID+PID+label,精确匹配可靠,匹配不到不退回其它设备
-    val selection = selectUsbExclusiveDevice(
-        candidates = candidates,
-        selectedDeviceKey = selectedDeviceKey,
-        allowSingleFallback = false
-    ) { device -> device.matchesUsbExclusiveDeviceKey(selectedDeviceKey) }
+    val selection = selectPermittedUsbAudioDevice(usbManager, selectedDeviceKey)
     val targetDevice = when (selection.outcome) {
         UsbExclusiveDeviceSelectionOutcome.SELECTED -> selection.device ?: return null
         UsbExclusiveDeviceSelectionOutcome.AMBIGUOUS -> {
@@ -35,7 +56,7 @@ internal fun openPermittedUsbAudioDevice(
             NPLogger.w(
                 TAG,
                 "openPermittedUsbAudioDevice(): ambiguous selection, refusing to guess; " +
-                    "candidates=${candidates.size} key=$selectedDeviceKey"
+                    "key=$selectedDeviceKey"
             )
             return null
         }
@@ -45,10 +66,36 @@ internal fun openPermittedUsbAudioDevice(
     return targetDevice to connection
 }
 
+private fun selectPermittedUsbAudioDevice(
+    usbManager: UsbManager,
+    selectedDeviceKey: String
+): UsbExclusiveDeviceSelectionResult<UsbDevice> {
+    val candidates = runCatching {
+        usbManager.deviceList.values
+            .sortedBy { it.deviceName }
+            .filter { device ->
+                runCatching { usbManager.hasPermission(device) }.getOrDefault(false) &&
+                    device.hasAudioStreamingInterface()
+            }
+    }.getOrElse { emptyList() }
+    // host 侧持 VID+PID+label,精确匹配可靠,匹配不到不退回其它设备
+    return selectUsbExclusiveDevice(
+        candidates = candidates,
+        selectedDeviceKey = selectedDeviceKey,
+        allowSingleFallback = false
+    ) { device -> device.matchesUsbExclusiveDeviceKey(selectedDeviceKey) }
+}
+
 private fun UsbDevice.hasAudioStreamingInterface(): Boolean {
     return (0 until interfaceCount).any { index ->
         val usbInterface = getInterface(index)
         usbInterface.interfaceClass == UsbConstants.USB_CLASS_AUDIO &&
             usbInterface.interfaceSubclass == 0x02
     }
+}
+
+private fun AudioDeviceInfo.isUsbExclusiveOutput(): Boolean {
+    return type == AudioDeviceInfo.TYPE_USB_DEVICE ||
+        type == AudioDeviceInfo.TYPE_USB_ACCESSORY ||
+        type == AudioDeviceInfo.TYPE_USB_HEADSET
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/usb/device/UsbExclusiveDeviceIdentity.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/usb/device/UsbExclusiveDeviceIdentity.kt
@@ -17,7 +17,7 @@ internal fun UsbDevice.matchesUsbExclusiveDeviceKey(deviceKey: String): Boolean 
     val selection = parseUsbExclusiveDeviceKey(deviceKey) ?: return false
     return vendorId == selection.vendorId &&
         productId == selection.productId &&
-        normalizedDeviceLabel(stableUsbDeviceLabel()) == selection.label
+        normalizeUsbExclusiveDeviceLabel(stableUsbDeviceLabel()) == selection.label
 }
 
 internal fun AudioDeviceInfo.matchesUsbExclusiveDeviceKey(deviceKey: String): Boolean {
@@ -111,7 +111,7 @@ private fun buildUsbExclusiveDeviceKey(
     productId: Int,
     label: String
 ): String {
-    return "usb:$vendorId:$productId:${normalizedDeviceLabel(label)}"
+    return "usb:$vendorId:$productId:${normalizeUsbExclusiveDeviceLabel(label)}"
 }
 
 private fun parseUsbExclusiveDeviceKey(deviceKey: String): UsbExclusiveDeviceSelection? {
@@ -128,7 +128,7 @@ private fun usbExclusiveDeviceKeyMatchesLabel(
     label: String
 ): Boolean {
     // 精确相等,避免子串误命中(如键 "dac" 命中 "dac_pro"),与 host 侧 VID+PID+label 精确匹配对齐
-    val normalizedProduct = normalizedDeviceLabel(label)
+    val normalizedProduct = normalizeUsbExclusiveDeviceLabel(label)
     return normalizedProduct.isNotBlank() && normalizedProduct == selection.label
 }
 
@@ -139,7 +139,7 @@ private fun UsbDevice.stableUsbDeviceLabel(): String {
         ?: deviceName
 }
 
-private fun normalizedDeviceLabel(value: String): String {
+internal fun normalizeUsbExclusiveDeviceLabel(value: String): String {
     return value.trim()
         .lowercase()
         .replace(Regex("[^a-z0-9]+"), "_")

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/usb/sink/UsbExclusiveAudioSink.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/usb/sink/UsbExclusiveAudioSink.kt
@@ -50,6 +50,7 @@ import moe.ouom.neriplayer.core.player.lifecycle.scheduleUsbAudioSinkReconfigura
 import moe.ouom.neriplayer.core.player.lifecycle.scheduleUsbExclusiveTransportRecovery
 import moe.ouom.neriplayer.core.player.lifecycle.stopPlaybackAfterUsbExclusiveNativeFailure
 import moe.ouom.neriplayer.core.player.lifecycle.tryRecoverUsbExclusivePlaybackAfterNativeTransferFailure
+import moe.ouom.neriplayer.core.player.usb.device.hasPermittedUsbAudioOutput
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathTracker
 import moe.ouom.neriplayer.core.player.usb.session.UsbExclusiveSessionController
 import moe.ouom.neriplayer.core.player.usb.system.UsbExclusiveBackgroundAudioAnchorVolumeGuard
@@ -94,7 +95,13 @@ internal fun prepareUsbExclusiveNativeWrite(
 internal class UsbExclusiveAudioSink(
     private val context: Context,
     private val fallbackSink: AudioSink,
-    private val observeSystemVolume: Boolean = true
+    private val observeSystemVolume: Boolean = true,
+    private val nativeUsbAudioDeviceAvailable: () -> Boolean = {
+        hasPermittedUsbAudioOutput(
+            context = context,
+            selectedDeviceKey = PlayerManager.usbExclusivePreferences.selectedDeviceKey
+        )
+    }
 ) : ForwardingAudioSink(fallbackSink) {
     private companion object {
         const val PARAMETER_EPSILON = 0.0001f
@@ -240,11 +247,25 @@ internal class UsbExclusiveAudioSink(
     }
 
     override fun supportsFormat(format: Format): Boolean {
+        if (
+            PlayerManager.usbExclusivePlaybackEnabled &&
+            isUsbNativePcmFormat(format) &&
+            !nativeUsbAudioDeviceAvailable()
+        ) {
+            return false
+        }
         return fallbackSink.supportsFormat(format) ||
             (PlayerManager.usbExclusivePlaybackEnabled && isUsbNativePcmFormat(format))
     }
 
     override fun getFormatSupport(format: Format): Int {
+        if (
+            PlayerManager.usbExclusivePlaybackEnabled &&
+            isUsbNativePcmFormat(format) &&
+            !nativeUsbAudioDeviceAvailable()
+        ) {
+            return AudioSink.SINK_FORMAT_UNSUPPORTED
+        }
         val fallbackSupport = fallbackSink.getFormatSupport(format)
         return if (PlayerManager.usbExclusivePlaybackEnabled && isUsbNativePcmFormat(format)) {
             max(fallbackSupport, AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY)

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/usb/device/UsbExclusiveDeviceSelectionTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/usb/device/UsbExclusiveDeviceSelectionTest.kt
@@ -1,10 +1,13 @@
 package moe.ouom.neriplayer.core.player.usb.device
 
+import android.content.Context
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 /**
  * 覆盖 H1(多设备选错/无声)与 L1(子串误命中)修复的纯函数级判定:
@@ -47,6 +50,15 @@ class UsbExclusiveDeviceSelectionTest {
             allowSingleFallback = true
         ) { true }
         assertEquals(UsbExclusiveDeviceSelectionOutcome.NONE, result.outcome)
+    }
+
+    @Test
+    fun `missing usb manager reports no permitted audio device`() {
+        val context = mock(Context::class.java)
+        `when`(context.applicationContext).thenReturn(context)
+        `when`(context.getSystemService(Context.USB_SERVICE)).thenReturn(null)
+
+        assertFalse(hasPermittedUsbAudioOutput(context))
     }
 
     @Test

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/usb/sink/UsbExclusiveAudioSinkTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/usb/sink/UsbExclusiveAudioSinkTest.kt
@@ -10,6 +10,7 @@ import androidx.media3.exoplayer.audio.AudioSink
 import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.core.player.usb.path.UsbExclusiveAudioPathTracker
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.After
 import org.junit.Test
@@ -43,7 +44,8 @@ class UsbExclusiveAudioSinkTest {
         val sink = UsbExclusiveAudioSink(
             context = context,
             fallbackSink = fallbackSink,
-            observeSystemVolume = false
+            observeSystemVolume = false,
+            nativeUsbAudioDeviceAvailable = { true }
         )
         val format = rawPcmFormat()
 
@@ -68,10 +70,32 @@ class UsbExclusiveAudioSinkTest {
         val sink = UsbExclusiveAudioSink(
             context = context,
             fallbackSink = fallbackSink,
-            observeSystemVolume = false
+            observeSystemVolume = false,
+            nativeUsbAudioDeviceAvailable = { true }
         )
 
         assertTrue(sink.supportsFormat(rawFloatPcmFormat()))
+    }
+
+    @Test
+    fun `usb native pcm is rejected before decoder selection when no device is available`() {
+        PlayerManager.usbExclusivePlaybackEnabled = true
+        val context = mock(Context::class.java)
+        `when`(context.applicationContext).thenReturn(context)
+        `when`(context.getSystemService(Context.AUDIO_SERVICE)).thenReturn(null)
+        val fallbackSink = mock(AudioSink::class.java)
+        `when`(fallbackSink.supportsFormat(rawPcmFormat())).thenReturn(true)
+        `when`(fallbackSink.getFormatSupport(rawPcmFormat()))
+            .thenReturn(AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY)
+        val sink = UsbExclusiveAudioSink(
+            context = context,
+            fallbackSink = fallbackSink,
+            observeSystemVolume = false,
+            nativeUsbAudioDeviceAvailable = { false }
+        )
+
+        assertFalse(sink.supportsFormat(rawPcmFormat()))
+        assertEquals(AudioSink.SINK_FORMAT_UNSUPPORTED, sink.getFormatSupport(rawPcmFormat()))
     }
 
     @Test


### PR DESCRIPTION
fix #385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- USB 音频输出不可用时，`UsbExclusiveAudioSink` 会在格式协商阶段拒绝原生 PCM 路径，并使用回退音频路径。
- 支持按所选设备键检查 USB 输出，也支持单设备回退判断。
- USB 服务不可用或访问异常时，设备检查返回不可用，避免无 DAC 设备导致崩溃。
- 新增测试覆盖 USB 服务缺失、设备不可用时拒绝原生 PCM，以及设备可用时的既有路径。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->