### PR TITLE
feat: apply lyric offsets to Lyricon and unify offset resolution

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/lyricon/LyriconManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/lyricon/LyriconManager.kt
@@ -46,6 +46,8 @@ object LyriconManager {
     private var songDurationMs: Long = 0L
     @Volatile
     private var playbackSpeed: Float = 1f
+    @Volatile
+    private var effectiveLyricOffsetMs: Long = 0L
 
     fun initialize(context: Context) {
         if (provider != null) return
@@ -133,6 +135,7 @@ object LyriconManager {
             val displayPositionMs = displayLyriconPositionMs(
                 mediaPositionMs = mediaPositionMs,
                 durationMs = songDurationMs,
+                lyricOffsetMs = effectiveLyricOffsetMs,
             )
             runCatching { provider?.player?.setPosition(displayPositionMs) }
             updateSuperLyric(displayPositionMs)
@@ -157,13 +160,24 @@ object LyriconManager {
         val displaySynced = displayLyriconPositionMs(
             mediaPositionMs = mediaSynced,
             durationMs = songDurationMs,
+            lyricOffsetMs = effectiveLyricOffsetMs,
         )
         runCatching { provider?.player?.setPosition(displaySynced) }
     }
 
-    fun updateSong(song: SongItem, lyrics: List<LyricEntry>?, translatedLyrics: List<LyricEntry>?) {
+    fun setLyricOffset(lyricOffsetMs: Long) {
+        effectiveLyricOffsetMs = lyricOffsetMs
+    }
+
+    fun updateSong(
+        song: SongItem,
+        lyrics: List<LyricEntry>?,
+        translatedLyrics: List<LyricEntry>?,
+        lyricOffsetMs: Long = 0L,
+    ) {
         if (!enabled) return
         try {
+            setLyricOffset(lyricOffsetMs)
             LyriconManager.lyrics = lyrics
             LyriconManager.translatedLyrics = translatedLyrics
             translationMatchesByIndex = if (lyrics.isNullOrEmpty()) {
@@ -297,6 +311,7 @@ object LyriconManager {
         translationMatchesByIndex = emptyMap()
         currentSong = null
         songDurationMs = 0L
+        setLyricOffset(0L)
     }
 
     private fun updatePositionAnchor(positionMs: Long) {
@@ -336,6 +351,7 @@ object LyriconManager {
                         val displayPositionMs = displayLyriconPositionMs(
                             mediaPositionMs = mediaPositionMs,
                             durationMs = songDurationMs,
+                            lyricOffsetMs = effectiveLyricOffsetMs,
                         )
                         runCatching { activeProvider.player.setPosition(displayPositionMs) }
                     }

--- a/app/src/main/java/moe/ouom/neriplayer/core/lyricon/LyriconPositionFeed.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/lyricon/LyriconPositionFeed.kt
@@ -7,7 +7,7 @@ internal const val LYRICON_FEED_INTERVAL_MS = 200L
  * 推给 Lyricon/词幕的显示预推 (媒体时间轴)
  * 锚点用真实媒体进度, 仅显示层加 lead, 避免 dead-reckon 叠推
  */
-internal const val LYRICON_DISPLAY_LEAD_MS = 750L
+internal const val LYRICON_DISPLAY_LEAD_MS = 400L
 
 /**
  * 与高级歌词 resolveInterpolatedPlaybackPosition 同构的媒体锚点

--- a/app/src/main/java/moe/ouom/neriplayer/core/lyricon/LyriconPositionFeed.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/lyricon/LyriconPositionFeed.kt
@@ -65,18 +65,34 @@ internal fun mediaLyriconPositionMs(
 }
 
 /**
- * 推给 Lyricon/SuperLyric 的显示位置: 媒体进度 + 固定 lead
- * lead 不进锚点, 避免叠推
+ * 推给 Lyricon/SuperLyric 的显示位置: 先应用歌词偏移, 再加固定 lead
+ * 偏移与应用内歌词一样先在零点截断, lead 不进锚点, 避免叠推
  */
 internal fun displayLyriconPositionMs(
     mediaPositionMs: Long,
     durationMs: Long,
     leadMs: Long = LYRICON_DISPLAY_LEAD_MS,
+    lyricOffsetMs: Long = 0L,
 ): Long {
+    val lyricPositionMs = saturatingAddLyriconPositionMs(
+        mediaPositionMs.coerceAtLeast(0L),
+        lyricOffsetMs,
+    ).coerceAtLeast(0L)
     return clampLyriconPositionMs(
-        positionMs = mediaPositionMs.coerceAtLeast(0L) + leadMs.coerceAtLeast(0L),
+        positionMs = saturatingAddLyriconPositionMs(
+            lyricPositionMs,
+            leadMs.coerceAtLeast(0L),
+        ),
         durationMs = durationMs,
     )
+}
+
+private fun saturatingAddLyriconPositionMs(value: Long, delta: Long): Long {
+    return when {
+        delta > 0L && value > Long.MAX_VALUE - delta -> Long.MAX_VALUE
+        delta < 0L && value < Long.MIN_VALUE - delta -> Long.MIN_VALUE
+        else -> value + delta
+    }
 }
 
 /**

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -47,6 +47,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import com.google.gson.Gson
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -80,6 +81,7 @@ import moe.ouom.neriplayer.core.player.lifecycle.initializeImpl
 import moe.ouom.neriplayer.core.player.lifecycle.releaseImpl
 import moe.ouom.neriplayer.core.player.lifecycle.scheduleUsbAudioSinkReconfiguration
 import moe.ouom.neriplayer.core.player.lifecycle.updateAudioOffloadPreferences
+import moe.ouom.neriplayer.core.player.lyrics.LyriconUpdateCoordinator
 import moe.ouom.neriplayer.core.player.lyrics.syncExternalBluetoothLyrics
 import moe.ouom.neriplayer.core.player.model.AudioDevice
 import moe.ouom.neriplayer.core.player.model.DEFAULT_PLAYBACK_LOUDNESS_GAIN_MB
@@ -320,9 +322,7 @@ object PlayerManager {
     internal var ioScope = newIoScope()
     internal var mainScope = newMainScope()
     internal var progressJob: Job? = null
-    internal var lyriconUpdateJob: Job? = null
-    private val lyriconUpdateLock = Any()
-    private var lyriconUpdateGeneration = 0L
+    private val lyriconUpdateCoordinator = LyriconUpdateCoordinator()
     internal var externalBluetoothLyricsLoadJob: Job? = null
     internal var externalBluetoothTranslationLoadJob: Job? = null
     internal var volumeFadeJob: Job? = null
@@ -809,51 +809,62 @@ object PlayerManager {
         song: SongItem?,
         lyricOffsetOverrideMs: Long? = null,
     ) {
-        val updateGeneration = synchronized(lyriconUpdateLock) {
-            lyriconUpdateGeneration += 1L
-            lyriconUpdateGeneration
-        }
-        lyriconUpdateJob?.cancel()
-        if (!lyriconEnabled) {
-            lyriconUpdateJob = null
-            LyriconManager.setPlaybackState(false)
-            return
-        }
-        if (song == null) {
-            lyriconUpdateJob = null
-            LyriconManager.setPlaybackState(false)
-            updateLyriconLyricOffset(null)
-            LyriconManager.setPosition(0L)
-            return
-        }
-        val lyricOffsetMs = lyricOffsetOverrideMs ?: resolveLyriconLyricOffsetMs(song)
-        LyriconManager.updateSong(
-            song = song,
-            lyrics = null,
-            translatedLyrics = null,
-            lyricOffsetMs = lyricOffsetMs,
-        )
-        lyriconUpdateJob = ioScope.launch {
-            val lyrics = getLyrics(song)
-            currentCoroutineContext().ensureActive()
-            val translatedLyrics = getTranslatedLyrics(song)
-            currentCoroutineContext().ensureActive()
-            synchronized(lyriconUpdateLock) {
-                if (updateGeneration != lyriconUpdateGeneration) {
-                    return@synchronized
+        val request = lyriconUpdateCoordinator.replace(
+            createJob = { updateGeneration ->
+                if (!lyriconEnabled || song == null) {
+                    null
+                } else {
+                    ioScope.launch(start = CoroutineStart.LAZY) lyriconUpdate@{
+                        val lyrics = getLyrics(song)
+                        currentCoroutineContext().ensureActive()
+                        val translatedLyrics = getTranslatedLyrics(song)
+                        currentCoroutineContext().ensureActive()
+                        val updateJob = currentCoroutineContext()[Job] ?: return@lyriconUpdate
+                        lyriconUpdateCoordinator.runIfCurrent(
+                            generation = updateGeneration,
+                            job = updateJob,
+                        ) {
+                            val currentSong = _currentSongFlow.value
+                            if (currentSong?.sameIdentityAs(song) == true) {
+                                LyriconManager.updateSong(
+                                    song = currentSong,
+                                    lyrics = lyrics,
+                                    translatedLyrics = translatedLyrics,
+                                    lyricOffsetMs = lyricOffsetOverrideMs
+                                        ?: resolveLyriconLyricOffsetMs(currentSong),
+                                )
+                            }
+                        }
+                    }
                 }
-                val currentSong = _currentSongFlow.value
-                if (currentSong?.sameIdentityAs(song) == true) {
-                    LyriconManager.updateSong(
-                        song = currentSong,
-                        lyrics = lyrics,
-                        translatedLyrics = translatedLyrics,
+            },
+            onPublished = {
+                when {
+                    !lyriconEnabled -> LyriconManager.setPlaybackState(false)
+                    song == null -> {
+                        LyriconManager.setPlaybackState(false)
+                        updateLyriconLyricOffset(null)
+                        LyriconManager.setPosition(0L)
+                    }
+                    else -> LyriconManager.updateSong(
+                        song = song,
+                        lyrics = null,
+                        translatedLyrics = null,
                         lyricOffsetMs = lyricOffsetOverrideMs
-                            ?: resolveLyriconLyricOffsetMs(currentSong),
+                            ?: resolveLyriconLyricOffsetMs(song),
                     )
                 }
-            }
-        }
+            },
+        )
+        request.job?.start()
+    }
+
+    internal fun cancelLyriconUpdate() {
+        lyriconUpdateCoordinator.cancelActive()
+    }
+
+    internal fun hasPendingLyriconUpdate(): Boolean {
+        return lyriconUpdateCoordinator.hasPendingJob()
     }
 
     internal fun updateLyriconLyricOffset(song: SongItem? = _currentSongFlow.value) {

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -50,7 +50,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -319,6 +321,8 @@ object PlayerManager {
     internal var mainScope = newMainScope()
     internal var progressJob: Job? = null
     internal var lyriconUpdateJob: Job? = null
+    private val lyriconUpdateLock = Any()
+    private var lyriconUpdateGeneration = 0L
     internal var externalBluetoothLyricsLoadJob: Job? = null
     internal var externalBluetoothTranslationLoadJob: Job? = null
     internal var volumeFadeJob: Job? = null
@@ -801,7 +805,14 @@ object PlayerManager {
         )
     }
 
-    internal fun syncLyriconSong(song: SongItem?) {
+    internal fun syncLyriconSong(
+        song: SongItem?,
+        lyricOffsetOverrideMs: Long? = null,
+    ) {
+        val updateGeneration = synchronized(lyriconUpdateLock) {
+            lyriconUpdateGeneration += 1L
+            lyriconUpdateGeneration
+        }
         lyriconUpdateJob?.cancel()
         if (!lyriconEnabled) {
             lyriconUpdateJob = null
@@ -815,7 +826,7 @@ object PlayerManager {
             LyriconManager.setPosition(0L)
             return
         }
-        val lyricOffsetMs = resolveLyriconLyricOffsetMs(song)
+        val lyricOffsetMs = lyricOffsetOverrideMs ?: resolveLyriconLyricOffsetMs(song)
         LyriconManager.updateSong(
             song = song,
             lyrics = null,
@@ -824,15 +835,23 @@ object PlayerManager {
         )
         lyriconUpdateJob = ioScope.launch {
             val lyrics = getLyrics(song)
+            currentCoroutineContext().ensureActive()
             val translatedLyrics = getTranslatedLyrics(song)
-            val currentSong = _currentSongFlow.value
-            if (currentSong?.sameIdentityAs(song) == true) {
-                LyriconManager.updateSong(
-                    song = currentSong,
-                    lyrics = lyrics,
-                    translatedLyrics = translatedLyrics,
-                    lyricOffsetMs = resolveLyriconLyricOffsetMs(currentSong),
-                )
+            currentCoroutineContext().ensureActive()
+            synchronized(lyriconUpdateLock) {
+                if (updateGeneration != lyriconUpdateGeneration) {
+                    return@synchronized
+                }
+                val currentSong = _currentSongFlow.value
+                if (currentSong?.sameIdentityAs(song) == true) {
+                    LyriconManager.updateSong(
+                        song = currentSong,
+                        lyrics = lyrics,
+                        translatedLyrics = translatedLyrics,
+                        lyricOffsetMs = lyricOffsetOverrideMs
+                            ?: resolveLyriconLyricOffsetMs(currentSong),
+                    )
+                }
             }
         }
     }
@@ -841,6 +860,7 @@ object PlayerManager {
         if (!lyriconEnabled) return
         val lyricOffsetMs = song?.let { resolveLyriconLyricOffsetMs(it) } ?: 0L
         LyriconManager.setLyricOffset(lyricOffsetMs)
+        LyriconManager.setPosition(song?.let { _playbackPositionMs.value } ?: 0L)
     }
 
     private fun resolveLyriconLyricOffsetMs(song: SongItem): Long {

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -220,6 +220,7 @@ import moe.ouom.neriplayer.data.settings.DEFAULT_CLOUD_MUSIC_LYRIC_OFFSET_MS
 import moe.ouom.neriplayer.data.settings.DEFAULT_QQ_MUSIC_LYRIC_OFFSET_MS
 import moe.ouom.neriplayer.data.settings.PlaybackPreferenceSnapshot
 import moe.ouom.neriplayer.data.settings.UsbExclusivePreferences
+import moe.ouom.neriplayer.data.settings.resolveEffectiveLyricOffsetMs
 import moe.ouom.neriplayer.listentogether.mapping.buildStableTrackKey
 import moe.ouom.neriplayer.listentogether.mapping.resolvedAudioId
 import moe.ouom.neriplayer.listentogether.mapping.resolvedChannelId
@@ -810,17 +811,45 @@ object PlayerManager {
         if (song == null) {
             lyriconUpdateJob = null
             LyriconManager.setPlaybackState(false)
+            updateLyriconLyricOffset(null)
             LyriconManager.setPosition(0L)
             return
         }
-        LyriconManager.updateSong(song, lyrics = null, translatedLyrics = null)
+        val lyricOffsetMs = resolveLyriconLyricOffsetMs(song)
+        LyriconManager.updateSong(
+            song = song,
+            lyrics = null,
+            translatedLyrics = null,
+            lyricOffsetMs = lyricOffsetMs,
+        )
         lyriconUpdateJob = ioScope.launch {
             val lyrics = getLyrics(song)
             val translatedLyrics = getTranslatedLyrics(song)
-            if (_currentSongFlow.value?.sameIdentityAs(song) == true) {
-                LyriconManager.updateSong(song, lyrics, translatedLyrics)
+            val currentSong = _currentSongFlow.value
+            if (currentSong?.sameIdentityAs(song) == true) {
+                LyriconManager.updateSong(
+                    song = currentSong,
+                    lyrics = lyrics,
+                    translatedLyrics = translatedLyrics,
+                    lyricOffsetMs = resolveLyriconLyricOffsetMs(currentSong),
+                )
             }
         }
+    }
+
+    internal fun updateLyriconLyricOffset(song: SongItem? = _currentSongFlow.value) {
+        if (!lyriconEnabled) return
+        val lyricOffsetMs = song?.let { resolveLyriconLyricOffsetMs(it) } ?: 0L
+        LyriconManager.setLyricOffset(lyricOffsetMs)
+    }
+
+    private fun resolveLyriconLyricOffsetMs(song: SongItem): Long {
+        return resolveEffectiveLyricOffsetMs(
+            lyricSource = song.matchedLyricSource,
+            cloudMusicDefaultOffsetMs = cloudMusicLyricDefaultOffsetMs,
+            qqMusicDefaultOffsetMs = qqMusicLyricDefaultOffsetMs,
+            userLyricOffsetMs = song.userLyricOffsetMs,
+        )
     }
 
     internal fun isApplicationInitialized(): Boolean = this::application.isInitialized

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
@@ -931,8 +931,7 @@ internal fun PlayerManager.initializeImpl(
                         LyriconManager.setPosition(_playbackPositionMs.value)
                     }
                 } else {
-                    lyriconUpdateJob?.cancel()
-                    lyriconUpdateJob = null
+                    cancelLyriconUpdate()
                 }
             }
         }
@@ -3811,8 +3810,7 @@ internal fun PlayerManager.releaseImpl() {
         currentGenericUrlPrefetchJob = null
         currentGenericUrlPrefetchKey = null
         genericUrlPrefetchCache.clear()
-        lyriconUpdateJob?.cancel()
-        lyriconUpdateJob = null
+        cancelLyriconUpdate()
         externalBluetoothLyricsLoadJob?.cancel()
         externalBluetoothLyricsLoadJob = null
         externalBluetoothTranslationLoadJob?.cancel()

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
@@ -1020,12 +1020,14 @@ internal fun PlayerManager.initializeImpl(
             settingsRepo.cloudMusicLyricDefaultOffsetMsFlow.collect { offsetMs ->
                 cloudMusicLyricDefaultOffsetMs = offsetMs
                 updateExternalBluetoothLyricLine(_playbackPositionMs.value)
+                updateLyriconLyricOffset()
             }
         }
         ioScope.launch {
             settingsRepo.qqMusicLyricDefaultOffsetMsFlow.collect { offsetMs ->
                 qqMusicLyricDefaultOffsetMs = offsetMs
                 updateExternalBluetoothLyricLine(_playbackPositionMs.value)
+                updateLyriconLyricOffset()
             }
         }
         ioScope.launch {

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lyrics/LyriconUpdateCoordinator.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lyrics/LyriconUpdateCoordinator.kt
@@ -1,0 +1,59 @@
+package moe.ouom.neriplayer.core.player.lyrics
+
+import kotlinx.coroutines.Job
+
+internal data class LyriconUpdateRequest(
+    val generation: Long,
+    val job: Job?,
+)
+
+internal class LyriconUpdateCoordinator {
+    private val lock = Any()
+    private var generation = 0L
+    private var activeJob: Job? = null
+
+    fun replace(
+        createJob: (generation: Long) -> Job?,
+        onPublished: (LyriconUpdateRequest) -> Unit,
+    ): LyriconUpdateRequest {
+        return synchronized(lock) {
+            val updateGeneration = ++generation
+            activeJob?.cancel()
+            activeJob = null
+
+            val request = LyriconUpdateRequest(
+                generation = updateGeneration,
+                job = createJob(updateGeneration),
+            )
+            activeJob = request.job
+            onPublished(request)
+            request
+        }
+    }
+
+    fun runIfCurrent(
+        generation: Long,
+        job: Job,
+        block: () -> Unit,
+    ): Boolean {
+        return synchronized(lock) {
+            if (generation != this.generation || activeJob !== job) {
+                return@synchronized false
+            }
+            block()
+            true
+        }
+    }
+
+    fun cancelActive() {
+        synchronized(lock) {
+            generation += 1L
+            activeJob?.cancel()
+            activeJob = null
+        }
+    }
+
+    fun hasPendingJob(): Boolean {
+        return synchronized(lock) { activeJob?.isCompleted == false }
+    }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lyrics/PlayerManagerExternalBluetoothLyrics.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lyrics/PlayerManagerExternalBluetoothLyrics.kt
@@ -14,7 +14,7 @@ import moe.ouom.neriplayer.core.player.metadata.resolveExternalBluetoothLyricPay
 import moe.ouom.neriplayer.data.model.SongItem
 import moe.ouom.neriplayer.data.model.sameIdentityAs
 import moe.ouom.neriplayer.data.model.stableKey
-import moe.ouom.neriplayer.data.settings.resolveLyricDefaultOffsetMs
+import moe.ouom.neriplayer.data.settings.resolveEffectiveLyricOffsetMs
 import moe.ouom.neriplayer.ui.component.lyrics.LyricEntry
 import moe.ouom.neriplayer.ui.component.lyrics.matchTranslationsToLineIndices
 
@@ -145,11 +145,12 @@ internal fun PlayerManager.updateExternalBluetoothLyricLine(positionMs: Long) {
         return
     }
 
-    val lyricOffsetMs = resolveLyricDefaultOffsetMs(
+    val lyricOffsetMs = resolveEffectiveLyricOffsetMs(
         lyricSource = song.matchedLyricSource,
         cloudMusicDefaultOffsetMs = cloudMusicLyricDefaultOffsetMs,
-        qqMusicDefaultOffsetMs = qqMusicLyricDefaultOffsetMs
-    ) + song.userLyricOffsetMs
+        qqMusicDefaultOffsetMs = qqMusicLyricDefaultOffsetMs,
+        userLyricOffsetMs = song.userLyricOffsetMs,
+    )
 
     val line = findExternalBluetoothLyricLine(
         lyrics = externalBluetoothLyrics,

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -2076,7 +2076,7 @@ internal suspend fun PlayerManager.rebaseUserLyricOffsetsForSourceImpl(
             )
         }
     if (currentSongForRebase != null && rebasedCurrentSong != null) {
-        val hasPendingLyriconUpdate = lyriconUpdateJob?.isActive == true
+        val hasPendingLyriconUpdate = hasPendingLyriconUpdate()
         setCurrentSongForPlayback(rebasedCurrentSong, syncLyricon = false)
         if (hasPendingLyriconUpdate) {
             syncLyriconSong(

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -2074,7 +2074,7 @@ internal suspend fun PlayerManager.rebaseUserLyricOffsetsForSourceImpl(
             )
         }
     if (rebasedCurrentSong != null) {
-        setCurrentSongForPlayback(rebasedCurrentSong)
+        setCurrentSongForPlayback(rebasedCurrentSong, syncLyricon = false)
     }
 
     val localUpdateSucceeded = runLocalPlaylistMutationSafely("rebaseLyricOffsetsForSource") {

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/persistence/PlayerManagerPersistenceExtensions.kt
@@ -58,6 +58,7 @@ import moe.ouom.neriplayer.data.local.media.CustomSongCoverStorage
 import moe.ouom.neriplayer.data.local.database.NeriUserDataDatabase
 import moe.ouom.neriplayer.data.auth.common.SavedCookieAuthState
 import moe.ouom.neriplayer.data.settings.rebaseLyricUserOffsetMs
+import moe.ouom.neriplayer.data.settings.saturatingAddLyricOffsetMs
 import moe.ouom.neriplayer.data.settings.shouldRebaseLyricOffsetForSource
 import moe.ouom.neriplayer.ui.component.lyrics.LyricEntry
 import moe.ouom.neriplayer.ui.viewmodel.playlist.BiliVideoItem
@@ -2056,7 +2057,7 @@ internal suspend fun PlayerManager.rebaseUserLyricOffsetsForSourceImpl(
     }
 
     val currentSong = _currentSongFlow.value
-    val rebasedCurrentSong = currentSong
+    val currentSongForRebase = currentSong
         ?.takeIf {
             shouldRebaseLyricOffsetForSource(
                 lyricSource = it.matchedLyricSource,
@@ -2064,6 +2065,7 @@ internal suspend fun PlayerManager.rebaseUserLyricOffsetsForSourceImpl(
                 userOffsetMs = it.userLyricOffsetMs
             )
         }
+    val rebasedCurrentSong = currentSongForRebase
         ?.let { song ->
             song.copy(
                 userLyricOffsetMs = rebaseLyricUserOffsetMs(
@@ -2073,8 +2075,18 @@ internal suspend fun PlayerManager.rebaseUserLyricOffsetsForSourceImpl(
                 )
             )
         }
-    if (rebasedCurrentSong != null) {
+    if (currentSongForRebase != null && rebasedCurrentSong != null) {
+        val hasPendingLyriconUpdate = lyriconUpdateJob?.isActive == true
         setCurrentSongForPlayback(rebasedCurrentSong, syncLyricon = false)
+        if (hasPendingLyriconUpdate) {
+            syncLyriconSong(
+                song = rebasedCurrentSong,
+                lyricOffsetOverrideMs = saturatingAddLyricOffsetMs(
+                    value = previousDefaultOffsetMs,
+                    delta = currentSongForRebase.userLyricOffsetMs
+                )
+            )
+        }
     }
 
     val localUpdateSucceeded = runLocalPlaylistMutationSafely("rebaseLyricOffsetsForSource") {

--- a/app/src/main/java/moe/ouom/neriplayer/data/settings/LyricDefaultOffset.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/settings/LyricDefaultOffset.kt
@@ -27,6 +27,19 @@ internal fun resolveLyricDefaultOffsetMs(
     }
 }
 
+internal fun resolveEffectiveLyricOffsetMs(
+    lyricSource: MusicPlatform?,
+    cloudMusicDefaultOffsetMs: Long,
+    qqMusicDefaultOffsetMs: Long,
+    userLyricOffsetMs: Long
+): Long {
+    return resolveLyricDefaultOffsetMs(
+        lyricSource = lyricSource,
+        cloudMusicDefaultOffsetMs = cloudMusicDefaultOffsetMs,
+        qqMusicDefaultOffsetMs = qqMusicDefaultOffsetMs
+    ) + userLyricOffsetMs
+}
+
 internal fun shouldRebaseLyricOffsetForSource(
     lyricSource: MusicPlatform?,
     targetSource: MusicPlatform,

--- a/app/src/main/java/moe/ouom/neriplayer/data/settings/LyricDefaultOffset.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/data/settings/LyricDefaultOffset.kt
@@ -33,11 +33,30 @@ internal fun resolveEffectiveLyricOffsetMs(
     qqMusicDefaultOffsetMs: Long,
     userLyricOffsetMs: Long
 ): Long {
-    return resolveLyricDefaultOffsetMs(
-        lyricSource = lyricSource,
-        cloudMusicDefaultOffsetMs = cloudMusicDefaultOffsetMs,
-        qqMusicDefaultOffsetMs = qqMusicDefaultOffsetMs
-    ) + userLyricOffsetMs
+    return saturatingAddLyricOffsetMs(
+        value = resolveLyricDefaultOffsetMs(
+            lyricSource = lyricSource,
+            cloudMusicDefaultOffsetMs = cloudMusicDefaultOffsetMs,
+            qqMusicDefaultOffsetMs = qqMusicDefaultOffsetMs
+        ),
+        delta = userLyricOffsetMs
+    )
+}
+
+internal fun saturatingAddLyricOffsetMs(value: Long, delta: Long): Long {
+    return when {
+        delta > 0L && value > Long.MAX_VALUE - delta -> Long.MAX_VALUE
+        delta < 0L && value < Long.MIN_VALUE - delta -> Long.MIN_VALUE
+        else -> value + delta
+    }
+}
+
+private fun saturatingSubtractLyricOffsetMs(value: Long, delta: Long): Long {
+    return when {
+        delta > 0L && value < Long.MIN_VALUE + delta -> Long.MIN_VALUE
+        delta < 0L && value > Long.MAX_VALUE + delta -> Long.MAX_VALUE
+        else -> value - delta
+    }
 }
 
 internal fun shouldRebaseLyricOffsetForSource(
@@ -59,5 +78,11 @@ internal fun rebaseLyricUserOffsetMs(
     previousDefaultOffsetMs: Long,
     newDefaultOffsetMs: Long
 ): Long {
-    return userOffsetMs + previousDefaultOffsetMs - newDefaultOffsetMs
+    return saturatingSubtractLyricOffsetMs(
+        value = saturatingAddLyricOffsetMs(
+            value = userOffsetMs,
+            delta = previousDefaultOffsetMs
+        ),
+        delta = newDefaultOffsetMs
+    )
 }

--- a/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/ui/screen/NowPlayingScreen.kt
@@ -262,7 +262,7 @@ import moe.ouom.neriplayer.data.settings.MIN_LYRIC_FONT_SCALE
 import moe.ouom.neriplayer.data.settings.PlaybackControlLayoutPreferences
 import moe.ouom.neriplayer.data.settings.ThemeDefaults
 import moe.ouom.neriplayer.data.settings.normalizeLyricFontScale
-import moe.ouom.neriplayer.data.settings.resolveLyricDefaultOffsetMs
+import moe.ouom.neriplayer.data.settings.resolveEffectiveLyricOffsetMs
 import moe.ouom.neriplayer.data.settings.scaledLyricFontSize
 import moe.ouom.neriplayer.ui.LocalMiniPlayerHeight
 import moe.ouom.neriplayer.ui.component.lyrics.AdvancedLyricsView
@@ -2596,13 +2596,12 @@ fun NowPlayingScreen(
     )
 
     // 歌词偏移 (平台 + 用户自定义)
-    val platformOffset = resolveLyricDefaultOffsetMs(
+    val totalOffset = resolveEffectiveLyricOffsetMs(
         lyricSource = currentSong?.matchedLyricSource,
         cloudMusicDefaultOffsetMs = cloudMusicLyricDefaultOffsetMs,
-        qqMusicDefaultOffsetMs = qqMusicLyricDefaultOffsetMs
+        qqMusicDefaultOffsetMs = qqMusicLyricDefaultOffsetMs,
+        userLyricOffsetMs = currentSong?.userLyricOffsetMs ?: 0L,
     )
-    val userOffset = currentSong?.userLyricOffsetMs ?: 0L
-    val totalOffset = platformOffset + userOffset
     val progressInfoSegments = remember(
         currentPlaybackAudioInfo,
         showProgressQualitySwitch,

--- a/app/src/test/java/moe/ouom/neriplayer/core/lyricon/LyriconPositionFeedTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/lyricon/LyriconPositionFeedTest.kt
@@ -165,13 +165,13 @@ class LyriconPositionFeedTest {
 
     @Test
     fun `display lead compensates status bar lag without stacking into anchor`() {
-        assertEquals(750L, LYRICON_DISPLAY_LEAD_MS)
+        assertEquals(400L, LYRICON_DISPLAY_LEAD_MS)
         assertEquals(
-            1_750L,
+            1_400L,
             displayLyriconPositionMs(mediaPositionMs = 1_000L, durationMs = 10_000L)
         )
         assertEquals(
-            10_000L,
+            9_900L,
             displayLyriconPositionMs(mediaPositionMs = 9_500L, durationMs = 10_000L)
         )
         // lead 不进媒体锚点: 同一 media 多次 display 结果稳定
@@ -185,7 +185,7 @@ class LyriconPositionFeedTest {
     @Test
     fun `display position applies lyric offset before display lead`() {
         assertEquals(
-            2_750L,
+            2_400L,
             displayLyriconPositionMs(
                 mediaPositionMs = 1_000L,
                 durationMs = 10_000L,
@@ -193,7 +193,7 @@ class LyriconPositionFeedTest {
             )
         )
         assertEquals(
-            1_250L,
+            900L,
             displayLyriconPositionMs(
                 mediaPositionMs = 1_000L,
                 durationMs = 10_000L,
@@ -205,7 +205,7 @@ class LyriconPositionFeedTest {
     @Test
     fun `negative lyric offset clamps before lead and output remains bounded`() {
         assertEquals(
-            750L,
+            400L,
             displayLyriconPositionMs(
                 mediaPositionMs = 100L,
                 durationMs = 10_000L,

--- a/app/src/test/java/moe/ouom/neriplayer/core/lyricon/LyriconPositionFeedTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/lyricon/LyriconPositionFeedTest.kt
@@ -183,6 +183,58 @@ class LyriconPositionFeedTest {
     }
 
     @Test
+    fun `display position applies lyric offset before display lead`() {
+        assertEquals(
+            2_750L,
+            displayLyriconPositionMs(
+                mediaPositionMs = 1_000L,
+                durationMs = 10_000L,
+                lyricOffsetMs = 1_000L,
+            )
+        )
+        assertEquals(
+            1_250L,
+            displayLyriconPositionMs(
+                mediaPositionMs = 1_000L,
+                durationMs = 10_000L,
+                lyricOffsetMs = -500L,
+            )
+        )
+    }
+
+    @Test
+    fun `negative lyric offset clamps before lead and output remains bounded`() {
+        assertEquals(
+            750L,
+            displayLyriconPositionMs(
+                mediaPositionMs = 100L,
+                durationMs = 10_000L,
+                lyricOffsetMs = -500L,
+            )
+        )
+        assertEquals(
+            10_000L,
+            displayLyriconPositionMs(
+                mediaPositionMs = 9_500L,
+                durationMs = 10_000L,
+                lyricOffsetMs = 1_000L,
+            )
+        )
+    }
+
+    @Test
+    fun `display position saturates when duration is unknown`() {
+        assertEquals(
+            Long.MAX_VALUE,
+            displayLyriconPositionMs(
+                mediaPositionMs = Long.MAX_VALUE,
+                durationMs = 0L,
+                lyricOffsetMs = 1L,
+            )
+        )
+    }
+
+    @Test
     fun `position clamp never goes negative or past duration`() {
         assertEquals(0L, clampLyriconPositionMs(-10L, 1_000L))
         assertEquals(1_000L, clampLyriconPositionMs(5_000L, 1_000L))

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/lyrics/LyriconUpdateCoordinatorTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/lyrics/LyriconUpdateCoordinatorTest.kt
@@ -1,0 +1,77 @@
+package moe.ouom.neriplayer.core.player.lyrics
+
+import kotlinx.coroutines.Job
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LyriconUpdateCoordinatorTest {
+
+    @Test
+    fun `replacement cancels old job before publishing current job`() {
+        val coordinator = LyriconUpdateCoordinator()
+        val oldJob = Job()
+        coordinator.replace(createJob = { oldJob }, onPublished = {})
+
+        val currentJob = Job()
+        var publishedRequest: LyriconUpdateRequest? = null
+        val currentRequest = coordinator.replace(
+            createJob = { currentJob },
+            onPublished = { request ->
+                publishedRequest = request
+                assertTrue(oldJob.isCancelled)
+                assertFalse(currentJob.isCancelled)
+                assertTrue(
+                    coordinator.runIfCurrent(request.generation, currentJob) {}
+                )
+            },
+        )
+
+        assertSame(currentRequest, publishedRequest)
+        assertTrue(coordinator.hasPendingJob())
+
+        oldJob.cancel()
+        currentJob.cancel()
+    }
+
+    @Test
+    fun `stale completion cannot update after a newer job is published`() {
+        val coordinator = LyriconUpdateCoordinator()
+        val oldJob = Job()
+        val oldRequest = coordinator.replace(createJob = { oldJob }, onPublished = {})
+        val currentJob = Job()
+        val currentRequest = coordinator.replace(createJob = { currentJob }, onPublished = {})
+        var staleCompletionRan = false
+        var currentCompletionRan = false
+
+        assertFalse(
+            coordinator.runIfCurrent(oldRequest.generation, oldJob) {
+                staleCompletionRan = true
+            }
+        )
+        assertTrue(
+            coordinator.runIfCurrent(currentRequest.generation, currentJob) {
+                currentCompletionRan = true
+            }
+        )
+        assertFalse(staleCompletionRan)
+        assertTrue(currentCompletionRan)
+
+        oldJob.cancel()
+        currentJob.cancel()
+    }
+
+    @Test
+    fun `cancellation invalidates current completion`() {
+        val coordinator = LyriconUpdateCoordinator()
+        val job = Job()
+        val request = coordinator.replace(createJob = { job }, onPublished = {})
+
+        coordinator.cancelActive()
+
+        assertTrue(job.isCancelled)
+        assertFalse(coordinator.hasPendingJob())
+        assertFalse(coordinator.runIfCurrent(request.generation, job) {})
+    }
+}

--- a/app/src/test/java/moe/ouom/neriplayer/data/settings/LyricDefaultOffsetTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/settings/LyricDefaultOffsetTest.kt
@@ -64,6 +64,28 @@ class LyricDefaultOffsetTest {
     }
 
     @Test
+    fun resolveEffectiveLyricOffsetMs_saturatesOverflow() {
+        assertEquals(
+            Long.MAX_VALUE,
+            resolveEffectiveLyricOffsetMs(
+                lyricSource = MusicPlatform.CLOUD_MUSIC,
+                cloudMusicDefaultOffsetMs = 1_000L,
+                qqMusicDefaultOffsetMs = 500L,
+                userLyricOffsetMs = Long.MAX_VALUE,
+            )
+        )
+        assertEquals(
+            Long.MIN_VALUE,
+            resolveEffectiveLyricOffsetMs(
+                lyricSource = MusicPlatform.QQ_MUSIC,
+                cloudMusicDefaultOffsetMs = 1_000L,
+                qqMusicDefaultOffsetMs = -1_000L,
+                userLyricOffsetMs = Long.MIN_VALUE,
+            )
+        )
+    }
+
+    @Test
     fun shouldRebaseLyricOffsetForSource_onlyTouchesCustomizedSongsOfTheTargetSource() {
         assertTrue(
             shouldRebaseLyricOffsetForSource(
@@ -99,5 +121,25 @@ class LyricDefaultOffsetTest {
         assertEquals(550L, rebased)
         assertEquals(1_250L, 1_000L + 250L)
         assertEquals(1_250L, 700L + rebased)
+    }
+
+    @Test
+    fun rebaseLyricUserOffsetMs_saturatesOverflow() {
+        assertEquals(
+            Long.MAX_VALUE,
+            rebaseLyricUserOffsetMs(
+                userOffsetMs = Long.MAX_VALUE,
+                previousDefaultOffsetMs = 1_000L,
+                newDefaultOffsetMs = -1_000L
+            )
+        )
+        assertEquals(
+            Long.MIN_VALUE,
+            rebaseLyricUserOffsetMs(
+                userOffsetMs = Long.MIN_VALUE,
+                previousDefaultOffsetMs = -1_000L,
+                newDefaultOffsetMs = 1_000L
+            )
+        )
     }
 }

--- a/app/src/test/java/moe/ouom/neriplayer/data/settings/LyricDefaultOffsetTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/data/settings/LyricDefaultOffsetTest.kt
@@ -42,6 +42,28 @@ class LyricDefaultOffsetTest {
     }
 
     @Test
+    fun resolveEffectiveLyricOffsetMs_combinesPlatformDefaultAndUserOffset() {
+        assertEquals(
+            1_250L,
+            resolveEffectiveLyricOffsetMs(
+                lyricSource = MusicPlatform.CLOUD_MUSIC,
+                cloudMusicDefaultOffsetMs = 1_000L,
+                qqMusicDefaultOffsetMs = 500L,
+                userLyricOffsetMs = 250L,
+            )
+        )
+        assertEquals(
+            -100L,
+            resolveEffectiveLyricOffsetMs(
+                lyricSource = MusicPlatform.QQ_MUSIC,
+                cloudMusicDefaultOffsetMs = 1_000L,
+                qqMusicDefaultOffsetMs = 500L,
+                userLyricOffsetMs = -600L,
+            )
+        )
+    }
+
+    @Test
     fun shouldRebaseLyricOffsetForSource_onlyTouchesCustomizedSongsOfTheTargetSource() {
         assertTrue(
             shouldRebaseLyricOffsetForSource(


### PR DESCRIPTION
fix #391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Lyricon 现在应用歌词偏移，外部歌词与应用内歌词保持同步。
- 云音乐和 QQ 音乐的默认偏移与用户偏移统一解析。偏移配置更新后，Lyricon 会同步更新。
- 负偏移会先进行位置裁剪。未知时长时，位置计算会饱和，避免数值溢出。
- 新增测试，覆盖偏移计算顺序、边界限制、偏移合并和溢出饱和。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->