### PR TITLE
feat(lyrics): support square-bracket word timing, trailing timestamps, and translation folding

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ NeriPlayer 是一个基于 **Jetpack Compose + Media3** 的原生 Android
   shader 内部基于封面取色、动态色块和轻量颗粒噪声生成流体背景，
   并接入 `uMusicLevel / uBeat` 做音频响应，不是简单把封面做高斯模糊。
 - **仿 Apple Music 的深度歌词体验**：
-  `SyncedLyricsView` 与 `AdvancedLyricsView` 支持逐词/逐字高亮、翻译歌词、
+  `SyncedLyricsView` 与 `AdvancedLyricsView` 支持逐行、逐词/逐字 LRC（含行尾
+  时间和方括号逐字时间戳）以及 YRC/TTML 歌词的高亮、翻译歌词、
   音译显示、歌词偏移、点击跳转、长按分享、景深模糊、边缘渐隐和全屏歌词；
   `LyricShareSheet` 可选择歌词行，复制文本、分享歌曲或生成 1080px 歌词卡片；
   歌词页遇到含假名的日语原文时，会为翻译行额外留出间距，避免日文字形和译文挤在一起；

--- a/README_EN.md
+++ b/README_EN.md
@@ -154,8 +154,10 @@ Current positioning:
   requires Android 12+, while advanced blur requires Android 13+; older versions
   automatically use a compatible fallback without those effects.
 - **Apple Music-style lyrics, backed by the playback pipeline**:
-  `SyncedLyricsView` and `AdvancedLyricsView` support word/character-timed
-  highlighting, translated lyrics, phonetic display, lyric offset, click-to-seek,
+  `SyncedLyricsView` and `AdvancedLyricsView` support line-, word-, and
+  character-timed LRC (including trailing timestamps and square-bracket word
+  timestamps), plus YRC/TTML highlighting, translated lyrics, phonetic display,
+  lyric offset, click-to-seek,
   long-press sharing, depth blur, edge fade, and a full-screen Lyrics page.
   `LyricShareSheet` can select lyric lines, copy text, share the song, or render
   a 1080px lyric card. The Now Playing cover lyric view and bottom Dock can be

--- a/app/src/main/java/moe/ouom/neriplayer/ui/component/lyrics/SyncedLyricsView.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/component/lyrics/SyncedLyricsView.kt
@@ -484,7 +484,11 @@ private val LrcCreditLineRegex = Regex(
 
 private data class LrcTimelineEntry(
     val startTimeMs: Long,
-    val text: String
+    val text: String,
+    val words: List<EnhancedLrcWord>? = null,
+    val explicitEndTimeMs: Long? = null,
+    val sourceLineIndex: Int = 0,
+    val timestampIndex: Int = 0
 )
 
 private data class EnhancedLrcWord(
@@ -1359,6 +1363,110 @@ private fun parseLrcTimestampMs(timestamp: MatchResult): Long? {
     return minutes * 60_000L + seconds * 1_000L + milliseconds
 }
 
+private fun parseSquareBracketLrcTimelineEntries(
+    rawLine: String,
+    sourceLineIndex: Int
+): List<LrcTimelineEntry> {
+    val line = rawLine.trim()
+    val timestamps = EnhancedLrcLineTimestampRegex.findAll(line).toList()
+    if (timestamps.isEmpty() || timestamps.first().range.first != 0) {
+        return emptyList()
+    }
+
+    var leadingTimestampCount = 1
+    var nextExpectedStart = timestamps.first().range.last + 1
+    while (
+        leadingTimestampCount < timestamps.size &&
+        timestamps[leadingTimestampCount].range.first == nextExpectedStart
+    ) {
+        nextExpectedStart = timestamps[leadingTimestampCount].range.last + 1
+        leadingTimestampCount++
+    }
+
+    val primaryTimestampIndex = leadingTimestampCount - 1
+    val primaryTimestamp = timestamps[primaryTimestampIndex]
+    val primaryStartTimeMs = parseLrcTimestampMs(primaryTimestamp) ?: return emptyList()
+    val inlineTimestamps = timestamps.drop(leadingTimestampCount)
+    val fragments = buildList {
+        val firstTextEnd = inlineTimestamps.firstOrNull()?.range?.first ?: line.length
+        add(
+            EnhancedLrcWord(
+                text = line.substring(primaryTimestamp.range.last + 1, firstTextEnd),
+                startTimeMs = primaryStartTimeMs,
+                endTimeMs = inlineTimestamps.firstOrNull()?.let(::parseLrcTimestampMs)
+            )
+        )
+        inlineTimestamps.forEachIndexed { index, timestamp ->
+            val textStart = timestamp.range.last + 1
+            val textEnd = inlineTimestamps.getOrNull(index + 1)?.range?.first ?: line.length
+            add(
+                EnhancedLrcWord(
+                    text = line.substring(textStart, textEnd),
+                    startTimeMs = parseLrcTimestampMs(timestamp) ?: return@forEachIndexed,
+                    endTimeMs = inlineTimestamps.getOrNull(index + 1)
+                        ?.let(::parseLrcTimestampMs)
+                )
+            )
+        }
+    }
+    val visibleFragments = fragments.filterIndexed { index, fragment ->
+        fragment.text.isNotEmpty() &&
+            (index != 0 || fragment.text.any { !it.isWhitespace() })
+    }
+
+    if (visibleFragments.size >= 2) {
+        return listOf(
+            LrcTimelineEntry(
+                startTimeMs = primaryStartTimeMs,
+                text = visibleFragments.joinToString(separator = "") { it.text },
+                words = visibleFragments,
+                sourceLineIndex = sourceLineIndex,
+                timestampIndex = primaryTimestampIndex
+            )
+        )
+    }
+
+    val text = visibleFragments.singleOrNull()?.text?.trim().orEmpty()
+    val explicitEndTimeMs = visibleFragments.singleOrNull()?.endTimeMs
+    return timestamps.take(leadingTimestampCount).mapIndexedNotNull { timestampIndex, timestamp ->
+        val startTimeMs = parseLrcTimestampMs(timestamp) ?: return@mapIndexedNotNull null
+        LrcTimelineEntry(
+            startTimeMs = startTimeMs,
+            text = text,
+            explicitEndTimeMs = explicitEndTimeMs.takeIf { leadingTimestampCount == 1 },
+            sourceLineIndex = sourceLineIndex,
+            timestampIndex = timestampIndex
+        )
+    }
+}
+
+private fun foldAdjacentSquareBracketTranslations(
+    entries: List<LyricEntry>
+): List<LyricEntry> {
+    val foldedEntries = mutableListOf<LyricEntry>()
+    var index = 0
+    while (index < entries.size) {
+        val entry = entries[index]
+        val followingEntry = entries.getOrNull(index + 1)
+        val followingText = followingEntry?.text.orEmpty()
+        val isAdjacentTranslation =
+            !entry.words.isNullOrEmpty() &&
+                followingEntry?.words.isNullOrEmpty() &&
+                followingEntry?.startTimeMs == entry.startTimeMs &&
+                followingText.isNotBlank() &&
+                !LrcCreditLineRegex.containsMatchIn(followingText) &&
+                !isLyricCreditMetadataLine(followingText)
+        if (isAdjacentTranslation) {
+            foldedEntries += entry.copy(translation = followingText)
+            index += 2
+        } else {
+            foldedEntries += entry
+            index++
+        }
+    }
+    return foldedEntries
+}
+
 /** 小数字符偏移的多行 reveal */
 @Composable
 internal fun Modifier.multilineGradientReveal(
@@ -1665,29 +1773,24 @@ fun parseNeteaseLrc(lrc: String): List<LyricEntry> {
     if (isEnhancedLrc(normalizedLrc)) {
         return parseEnhancedLrc(normalizedLrc)
     }
-    val tag = Regex("""\[(\d{2}):(\d{2})(?:\.(\d{2,3}))?]""")
     val timeline = mutableListOf<LrcTimelineEntry>()
 
-    normalizedLrc.lineSequence().forEach { raw ->
+    normalizedLrc.lineSequence().forEachIndexed { sourceLineIndex, raw ->
         val line = raw.trim()
-        if (line.isEmpty()) return@forEach
-        if (line.startsWith("{") || line.startsWith("}")) return@forEach // 过滤 JSON 段
+        if (line.isEmpty()) return@forEachIndexed
+        if (line.startsWith("{") || line.startsWith("}")) return@forEachIndexed // 过滤 JSON 段
 
-        val m = tag.find(line) ?: return@forEach
-        val mm = m.groupValues[1].toInt()
-        val ss = m.groupValues[2].toInt()
-        val msStr = m.groupValues.getOrNull(3).orEmpty()
-        val ms = when (msStr.length) {
-            0 -> 0
-            2 -> msStr.toInt() * 10
-            else -> msStr.toInt()
-        }
-        val time = mm * 60_000L + ss * 1_000L + ms
-        val text = line.substring(m.range.last + 1).trim()
-        timeline.add(LrcTimelineEntry(startTimeMs = time, text = text))
+        timeline += parseSquareBracketLrcTimelineEntries(
+            rawLine = line,
+            sourceLineIndex = sourceLineIndex
+        )
     }
 
-    timeline.sortBy { it.startTimeMs }
+    timeline.sortWith(
+        compareBy<LrcTimelineEntry> { it.startTimeMs }
+            .thenBy { it.sourceLineIndex }
+            .thenBy { it.timestampIndex }
+    )
     val suffixContainsOnlyCredits = BooleanArray(timeline.size + 1)
     suffixContainsOnlyCredits[timeline.size] = true
     for (index in timeline.lastIndex downTo 0) {
@@ -1716,19 +1819,41 @@ fun parseNeteaseLrc(lrc: String): List<LyricEntry> {
     for (index in effectiveTimeline.lastIndex downTo 0) {
         val entry = effectiveTimeline[index]
         if (entry.text.isNotBlank()) {
+            val nextDistinctTimestampMs = effectiveTimeline
+                .asSequence()
+                .drop(index + 1)
+                .firstOrNull { it.startTimeMs > entry.startTimeMs }
+                ?.startTimeMs
+            val words = entry.words?.let { sourceWords ->
+                sourceWords.mapIndexed { wordIndex, word ->
+                    val fallbackEndTimeMs = sourceWords.getOrNull(wordIndex + 1)?.startTimeMs
+                        ?: nextDistinctTimestampMs
+                        ?: entry.startTimeMs.saturatingAdd(5_000L)
+                    WordTiming(
+                        startTimeMs = word.startTimeMs,
+                        endTimeMs = (word.endTimeMs ?: fallbackEndTimeMs)
+                            .coerceAtLeast(word.startTimeMs),
+                        charCount = word.text.length
+                    )
+                }
+            }
+            val endTimeMs = words?.maxOfOrNull { it.endTimeMs }
+                ?: entry.explicitEndTimeMs
+                ?: nextTimestampMs
+                ?: entry.startTimeMs.saturatingAdd(5_000L)
             out.add(
                 LyricEntry(
                     text = entry.text,
                     startTimeMs = entry.startTimeMs,
-                    endTimeMs = nextTimestampMs ?: (entry.startTimeMs + 5_000L),
-                    words = null
+                    endTimeMs = endTimeMs.coerceAtLeast(entry.startTimeMs),
+                    words = words
                 )
             )
         }
         nextTimestampMs = entry.startTimeMs
     }
     out.reverse()
-    return out
+    return foldAdjacentSquareBracketTranslations(out)
 }
 
 @Composable

--- a/app/src/test/java/moe/ouom/neriplayer/ui/component/lyrics/AdvancedLyricsViewTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/component/lyrics/AdvancedLyricsViewTest.kt
@@ -66,6 +66,28 @@ class AdvancedLyricsViewTest {
     }
 
     @Test
+    fun `buildAdvancedSyncedLyrics renders square bracket word timing and translation`() {
+        val rawLyrics = """
+            [00:01.000]日[00:01.200]本[00:01.400]
+            [00:01.000]translation
+            """.trimIndent()
+        val parsedLyrics = parseNeteaseLyricsAuto(rawLyrics)
+
+        val result = buildAdvancedSyncedLyrics(
+            rawLyrics = rawLyrics,
+            rawTranslatedLyrics = null,
+            lyrics = parsedLyrics,
+            translatedLyrics = emptyList()
+        )
+
+        val line = result.lines.single() as KaraokeLine.MainKaraokeLine
+        assertEquals("日本", line.syllables.joinToString(separator = "") { it.content })
+        assertEquals(1_000, line.syllables.first().start)
+        assertEquals(1_400, line.syllables.last().end)
+        assertEquals("translation", line.translation)
+    }
+
+    @Test
     fun `parseTtmlLyrics keeps inline translation on word timed lines`() {
         val ttml = """
             <tt xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata">

--- a/app/src/test/java/moe/ouom/neriplayer/ui/component/lyrics/SyncedLyricsTimingTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/ui/component/lyrics/SyncedLyricsTimingTest.kt
@@ -78,6 +78,85 @@ class SyncedLyricsViewTimingTest {
     }
 
     @Test
+    fun `parseNeteaseLyricsAuto preserves square bracket word timing`() {
+        val lyrics = parseNeteaseLyricsAuto(
+            """
+            [00:01.000]A[00:01.200][00:01.300] B[00:01.500]CD[00:02.000]
+            """.trimIndent()
+        )
+
+        val line = lyrics.single()
+        assertEquals("A BCD", line.text)
+        assertEquals(1_000L, line.startTimeMs)
+        assertEquals(2_000L, line.endTimeMs)
+        assertEquals(3, line.words?.size)
+        assertEquals(1_000L, line.words?.get(0)?.startTimeMs)
+        assertEquals(1_200L, line.words?.get(0)?.endTimeMs)
+        assertEquals(1, line.words?.get(0)?.charCount)
+        assertEquals(1_300L, line.words?.get(1)?.startTimeMs)
+        assertEquals(1_500L, line.words?.get(1)?.endTimeMs)
+        assertEquals(2, line.words?.get(1)?.charCount)
+        assertEquals(1_500L, line.words?.get(2)?.startTimeMs)
+        assertEquals(2_000L, line.words?.get(2)?.endTimeMs)
+        assertEquals(2, line.words?.get(2)?.charCount)
+    }
+
+    @Test
+    fun `parseNeteaseLrc treats an inline trailing timestamp as a line end`() {
+        val lyrics = parseNeteaseLrc(
+            """
+            [00:05.790]plain line[00:11.470]
+            [00:11.470]next line
+            """.trimIndent()
+        )
+
+        assertEquals(listOf("plain line", "next line"), lyrics.map { it.text })
+        assertEquals(11_470L, lyrics[0].endTimeMs)
+        assertEquals(null, lyrics[0].words)
+    }
+
+    @Test
+    fun `parseNeteaseLrc folds an adjacent same timestamp translation into square word timing`() {
+        val lyrics = parseNeteaseLrc(
+            """
+            [00:01.000]日[00:01.200]本[00:01.400]
+            [00:01.000]translation
+            [00:01.400]next line
+            """.trimIndent()
+        )
+
+        assertEquals(2, lyrics.size)
+        assertEquals("日本", lyrics[0].text)
+        assertEquals("translation", lyrics[0].translation)
+        assertEquals(2, lyrics[0].words?.size)
+        assertEquals("next line", lyrics[1].text)
+    }
+
+    @Test
+    fun `parseNeteaseLrc keeps adjacent credits separate from square word timing`() {
+        val lyrics = parseNeteaseLrc(
+            """
+            [00:01.000]日[00:01.200]本[00:01.400]
+            [00:01.000]词：author
+            [00:01.400]next line
+            """.trimIndent()
+        )
+
+        assertEquals(3, lyrics.size)
+        assertEquals(null, lyrics[0].translation)
+        assertEquals("词：author", lyrics[1].text)
+    }
+
+    @Test
+    fun `parseNeteaseLrc keeps multiple leading timestamps as ordinary lines`() {
+        val lyrics = parseNeteaseLrc("[00:01.000][00:02.000]repeated line")
+
+        assertEquals(listOf(1_000L, 2_000L), lyrics.map { it.startTimeMs })
+        assertEquals(listOf("repeated line", "repeated line"), lyrics.map { it.text })
+        assertTrue(lyrics.all { it.words == null })
+    }
+
+    @Test
     fun `parseNeteaseLrc trims credits after a terminal empty timestamp`() {
         val lyrics = parseNeteaseLrc(
             """


### PR DESCRIPTION
close #388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 支持同一行多个方括号时间戳、逐词时间戳和行尾时间戳。
- 支持将相邻且时间戳相同的翻译行合并到主歌词行。
- 过滤 JSON 片段和部分无效歌词片段。
- 新增测试，覆盖逐词计时、行尾时间戳、翻译合并、制作人员信息分离及多个前导时间戳。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->