### PR TITLE
fix(ui): copy lyric share bitmaps before recycling

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/ui/component/lyrics/LyricShareBitmapOwnershipTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/ui/component/lyrics/LyricShareBitmapOwnershipTest.kt
@@ -1,0 +1,45 @@
+package moe.ouom.neriplayer.ui.component.lyrics
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LyricShareBitmapOwnershipTest {
+    @Test
+    fun copiedCoverBitmapDoesNotAliasCoilBitmap() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val source = Bitmap.createBitmap(8, 8, Bitmap.Config.ARGB_8888)
+        source.eraseColor(0xFF336699.toInt())
+        val copied = copyDrawableToOwnedBitmap(
+            drawable = BitmapDrawable(context.resources, source),
+            width = 8,
+            height = 8,
+            config = Bitmap.Config.ARGB_8888
+        )
+
+        try {
+            assertNotSame(source, copied)
+            assertFalse(source.isRecycled)
+            assertEquals(source.getPixel(0, 0), copied.getPixel(0, 0))
+
+            copied.recycle()
+
+            assertFalse(source.isRecycled)
+        } finally {
+            if (!source.isRecycled) {
+                source.recycle()
+            }
+            if (!copied.isRecycled) {
+                copied.recycle()
+            }
+        }
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/ui/component/lyrics/LyricShareSheet.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/component/lyrics/LyricShareSheet.kt
@@ -8,9 +8,11 @@ import android.graphics.Canvas
 import android.graphics.LinearGradient
 import android.graphics.Paint
 import android.graphics.Path
+import android.graphics.Rect
 import android.graphics.RectF
 import android.graphics.Shader
 import android.graphics.Typeface
+import android.graphics.drawable.Drawable
 import android.text.Layout
 import android.text.StaticLayout
 import android.text.TextPaint
@@ -67,7 +69,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import androidx.core.graphics.createBitmap
-import androidx.core.graphics.drawable.toBitmap
 import androidx.core.graphics.get
 import androidx.core.graphics.scale
 import androidx.core.graphics.withClip
@@ -563,17 +564,46 @@ private suspend fun loadCoverBitmap(context: Context, coverUrl: String?): Bitmap
             allowHardware = false
         )
         val result = Coil.imageLoader(context).execute(request)
-        (result as? SuccessResult)
-            ?.drawable
-            ?.toBitmap(width = 512, height = 512, config = Bitmap.Config.ARGB_8888)
+        (result as? SuccessResult)?.drawable?.let { drawable ->
+            copyDrawableToOwnedBitmap(
+                drawable = drawable,
+                width = 512,
+                height = 512,
+                config = Bitmap.Config.ARGB_8888
+            )
+        }
     }.getOrNull()
+}
+
+// Coil may return a cache-owned bitmap, so the share card must keep its own copy
+internal fun copyDrawableToOwnedBitmap(
+    drawable: Drawable,
+    width: Int,
+    height: Int,
+    config: Bitmap.Config
+): Bitmap {
+    val bitmap = Bitmap.createBitmap(width, height, config)
+    val originalBounds = Rect(drawable.bounds)
+    return try {
+        drawable.setBounds(0, 0, width, height)
+        drawable.draw(Canvas(bitmap))
+        bitmap
+    } catch (error: Throwable) {
+        bitmap.recycle()
+        throw error
+    } finally {
+        drawable.bounds = originalBounds
+    }
 }
 
 private fun loadAppIconBitmap(context: Context): Bitmap? {
     return runCatching {
-        context.packageManager
-            .getApplicationIcon(context.applicationInfo)
-            .toBitmap(width = 128, height = 128, config = Bitmap.Config.ARGB_8888)
+        copyDrawableToOwnedBitmap(
+            drawable = context.packageManager.getApplicationIcon(context.applicationInfo),
+            width = 128,
+            height = 128,
+            config = Bitmap.Config.ARGB_8888
+        )
     }.getOrNull()
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

修复歌词分享位图在回收后失效的问题。应用现在会复制封面和应用图标位图，再用于分享流程，避免与 Coil 缓存位图共享实例。

新增 Android 仪器测试，验证复制位图不共享源实例或回收状态，并保持像素内容一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->