### PR TITLE
feat: prefer FFmpeg for FLAC decoding and support Netease resumable ranges

### DIFF
--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/player/engine/FfmpegFlacDecoderAvailabilityTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/player/engine/FfmpegFlacDecoderAvailabilityTest.kt
@@ -1,0 +1,23 @@
+@file:androidx.annotation.OptIn(markerClass = [androidx.media3.common.util.UnstableApi::class])
+
+package moe.ouom.neriplayer.core.player.engine
+
+import androidx.media3.common.MimeTypes
+import androidx.media3.decoder.ffmpeg.FfmpegLibrary
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FfmpegFlacDecoderAvailabilityTest {
+
+    @Test
+    fun bundledFfmpegCanDecodeFlacOnDevice() {
+        assertTrue("FFmpeg native library must load", FfmpegLibrary.isAvailable())
+        assertTrue(
+            "FFmpeg native library must support FLAC",
+            FfmpegLibrary.supportsFormat(MimeTypes.AUDIO_FLAC)
+        )
+    }
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/player/resolver/netease/NeteasePlaybackRangeSupportTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/player/resolver/netease/NeteasePlaybackRangeSupportTest.kt
@@ -1,0 +1,285 @@
+@file:androidx.annotation.OptIn(markerClass = [androidx.media3.common.util.UnstableApi::class])
+
+package moe.ouom.neriplayer.core.player.resolver.netease
+
+import android.net.Uri
+import androidx.media3.common.C
+import androidx.media3.datasource.BaseDataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.HttpDataSource
+import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import moe.ouom.neriplayer.core.player.resolver.youtube.ConditionalChunkedHttpDataSource
+import moe.ouom.neriplayer.core.player.resolver.youtube.shouldUseResumableChunkedHttpRange
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NeteasePlaybackRangeSupportTest {
+
+    @Test
+    fun trustedNeteaseFlacUsesResumableRanges() {
+        val dataSpec = DataSpec.Builder()
+            .setUri("https://m701.music.126.net/audio/track.flac?redacted=1")
+            .build()
+
+        assertTrue(shouldUseNeteaseFlacResumableRange(dataSpec.uri))
+        assertTrue(shouldUseResumableChunkedHttpRange(dataSpec))
+    }
+
+    @Test
+    fun neteaseFlacCorrectsCdnMimeBeforeExtractorSelection() {
+        val fixture = RangeFixture(
+            content = sampleContent(),
+            contentTypeHeaderName = "content-type"
+        )
+        val dataSource = createDataSource(fixture)
+        val dataSpec = neteaseFlacDataSpec()
+
+        val responseHeaders = try {
+            dataSource.open(dataSpec)
+            dataSource.responseHeaders
+        } finally {
+            dataSource.close()
+        }
+
+        assertEquals(listOf("audio/flac"), responseHeaders["Content-Type"])
+        val firstExtractorName = DefaultExtractorsFactory()
+            .createExtractors(dataSpec.uri, responseHeaders)
+            .first()
+            .underlyingImplementation
+            .javaClass
+            .simpleName
+        assertTrue(firstExtractorName.contains("Flac", ignoreCase = true))
+    }
+
+    @Test
+    fun nonFlacKeepsCdnMimeForExtractorSelection() {
+        val fixture = RangeFixture(content = sampleContent())
+        val dataSource = createDataSource(fixture)
+        val dataSpec = DataSpec.Builder()
+            .setUri("https://m701.music.126.net/audio/track.mp3?redacted=1")
+            .build()
+
+        val responseHeaders = try {
+            dataSource.open(dataSpec)
+            dataSource.responseHeaders
+        } finally {
+            dataSource.close()
+        }
+
+        assertEquals(listOf("audio/mpeg"), responseHeaders["Content-Type"])
+    }
+
+    @Test
+    fun nonFlacLookalikeAndExplicitRangeDoNotEnableManagedRanges() {
+        val flacUri = Uri.parse("https://m701.music.126.net/audio/track.flac")
+        val explicitRange = DataSpec.Builder()
+            .setUri(flacUri)
+            .setHttpRequestHeaders(mapOf("Range" to "bytes=0-1023"))
+            .build()
+
+        assertFalse(
+            shouldUseNeteaseFlacResumableRange(
+                Uri.parse("https://music.126.net.example/audio/track.flac")
+            )
+        )
+        assertFalse(
+            shouldUseNeteaseFlacResumableRange(
+                Uri.parse("https://m701.music.126.net/audio/track.mp3")
+            )
+        )
+        assertFalse(shouldUseResumableChunkedHttpRange(explicitRange))
+    }
+
+    @Test
+    fun earlyUpstreamEofResumesTheOriginalFlacBytes() {
+        val fixture = RangeFixture(
+            content = sampleContent(),
+            readableBytesForOpen = { openIndex, requestedLength ->
+                if (openIndex == 0) minOf(39, requestedLength) else requestedLength
+            }
+        )
+        val dataSource = createDataSource(fixture)
+
+        val read = try {
+            dataSource.open(neteaseFlacDataSpec())
+            readAll(dataSource)
+        } finally {
+            dataSource.close()
+        }
+
+        assertArrayEquals(fixture.content, read)
+        assertEquals(listOf(0L, 39L), fixture.requestPositions)
+    }
+
+    @Test
+    fun completeFlacEndsWithoutRetryingTheSameRange() {
+        val fixture = RangeFixture(content = sampleContent())
+        val dataSource = createDataSource(fixture)
+
+        val read = try {
+            dataSource.open(neteaseFlacDataSpec())
+            readAll(dataSource)
+        } finally {
+            dataSource.close()
+        }
+
+        assertArrayEquals(fixture.content, read)
+        assertEquals(listOf(0L), fixture.requestPositions)
+    }
+
+    @Test
+    fun zeroByteRangeIsRetriedOnlyOnce() {
+        val fixture = RangeFixture(
+            content = sampleContent(),
+            readableBytesForOpen = { _, _ -> 0 }
+        )
+        val dataSource = createDataSource(fixture)
+
+        val failure = try {
+            dataSource.open(neteaseFlacDataSpec())
+            runCatching { readAll(dataSource) }.exceptionOrNull()
+        } finally {
+            dataSource.close()
+        }
+
+        assertTrue(failure is IOException)
+        assertEquals(listOf(0L, 0L), fixture.requestPositions)
+    }
+
+    private fun createDataSource(fixture: RangeFixture): HttpDataSource {
+        return ConditionalChunkedHttpDataSource(
+            upstreamFactory = FixtureHttpDataSourceFactory(fixture),
+            transformDataSpec = { it }
+        )
+    }
+
+    private fun neteaseFlacDataSpec(): DataSpec {
+        return DataSpec.Builder()
+            .setUri("https://m701.music.126.net/audio/track.flac?redacted=1")
+            .build()
+    }
+
+    private fun sampleContent(): ByteArray {
+        return ByteArray(256 * 1024) { index -> (index % 251).toByte() }
+    }
+
+    private fun readAll(dataSource: HttpDataSource): ByteArray {
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(8 * 1024)
+        while (true) {
+            val read = dataSource.read(buffer, 0, buffer.size)
+            if (read == C.RESULT_END_OF_INPUT) {
+                return output.toByteArray()
+            }
+            output.write(buffer, 0, read)
+        }
+    }
+}
+
+private class RangeFixture(
+    val content: ByteArray,
+    val readableBytesForOpen: (openIndex: Int, requestedLength: Int) -> Int = { _, length ->
+        length
+    },
+    val contentTypeHeaderName: String = "Content-Type",
+    val contentType: String = "audio/mpeg"
+) {
+    val requestPositions = mutableListOf<Long>()
+}
+
+private class FixtureHttpDataSourceFactory(
+    private val fixture: RangeFixture
+) : HttpDataSource.Factory {
+
+    override fun createDataSource(): HttpDataSource = FixtureHttpDataSource(fixture)
+
+    override fun setDefaultRequestProperties(
+        defaultRequestProperties: Map<String, String>
+    ): HttpDataSource.Factory = this
+}
+
+private class FixtureHttpDataSource(
+    private val fixture: RangeFixture
+) : BaseDataSource(true), HttpDataSource {
+
+    private var opened = false
+    private var currentUri: Uri? = null
+    private var currentResponseHeaders: Map<String, List<String>> = emptyMap()
+    private var currentResponseCode = -1
+    private var readPosition = 0
+    private var readableEndPosition = 0
+
+    override fun open(dataSpec: DataSpec): Long {
+        transferInitializing(dataSpec)
+        val startPosition = dataSpec.position.toInt()
+        val availableLength = (fixture.content.size - startPosition).coerceAtLeast(0)
+        val requestedLength = when (dataSpec.length) {
+            C.LENGTH_UNSET.toLong() -> availableLength
+            else -> minOf(dataSpec.length, availableLength.toLong()).toInt()
+        }
+        val openIndex = fixture.requestPositions.size
+        fixture.requestPositions += dataSpec.position
+        val readableLength = fixture.readableBytesForOpen(openIndex, requestedLength)
+            .coerceIn(0, requestedLength)
+        val endPosition = startPosition + requestedLength
+        currentUri = dataSpec.uri
+        currentResponseCode = 206
+        currentResponseHeaders = mapOf(
+            fixture.contentTypeHeaderName to listOf(fixture.contentType),
+            "Content-Length" to listOf(requestedLength.toString()),
+            "Content-Range" to listOf(
+                "bytes $startPosition-${endPosition - 1}/${fixture.content.size}"
+            )
+        )
+        readPosition = startPosition
+        readableEndPosition = startPosition + readableLength
+        opened = true
+        transferStarted(dataSpec)
+        return requestedLength.toLong()
+    }
+
+    override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+        if (readPosition >= readableEndPosition) return C.RESULT_END_OF_INPUT
+
+        val readLength = minOf(length, readableEndPosition - readPosition)
+        fixture.content.copyInto(
+            destination = buffer,
+            destinationOffset = offset,
+            startIndex = readPosition,
+            endIndex = readPosition + readLength
+        )
+        readPosition += readLength
+        bytesTransferred(readLength)
+        return readLength
+    }
+
+    override fun close() {
+        if (opened) {
+            opened = false
+            transferEnded()
+        }
+        currentUri = null
+        currentResponseHeaders = emptyMap()
+        currentResponseCode = -1
+    }
+
+    override fun getUri(): Uri? = currentUri
+
+    override fun getResponseHeaders(): Map<String, List<String>> = currentResponseHeaders
+
+    override fun getResponseCode(): Int = currentResponseCode
+
+    override fun setRequestProperty(name: String, value: String) = Unit
+
+    override fun clearRequestProperty(name: String) = Unit
+
+    override fun clearAllRequestProperties() = Unit
+}

--- a/app/src/androidTest/java/moe/ouom/neriplayer/core/player/resolver/netease/NeteasePlaybackRangeSupportTest.kt
+++ b/app/src/androidTest/java/moe/ouom/neriplayer/core/player/resolver/netease/NeteasePlaybackRangeSupportTest.kt
@@ -154,6 +154,30 @@ class NeteasePlaybackRangeSupportTest {
         assertEquals(listOf(0L, 0L), fixture.requestPositions)
     }
 
+    @Test
+    fun zeroByteRangeRetryIsResetAfterThePreviousRangeMakesProgress() {
+        val fixture = RangeFixture(
+            content = sampleContent(size = 2 * 1024 * 1024),
+            readableBytesForOpen = { openIndex, requestedLength ->
+                if (openIndex == 0 || openIndex == 2) 0 else requestedLength
+            }
+        )
+        val dataSource = createDataSource(fixture)
+
+        val read = try {
+            dataSource.open(neteaseFlacDataSpec())
+            readAll(dataSource)
+        } finally {
+            dataSource.close()
+        }
+
+        assertArrayEquals(fixture.content, read)
+        assertEquals(
+            listOf(0L, 0L, 1024L * 1024L, 1024L * 1024L),
+            fixture.requestPositions
+        )
+    }
+
     private fun createDataSource(fixture: RangeFixture): HttpDataSource {
         return ConditionalChunkedHttpDataSource(
             upstreamFactory = FixtureHttpDataSourceFactory(fixture),
@@ -167,8 +191,8 @@ class NeteasePlaybackRangeSupportTest {
             .build()
     }
 
-    private fun sampleContent(): ByteArray {
-        return ByteArray(256 * 1024) { index -> (index % 251).toByte() }
+    private fun sampleContent(size: Int = 256 * 1024): ByteArray {
+        return ByteArray(size) { index -> (index % 251).toByte() }
     }
 
     private fun readAll(dataSource: HttpDataSource): ByteArray {

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/PlayerManager.kt
@@ -2397,14 +2397,22 @@ object PlayerManager {
         allowCustomCacheKey: Boolean = true
     ): MediaItem {
         val mediaUrl = stripListenTogetherStreamQualityMetadata(url)
+        val mediaUri = mediaUrl.toUri()
         val isLocalFile =
             mediaUrl.startsWith("file://") ||
-                mediaUrl.startsWith("content://") ||
-                mediaUrl.startsWith("android.resource://") ||
-                mediaUrl.startsWith("/")
+            mediaUrl.startsWith("content://") ||
+            mediaUrl.startsWith("android.resource://") ||
+            mediaUrl.startsWith("/")
+        if (mediaUri.path?.endsWith(".flac", ignoreCase = true) == true) {
+            NPLogger.d(
+                "NERI-PlayerManager",
+                "build FLAC media item: songId=${song.id}, host=${mediaUri.host ?: "local"}, " +
+                    "declaredMimeType=${mimeType ?: "missing"}, cacheKey=$cacheKey"
+            )
+        }
         return MediaItem.Builder()
             .setMediaId("${song.id}|${song.album}|${song.mediaUri.orEmpty()}")
-            .setUri(mediaUrl.toUri())
+            .setUri(mediaUri)
             .apply {
                 if (!mimeType.isNullOrBlank()) {
                     setMimeType(mimeType)

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/engine/ReactiveRenderersFactory.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/engine/ReactiveRenderersFactory.kt
@@ -25,22 +25,93 @@ package moe.ouom.neriplayer.core.player.engine
 
 
 import android.content.Context
+import android.os.Handler
+import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.audio.AudioProcessor
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.decoder.ffmpeg.FfmpegAudioRenderer
+import androidx.media3.decoder.ffmpeg.FfmpegLibrary
 import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.Renderer
 import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.AudioRendererEventListener
 import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.audio.ForwardingAudioSink
 import androidx.media3.exoplayer.audio.TeeAudioProcessor
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.core.player.usb.sink.UsbExclusiveAudioSink
 import moe.ouom.neriplayer.core.player.effects.AudioReactive
 
 /**
  * 自定义 RenderersFactory:
  * - 注入 TeeAudioProcessor 将 PCM 能量送入 AudioReactive, 供可视化/背景特效使用
- * - FFmpeg renderer 交给 Media3 扩展模式注册, 避免抢在平台解码器前面
+ * - 仅对 FLAC 优先使用内置 FFmpeg, 避免部分设备的平台解码器将有效比特流过早标记为结束
  */
 @UnstableApi
 class ReactiveRenderersFactory(context: Context) : DefaultRenderersFactory(context) {
+    init {
+        val ffmpegCanDecodeFlac = runCatching {
+            FfmpegLibrary.isAvailable() && FfmpegLibrary.supportsFormat(MimeTypes.AUDIO_FLAC)
+        }.getOrElse { error ->
+            NPLogger.w(
+                "NERI-Player",
+                "FFmpeg FLAC decoder probe failed; keep platform decoder",
+                error
+            )
+            false
+        }
+        if (ffmpegCanDecodeFlac) {
+            setMediaCodecSelector(
+                FfmpegFlacMediaCodecSelector(
+                    delegate = MediaCodecSelector.DEFAULT,
+                    shouldPreferFfmpegForFlac = true
+                )
+            )
+            NPLogger.i(
+                "NERI-Player",
+                "FLAC decoder policy: prefer bundled FFmpeg over platform MediaCodec"
+            )
+        } else {
+            NPLogger.w(
+                "NERI-Player",
+                "Bundled FFmpeg cannot decode FLAC; keep platform MediaCodec"
+            )
+        }
+    }
+
+    override fun buildAudioRenderers(
+        context: Context,
+        extensionRendererMode: Int,
+        mediaCodecSelector: MediaCodecSelector,
+        enableDecoderFallback: Boolean,
+        audioSink: AudioSink,
+        eventHandler: Handler,
+        eventListener: AudioRendererEventListener,
+        out: ArrayList<Renderer>
+    ) {
+        super.buildAudioRenderers(
+            context,
+            extensionRendererMode,
+            mediaCodecSelector,
+            enableDecoderFallback,
+            audioSink,
+            eventHandler,
+            eventListener,
+            out
+        )
+        val ffmpegRendererIndex = out.indexOfFirst { it is FfmpegAudioRenderer }
+        if (ffmpegRendererIndex < 0) return
+
+        out[ffmpegRendererIndex] = FfmpegAudioRenderer(
+            eventHandler,
+            eventListener,
+            FfmpegPcm16AudioSink(audioSink)
+        )
+    }
+
     override fun buildAudioSink(
         context: Context,
         enableFloatOutput: Boolean,
@@ -57,5 +128,50 @@ class ReactiveRenderersFactory(context: Context) : DefaultRenderersFactory(conte
             .setEnableAudioOutputPlaybackParameters(false)
             .build()
         return UsbExclusiveAudioSink(context.applicationContext, fallbackSink)
+    }
+}
+
+@UnstableApi
+internal class FfmpegPcm16AudioSink(
+    delegate: AudioSink
+) : ForwardingAudioSink(delegate) {
+    override fun supportsFormat(format: Format): Boolean {
+        return !format.isFloatPcm() && super.supportsFormat(format)
+    }
+
+    override fun getFormatSupport(format: Format): Int {
+        return if (format.isFloatPcm()) {
+            SINK_FORMAT_UNSUPPORTED
+        } else {
+            super.getFormatSupport(format)
+        }
+    }
+
+    private fun Format.isFloatPcm(): Boolean {
+        return sampleMimeType == MimeTypes.AUDIO_RAW &&
+            pcmEncoding == C.ENCODING_PCM_FLOAT
+    }
+}
+
+@UnstableApi
+internal class FfmpegFlacMediaCodecSelector(
+    private val delegate: MediaCodecSelector,
+    private val shouldPreferFfmpegForFlac: Boolean
+) : MediaCodecSelector {
+    override fun getDecoderInfos(
+        mimeType: String,
+        requiresSecureDecoder: Boolean,
+        requiresTunnelingDecoder: Boolean
+    ) = if (
+        shouldPreferFfmpegForFlac &&
+        mimeType.equals(MimeTypes.AUDIO_FLAC, ignoreCase = true)
+    ) {
+        emptyList()
+    } else {
+        delegate.getDecoderInfos(
+            mimeType,
+            requiresSecureDecoder,
+            requiresTunnelingDecoder
+        )
     }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/engine/ReactiveRenderersFactory.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/engine/ReactiveRenderersFactory.kt
@@ -42,6 +42,7 @@ import androidx.media3.exoplayer.audio.ForwardingAudioSink
 import androidx.media3.exoplayer.audio.TeeAudioProcessor
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.core.player.PlayerManager
 import moe.ouom.neriplayer.core.player.usb.sink.UsbExclusiveAudioSink
 import moe.ouom.neriplayer.core.player.effects.AudioReactive
 
@@ -112,7 +113,9 @@ class ReactiveRenderersFactory(context: Context) : DefaultRenderersFactory(conte
             eventListener,
             FfmpegPcm16AudioSink(
                 delegate = audioSink,
-                forcePcm16 = forceFfmpegPcm16Output
+                shouldForcePcm16 = {
+                    forceFfmpegPcm16Output && !PlayerManager.usbExclusivePlaybackEnabled
+                }
             )
         )
     }
@@ -140,14 +143,14 @@ class ReactiveRenderersFactory(context: Context) : DefaultRenderersFactory(conte
 @UnstableApi
 internal class FfmpegPcm16AudioSink(
     delegate: AudioSink,
-    private val forcePcm16: Boolean
+    private val shouldForcePcm16: () -> Boolean
 ) : ForwardingAudioSink(delegate) {
     override fun supportsFormat(format: Format): Boolean {
-        return (!forcePcm16 || !format.isFloatPcm()) && super.supportsFormat(format)
+        return (!shouldForcePcm16() || !format.isFloatPcm()) && super.supportsFormat(format)
     }
 
     override fun getFormatSupport(format: Format): Int {
-        return if (forcePcm16 && format.isFloatPcm()) {
+        return if (shouldForcePcm16() && format.isFloatPcm()) {
             SINK_FORMAT_UNSUPPORTED
         } else {
             super.getFormatSupport(format)

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/engine/ReactiveRenderersFactory.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/engine/ReactiveRenderersFactory.kt
@@ -52,6 +52,8 @@ import moe.ouom.neriplayer.core.player.effects.AudioReactive
  */
 @UnstableApi
 class ReactiveRenderersFactory(context: Context) : DefaultRenderersFactory(context) {
+    private var forceFfmpegPcm16Output = true
+
     init {
         val ffmpegCanDecodeFlac = runCatching {
             FfmpegLibrary.isAvailable() && FfmpegLibrary.supportsFormat(MimeTypes.AUDIO_FLAC)
@@ -108,7 +110,10 @@ class ReactiveRenderersFactory(context: Context) : DefaultRenderersFactory(conte
         out[ffmpegRendererIndex] = FfmpegAudioRenderer(
             eventHandler,
             eventListener,
-            FfmpegPcm16AudioSink(audioSink)
+            FfmpegPcm16AudioSink(
+                delegate = audioSink,
+                forcePcm16 = forceFfmpegPcm16Output
+            )
         )
     }
 
@@ -117,6 +122,7 @@ class ReactiveRenderersFactory(context: Context) : DefaultRenderersFactory(conte
         enableFloatOutput: Boolean,
         enableAudioTrackPlaybackParams: Boolean
     ): AudioSink {
+        forceFfmpegPcm16Output = !enableFloatOutput
         val volumeNormalization = VolumeNormalizationAudioProcessor()
         val balance = StereoBalanceAudioProcessor()
         val tee = TeeAudioProcessor(AudioReactive.teeSink)
@@ -133,14 +139,15 @@ class ReactiveRenderersFactory(context: Context) : DefaultRenderersFactory(conte
 
 @UnstableApi
 internal class FfmpegPcm16AudioSink(
-    delegate: AudioSink
+    delegate: AudioSink,
+    private val forcePcm16: Boolean
 ) : ForwardingAudioSink(delegate) {
     override fun supportsFormat(format: Format): Boolean {
-        return !format.isFloatPcm() && super.supportsFormat(format)
+        return (!forcePcm16 || !format.isFloatPcm()) && super.supportsFormat(format)
     }
 
     override fun getFormatSupport(format: Format): Int {
-        return if (format.isFloatPcm()) {
+        return if (forcePcm16 && format.isFloatPcm()) {
             SINK_FORMAT_UNSUPPORTED
         } else {
             super.getFormatSupport(format)

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/engine/datasource/TrafficCountingHttpDataSource.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/engine/datasource/TrafficCountingHttpDataSource.kt
@@ -1,10 +1,12 @@
 package moe.ouom.neriplayer.core.player.engine.datasource
 
 import android.net.Uri
+import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.TransferListener
+import moe.ouom.neriplayer.core.logging.NPLogger
 import moe.ouom.neriplayer.data.traffic.TrafficByteAccumulator
 import moe.ouom.neriplayer.data.traffic.TrafficNetworkType
 import moe.ouom.neriplayer.data.traffic.TrafficStatsRepository
@@ -21,6 +23,7 @@ internal class TrafficCountingHttpDataSource(
     @Volatile
     private var active = false
     private var accumulator = newAccumulator()
+    private var neteaseFlacDiagnostic: NeteaseFlacStreamDiagnostic? = null
 
     override fun addTransferListener(transferListener: TransferListener) {
         delegate.addTransferListener(transferListener)
@@ -29,11 +32,14 @@ internal class TrafficCountingHttpDataSource(
     override fun open(dataSpec: DataSpec): Long {
         val nextAccumulator = newAccumulator()
         val length = delegate.open(dataSpec)
+        val diagnostic = buildNeteaseFlacDiagnostic(dataSpec, length)
         synchronized(trafficLock) {
             accumulator.flush()
             accumulator = nextAccumulator
             active = true
+            neteaseFlacDiagnostic = diagnostic
         }
+        diagnostic?.let(::logNeteaseFlacOpen)
         return length
     }
 
@@ -43,9 +49,27 @@ internal class TrafficCountingHttpDataSource(
         }
         val read = delegate.read(buffer, offset, length)
         if (readAccumulator != null && read > 0) {
-            synchronized(trafficLock) {
+            val signatureToLog = synchronized(trafficLock) {
                 readAccumulator.add(read.toLong())
+                neteaseFlacDiagnostic?.let { diagnostic ->
+                    diagnostic.bytesRead += read
+                    if (!diagnostic.firstPayloadSignatureLogged) {
+                        diagnostic.firstPayloadSignatureLogged = true
+                        diagnostic.firstPayloadSignature = flacPayloadSignature(buffer, offset, read)
+                        diagnostic
+                    } else {
+                        null
+                    }
+                }
             }
+            signatureToLog?.let(::logNeteaseFlacPayloadSignature)
+        } else if (read == C.RESULT_END_OF_INPUT) {
+            val diagnostic = synchronized(trafficLock) {
+                neteaseFlacDiagnostic?.takeUnless { it.endOfInputLogged }?.also {
+                    it.endOfInputLogged = true
+                }
+            }
+            diagnostic?.let(::logNeteaseFlacEndOfInput)
         }
         return read
     }
@@ -55,13 +79,17 @@ internal class TrafficCountingHttpDataSource(
     override fun getResponseHeaders(): Map<String, List<String>> = delegate.responseHeaders
 
     override fun close() {
+        var diagnostic: NeteaseFlacStreamDiagnostic? = null
         try {
             delegate.close()
         } finally {
             synchronized(trafficLock) {
                 active = false
                 accumulator.flush()
+                diagnostic = neteaseFlacDiagnostic
+                neteaseFlacDiagnostic = null
             }
+            diagnostic?.takeUnless { it.endOfInputLogged }?.let(::logNeteaseFlacClose)
         }
     }
 
@@ -89,4 +117,105 @@ internal class TrafficCountingHttpDataSource(
             )
         }
     }
+
+    private fun buildNeteaseFlacDiagnostic(
+        dataSpec: DataSpec,
+        openedLength: Long
+    ): NeteaseFlacStreamDiagnostic? {
+        val uri = delegate.uri ?: dataSpec.uri
+        val host = uri.host?.lowercase() ?: return null
+        val responseHeaders = delegate.responseHeaders
+        val contentType = responseHeaders.headerValue("Content-Type")
+            ?.substringBefore(';')
+            ?.trim()
+            ?.lowercase()
+        val isNeteaseStream = host == "music.126.net" || host.endsWith(".music.126.net")
+        val isFlac = uri.path?.lowercase()?.endsWith(".flac") == true ||
+            contentType == "audio/flac" ||
+            contentType == "audio/x-flac"
+        if (!isNeteaseStream || !isFlac) return null
+        return NeteaseFlacStreamDiagnostic(
+            host = host,
+            requestPosition = dataSpec.position,
+            requestLength = dataSpec.length,
+            openedLength = openedLength,
+            responseCode = delegate.responseCode,
+            contentType = contentType,
+            contentLength = responseHeaders.headerValue("Content-Length"),
+            contentRange = responseHeaders.headerValue("Content-Range")
+        )
+    }
+
+    private fun logNeteaseFlacOpen(diagnostic: NeteaseFlacStreamDiagnostic) {
+        NPLogger.d(
+            "NERI-PlaybackHttp",
+            "Netease FLAC stream open: host=${diagnostic.host}, position=${diagnostic.requestPosition}, " +
+                "requestedLength=${diagnostic.requestLength}, openedLength=${diagnostic.openedLength}, " +
+                "responseCode=${diagnostic.responseCode}, contentType=${diagnostic.contentType}, " +
+                "contentLength=${diagnostic.contentLength}, contentRange=${diagnostic.contentRange}"
+        )
+    }
+
+    private fun logNeteaseFlacPayloadSignature(diagnostic: NeteaseFlacStreamDiagnostic) {
+        NPLogger.d(
+            "NERI-PlaybackHttp",
+            "Netease FLAC payload signature: host=${diagnostic.host}, " +
+                "position=${diagnostic.requestPosition}, signature=${diagnostic.firstPayloadSignature}"
+        )
+    }
+
+    private fun logNeteaseFlacEndOfInput(diagnostic: NeteaseFlacStreamDiagnostic) {
+        NPLogger.w(
+            "NERI-PlaybackHttp",
+            "Netease FLAC stream EOF: host=${diagnostic.host}, position=${diagnostic.requestPosition}, " +
+                "openedLength=${diagnostic.openedLength}, bytesRead=${diagnostic.bytesRead}, " +
+                "responseCode=${diagnostic.responseCode}, contentLength=${diagnostic.contentLength}, " +
+                "contentRange=${diagnostic.contentRange}"
+        )
+    }
+
+    private fun logNeteaseFlacClose(diagnostic: NeteaseFlacStreamDiagnostic) {
+        NPLogger.d(
+            "NERI-PlaybackHttp",
+            "Netease FLAC stream closed before EOF: host=${diagnostic.host}, " +
+                "position=${diagnostic.requestPosition}, bytesRead=${diagnostic.bytesRead}, " +
+                "openedLength=${diagnostic.openedLength}"
+        )
+    }
+}
+
+private data class NeteaseFlacStreamDiagnostic(
+    val host: String,
+    val requestPosition: Long,
+    val requestLength: Long,
+    val openedLength: Long,
+    val responseCode: Int,
+    val contentType: String?,
+    val contentLength: String?,
+    val contentRange: String?,
+    var bytesRead: Long = 0L,
+    var firstPayloadSignature: String? = null,
+    var firstPayloadSignatureLogged: Boolean = false,
+    var endOfInputLogged: Boolean = false
+)
+
+private fun flacPayloadSignature(buffer: ByteArray, offset: Int, length: Int): String {
+    if (length < 4) return "short_read"
+    return if (
+        buffer[offset] == 'f'.code.toByte() &&
+        buffer[offset + 1] == 'L'.code.toByte() &&
+        buffer[offset + 2] == 'a'.code.toByte() &&
+        buffer[offset + 3] == 'C'.code.toByte()
+    ) {
+        "fLaC"
+    } else {
+        "other"
+    }
+}
+
+private fun Map<String, List<String>>.headerValue(name: String): String? {
+    return entries.firstOrNull { (headerName, _) -> headerName.equals(name, ignoreCase = true) }
+        ?.value
+        ?.joinToString(",")
+        ?.takeIf { it.isNotBlank() }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/lifecycle/PlayerManagerLifecycleExtensions.kt
@@ -20,6 +20,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.TrackSelectionParameters
+import androidx.media3.common.Format
 import androidx.media3.database.StandaloneDatabaseProvider
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.cache.Cache.CacheException
@@ -29,7 +30,9 @@ import androidx.media3.datasource.cache.NoOpCacheEvictor
 import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.DecoderReuseEvaluation
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -446,6 +449,32 @@ internal fun PlayerManager.initializeImpl(
             .setMediaSourceFactory(mediaSourceFactory)
             .setLoadControl(buildAudioLoadControl())
             .build()
+        player.addAnalyticsListener(object : AnalyticsListener {
+            override fun onAudioInputFormatChanged(
+                eventTime: AnalyticsListener.EventTime,
+                format: Format,
+                decoderReuseEvaluation: DecoderReuseEvaluation?
+            ) {
+                NPLogger.i(
+                    "NERI-Player",
+                    "audio input format: sampleMimeType=${format.sampleMimeType}, " +
+                        "containerMimeType=${format.containerMimeType}, codecs=${format.codecs}, " +
+                        "sampleRate=${format.sampleRate}, channels=${format.channelCount}"
+                )
+            }
+
+            override fun onAudioDecoderInitialized(
+                eventTime: AnalyticsListener.EventTime,
+                decoderName: String,
+                initializedTimestampMs: Long,
+                initializationDurationMs: Long
+            ) {
+                NPLogger.i(
+                    "NERI-Player",
+                    "audio decoder initialized: name=$decoderName, durationMs=$initializationDurationMs"
+                )
+            }
+        })
         applyInitialPlaybackWakeMode()
         _playbackSoundState.value = playbackEffectsController.attachPlayer(player)
         applyPlaybackSoundConfig(playbackSoundConfig, persist = false)

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/resolver/netease/NeteasePlaybackRangeSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/resolver/netease/NeteasePlaybackRangeSupport.kt
@@ -1,0 +1,44 @@
+package moe.ouom.neriplayer.core.player.resolver.netease
+
+import android.net.Uri
+import androidx.media3.common.MimeTypes
+import java.util.Locale
+
+internal fun shouldUseNeteaseFlacResumableRange(uri: Uri): Boolean {
+    val scheme = uri.scheme?.lowercase(Locale.US) ?: return false
+    if (scheme != "http" && scheme != "https") return false
+
+    val host = uri.host?.lowercase(Locale.US) ?: return false
+    if (host != "music.126.net" && !host.endsWith(".music.126.net")) return false
+
+    return uri.path?.lowercase(Locale.US)?.endsWith(".flac") == true
+}
+
+internal fun normalizeNeteaseFlacResponseContentType(
+    uri: Uri,
+    responseHeaders: Map<String, List<String>>
+): Map<String, List<String>> {
+    if (!shouldUseNeteaseFlacResumableRange(uri)) return responseHeaders
+
+    val contentType = responseHeaders.firstHeaderValue("Content-Type")
+        ?.substringBefore(';')
+        ?.trim()
+        ?.lowercase(Locale.US)
+    if (contentType == MimeTypes.AUDIO_FLAC) return responseHeaders
+
+    return buildMap {
+        responseHeaders.forEach { (name, values) ->
+            if (!name.equals("Content-Type", ignoreCase = true)) {
+                put(name, values)
+            }
+        }
+        put("Content-Type", listOf(MimeTypes.AUDIO_FLAC))
+    }
+}
+
+private fun Map<String, List<String>>.firstHeaderValue(name: String): String? {
+    return entries.firstOrNull { (headerName, _) -> headerName.equals(name, ignoreCase = true) }
+        ?.value
+        ?.firstOrNull()
+        ?.takeIf { it.isNotBlank() }
+}

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/resolver/youtube/YouTubeGoogleVideoRangeSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/resolver/youtube/YouTubeGoogleVideoRangeSupport.kt
@@ -32,6 +32,8 @@ import androidx.media3.datasource.DataSpec
 import androidx.media3.datasource.HttpDataSource
 import moe.ouom.neriplayer.data.platform.youtube.isYouTubeGoogleVideoHost
 import moe.ouom.neriplayer.core.logging.NPLogger
+import moe.ouom.neriplayer.core.player.resolver.netease.normalizeNeteaseFlacResponseContentType
+import moe.ouom.neriplayer.core.player.resolver.netease.shouldUseNeteaseFlacResumableRange
 import okhttp3.Request
 import java.io.IOException
 import java.util.Locale
@@ -297,13 +299,23 @@ internal object YouTubeGoogleVideoRangeSupport {
 }
 
 @UnstableApi
+internal fun shouldUseResumableChunkedHttpRange(dataSpec: DataSpec): Boolean {
+    return dataSpec.httpMethod == DataSpec.HTTP_METHOD_GET &&
+        !YouTubeGoogleVideoRangeSupport.hasExplicitRangeHeader(dataSpec.httpRequestHeaders) &&
+        (
+            YouTubeGoogleVideoRangeSupport.shouldUseChunkedRange(dataSpec.uri) ||
+                shouldUseNeteaseFlacResumableRange(dataSpec.uri)
+            )
+}
+
+@UnstableApi
 internal class ConditionalChunkedHttpDataSource(
     private val upstreamFactory: HttpDataSource.Factory,
     private val transformDataSpec: (DataSpec) -> DataSpec
 ) : BaseDataSource(true), HttpDataSource {
 
     companion object {
-        private const val TAG = "YouTubeChunkedDs"
+        private const val TAG = "ResumableChunkedDs"
     }
 
     private val requestProperties = linkedMapOf<String, String>()
@@ -317,7 +329,11 @@ internal class ConditionalChunkedHttpDataSource(
     private var initialSpec: DataSpec? = null
     private var transformedSpec: DataSpec? = null
     private var chunkedMode = false
+    private var usesNeteaseFlacRange = false
+    private var neteaseFlacMimeOverrideLogged = false
     private var bytesReadFromRequest = 0L
+    private var bytesReadAtChunkStart = 0L
+    private var retriedZeroProgressChunk = false
     private var bytesRemainingInRequest = C.LENGTH_UNSET.toLong()
     private var bytesRemainingInChunk = 0L
     private var totalContentLength: Long? = null
@@ -331,12 +347,24 @@ internal class ConditionalChunkedHttpDataSource(
         initialSpec = dataSpec
         transformedSpec = preparedSpec
         bytesReadFromRequest = 0L
+        bytesReadAtChunkStart = 0L
+        retriedZeroProgressChunk = false
         bytesRemainingInChunk = 0L
         currentResponseHeaders = emptyMap()
         currentResponseCode = -1
         currentUri = preparedSpec.uri
         totalContentLength = null
         chunkedMode = shouldChunk(preparedSpec)
+        usesNeteaseFlacRange = chunkedMode &&
+            shouldUseNeteaseFlacResumableRange(preparedSpec.uri)
+        neteaseFlacMimeOverrideLogged = false
+        if (usesNeteaseFlacRange) {
+            NPLogger.d(
+                TAG,
+                "enable Netease FLAC resumable range: host=${preparedSpec.uri.host}, " +
+                    "position=${preparedSpec.position}, length=${preparedSpec.length}"
+            )
+        }
 
         if (chunkedMode) {
             bytesRemainingInRequest = if (preparedSpec.length != C.LENGTH_UNSET.toLong()) {
@@ -389,6 +417,33 @@ internal class ConditionalChunkedHttpDataSource(
                     bytesRemainingInRequest = 0L
                     return C.RESULT_END_OF_INPUT
                 }
+                val madeProgressInChunk = bytesReadFromRequest > bytesReadAtChunkStart
+                if (!madeProgressInChunk) {
+                    if (retriedZeroProgressChunk) {
+                        closeUpstreamQuietly()
+                        throw IOException(
+                            "Resumable range returned EOF twice without progress: " +
+                                "host=${currentUri?.host}, position=${transformedSpec?.position ?: 0L}"
+                        )
+                    }
+                    retriedZeroProgressChunk = true
+                    NPLogger.w(
+                        TAG,
+                        "retry resumable range after zero-byte EOF: " +
+                            "host=${currentUri?.host}, " +
+                            "position=${transformedSpec?.position ?: 0L}"
+                    )
+                } else {
+                    retriedZeroProgressChunk = false
+                }
+                if (usesNeteaseFlacRange && bytesRemainingInChunk > 0L) {
+                    NPLogger.w(
+                        TAG,
+                        "Netease FLAC range ended early: host=${currentUri?.host}, " +
+                            "position=${(transformedSpec?.position ?: 0L) + bytesReadFromRequest}, " +
+                            "remainingInRange=$bytesRemainingInChunk"
+                    )
+                }
                 bytesRemainingInChunk = 0L
                 continue
             }
@@ -417,7 +472,11 @@ internal class ConditionalChunkedHttpDataSource(
         initialSpec = null
         transformedSpec = null
         chunkedMode = false
+        usesNeteaseFlacRange = false
+        neteaseFlacMimeOverrideLogged = false
         bytesReadFromRequest = 0L
+        bytesReadAtChunkStart = 0L
+        retriedZeroProgressChunk = false
         bytesRemainingInRequest = C.LENGTH_UNSET.toLong()
         bytesRemainingInChunk = 0L
         totalContentLength = null
@@ -447,9 +506,7 @@ internal class ConditionalChunkedHttpDataSource(
     }
 
     private fun shouldChunk(dataSpec: DataSpec): Boolean {
-        return dataSpec.httpMethod == DataSpec.HTTP_METHOD_GET &&
-            YouTubeGoogleVideoRangeSupport.shouldUseChunkedRange(dataSpec.uri) &&
-            !YouTubeGoogleVideoRangeSupport.hasExplicitRangeHeader(dataSpec.httpRequestHeaders)
+        return shouldUseResumableChunkedHttpRange(dataSpec)
     }
 
     private fun mergeRequestProperties(dataSpec: DataSpec): DataSpec {
@@ -470,6 +527,13 @@ internal class ConditionalChunkedHttpDataSource(
             return false
         }
         val nextStartPosition = baseSpec.position + bytesReadFromRequest
+        if (usesNeteaseFlacRange) {
+            NPLogger.d(
+                TAG,
+                "resume Netease FLAC range: host=${baseSpec.uri.host}, " +
+                    "position=$nextStartPosition, totalLength=$totalContentLength"
+            )
+        }
         return try {
             openChunk(startPosition = nextStartPosition)
             true
@@ -536,6 +600,7 @@ internal class ConditionalChunkedHttpDataSource(
             headers = currentResponseHeaders
         ) ?: totalContentLength
         bytesRemainingInChunk = resolvedChunkLength.coerceAtLeast(0L)
+        bytesReadAtChunkStart = bytesReadFromRequest
 
         if (requestedRemaining == C.LENGTH_UNSET.toLong()) {
             bytesRemainingInRequest = when {
@@ -563,12 +628,35 @@ internal class ConditionalChunkedHttpDataSource(
     private fun bindOpenResult(delegate: HttpDataSource) {
         upstream = delegate
         currentUri = delegate.uri ?: transformedSpec?.uri
-        currentResponseHeaders = delegate.responseHeaders
+        val upstreamResponseHeaders = delegate.responseHeaders
+        currentResponseHeaders = currentUri?.let { uri ->
+            normalizeNeteaseFlacResponseContentType(uri, upstreamResponseHeaders)
+        } ?: upstreamResponseHeaders
         currentResponseCode = delegate.responseCode
+
+        if (usesNeteaseFlacRange && !neteaseFlacMimeOverrideLogged) {
+            val upstreamContentType = upstreamResponseHeaders.firstHeaderValue("Content-Type")
+            val extractorContentType = currentResponseHeaders.firstHeaderValue("Content-Type")
+            if (upstreamContentType != extractorContentType) {
+                neteaseFlacMimeOverrideLogged = true
+                NPLogger.d(
+                    TAG,
+                    "normalize Netease FLAC MIME for extractor: host=${currentUri?.host}, " +
+                        "upstream=$upstreamContentType, extractor=$extractorContentType"
+                )
+            }
+        }
     }
 
     private fun closeUpstreamQuietly() {
         runCatching { upstream?.close() }
         upstream = null
     }
+}
+
+private fun Map<String, List<String>>.firstHeaderValue(name: String): String? {
+    return entries.firstOrNull { (headerName, _) -> headerName.equals(name, ignoreCase = true) }
+        ?.value
+        ?.firstOrNull()
+        ?.takeIf { it.isNotBlank() }
 }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/resolver/youtube/YouTubeGoogleVideoRangeSupport.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/resolver/youtube/YouTubeGoogleVideoRangeSupport.kt
@@ -449,6 +449,7 @@ internal class ConditionalChunkedHttpDataSource(
             }
 
             bytesReadFromRequest += read
+            retriedZeroProgressChunk = false
             if (bytesRemainingInRequest != C.LENGTH_UNSET.toLong()) {
                 bytesRemainingInRequest = (bytesRemainingInRequest - read).coerceAtLeast(0L)
             }

--- a/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerUrlResolver.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/url/PlayerUrlResolver.kt
@@ -327,6 +327,7 @@ internal fun buildNeteaseSuccessResult(
     }
     return SongUrlResult.Success(
         url = finalUrl,
+        mimeType = normalizeNeteaseMimeType(parsed.type),
         noticeMessage = noticeMessage,
         expectedContentLength = parsed.contentLength,
         audioInfo = buildNeteasePlaybackAudioInfo(

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/engine/FfmpegFlacMediaCodecSelectorTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/engine/FfmpegFlacMediaCodecSelectorTest.kt
@@ -1,0 +1,78 @@
+package moe.ouom.neriplayer.core.player.engine
+
+import androidx.media3.common.MimeTypes
+import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FfmpegFlacMediaCodecSelectorTest {
+
+    @Test
+    fun `enabled FFmpeg FLAC policy does not query platform decoder`() {
+        val delegate = RecordingMediaCodecSelector()
+        val selector = FfmpegFlacMediaCodecSelector(
+            delegate = delegate,
+            shouldPreferFfmpegForFlac = true
+        )
+
+        assertTrue(selector.getDecoderInfos(MimeTypes.AUDIO_FLAC, false, false).isEmpty())
+        assertTrue(delegate.requests.isEmpty())
+    }
+
+    @Test
+    fun `disabled FFmpeg FLAC policy delegates to platform decoder`() {
+        val delegate = RecordingMediaCodecSelector()
+        val selector = FfmpegFlacMediaCodecSelector(
+            delegate = delegate,
+            shouldPreferFfmpegForFlac = false
+        )
+
+        selector.getDecoderInfos(MimeTypes.AUDIO_FLAC, true, true)
+
+        assertEquals(
+            listOf(DecoderRequest(MimeTypes.AUDIO_FLAC, true, true)),
+            delegate.requests
+        )
+    }
+
+    @Test
+    fun `non FLAC formats retain the platform decoder selection`() {
+        val delegate = RecordingMediaCodecSelector()
+        val selector = FfmpegFlacMediaCodecSelector(
+            delegate = delegate,
+            shouldPreferFfmpegForFlac = true
+        )
+
+        selector.getDecoderInfos(MimeTypes.AUDIO_MPEG, false, true)
+
+        assertEquals(
+            listOf(DecoderRequest(MimeTypes.AUDIO_MPEG, false, true)),
+            delegate.requests
+        )
+    }
+}
+
+private class RecordingMediaCodecSelector : MediaCodecSelector {
+    val requests = mutableListOf<DecoderRequest>()
+
+    override fun getDecoderInfos(
+        mimeType: String,
+        requiresSecureDecoder: Boolean,
+        requiresTunnelingDecoder: Boolean
+    ): List<MediaCodecInfo> {
+        requests += DecoderRequest(
+            mimeType,
+            requiresSecureDecoder,
+            requiresTunnelingDecoder
+        )
+        return emptyList()
+    }
+}
+
+private data class DecoderRequest(
+    val mimeType: String,
+    val requiresSecureDecoder: Boolean,
+    val requiresTunnelingDecoder: Boolean
+)

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/engine/FfmpegPcm16AudioSinkTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/engine/FfmpegPcm16AudioSinkTest.kt
@@ -23,7 +23,7 @@ class FfmpegPcm16AudioSinkTest {
         `when`(delegate.supportsFormat(format)).thenReturn(true)
         `when`(delegate.getFormatSupport(format))
             .thenReturn(AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY)
-        val sink = FfmpegPcm16AudioSink(delegate, forcePcm16 = true)
+        val sink = FfmpegPcm16AudioSink(delegate) { true }
 
         assertFalse(sink.supportsFormat(format))
         assertEquals(AudioSink.SINK_FORMAT_UNSUPPORTED, sink.getFormatSupport(format))
@@ -38,7 +38,7 @@ class FfmpegPcm16AudioSinkTest {
         `when`(delegate.supportsFormat(format)).thenReturn(true)
         `when`(delegate.getFormatSupport(format))
             .thenReturn(AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY)
-        val sink = FfmpegPcm16AudioSink(delegate, forcePcm16 = true)
+        val sink = FfmpegPcm16AudioSink(delegate) { true }
 
         assertTrue(sink.supportsFormat(format))
         assertEquals(
@@ -52,7 +52,7 @@ class FfmpegPcm16AudioSinkTest {
     @Test
     fun `java default methods are forwarded to the wrapped sink`() {
         val delegate = mock(AudioSink::class.java)
-        val sink = FfmpegPcm16AudioSink(delegate, forcePcm16 = true)
+        val sink = FfmpegPcm16AudioSink(delegate) { true }
 
         sink.setOutputStreamOffsetUs(123L)
 
@@ -66,7 +66,33 @@ class FfmpegPcm16AudioSinkTest {
         `when`(delegate.supportsFormat(format)).thenReturn(true)
         `when`(delegate.getFormatSupport(format))
             .thenReturn(AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY)
-        val sink = FfmpegPcm16AudioSink(delegate, forcePcm16 = false)
+        val sink = FfmpegPcm16AudioSink(delegate) { false }
+
+        assertTrue(sink.supportsFormat(format))
+        assertEquals(
+            AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY,
+            sink.getFormatSupport(format)
+        )
+        verify(delegate).supportsFormat(format)
+        verify(delegate).getFormatSupport(format)
+    }
+
+    @Test
+    fun `float pcm support is restored when usb exclusive output becomes active`() {
+        val delegate = mock(AudioSink::class.java)
+        val format = rawPcmFormat(C.ENCODING_PCM_FLOAT)
+        `when`(delegate.supportsFormat(format)).thenReturn(true)
+        `when`(delegate.getFormatSupport(format))
+            .thenReturn(AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY)
+        var usbExclusiveOutput = false
+        val sink = FfmpegPcm16AudioSink(delegate) { !usbExclusiveOutput }
+
+        assertFalse(sink.supportsFormat(format))
+        assertEquals(AudioSink.SINK_FORMAT_UNSUPPORTED, sink.getFormatSupport(format))
+        verify(delegate, never()).supportsFormat(format)
+        verify(delegate, never()).getFormatSupport(format)
+
+        usbExclusiveOutput = true
 
         assertTrue(sink.supportsFormat(format))
         assertEquals(

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/engine/FfmpegPcm16AudioSinkTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/engine/FfmpegPcm16AudioSinkTest.kt
@@ -23,7 +23,7 @@ class FfmpegPcm16AudioSinkTest {
         `when`(delegate.supportsFormat(format)).thenReturn(true)
         `when`(delegate.getFormatSupport(format))
             .thenReturn(AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY)
-        val sink = FfmpegPcm16AudioSink(delegate)
+        val sink = FfmpegPcm16AudioSink(delegate, forcePcm16 = true)
 
         assertFalse(sink.supportsFormat(format))
         assertEquals(AudioSink.SINK_FORMAT_UNSUPPORTED, sink.getFormatSupport(format))
@@ -38,7 +38,7 @@ class FfmpegPcm16AudioSinkTest {
         `when`(delegate.supportsFormat(format)).thenReturn(true)
         `when`(delegate.getFormatSupport(format))
             .thenReturn(AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY)
-        val sink = FfmpegPcm16AudioSink(delegate)
+        val sink = FfmpegPcm16AudioSink(delegate, forcePcm16 = true)
 
         assertTrue(sink.supportsFormat(format))
         assertEquals(
@@ -52,11 +52,29 @@ class FfmpegPcm16AudioSinkTest {
     @Test
     fun `java default methods are forwarded to the wrapped sink`() {
         val delegate = mock(AudioSink::class.java)
-        val sink = FfmpegPcm16AudioSink(delegate)
+        val sink = FfmpegPcm16AudioSink(delegate, forcePcm16 = true)
 
         sink.setOutputStreamOffsetUs(123L)
 
         verify(delegate).setOutputStreamOffsetUs(123L)
+    }
+
+    @Test
+    fun `float pcm support is delegated when high resolution output is enabled`() {
+        val delegate = mock(AudioSink::class.java)
+        val format = rawPcmFormat(C.ENCODING_PCM_FLOAT)
+        `when`(delegate.supportsFormat(format)).thenReturn(true)
+        `when`(delegate.getFormatSupport(format))
+            .thenReturn(AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY)
+        val sink = FfmpegPcm16AudioSink(delegate, forcePcm16 = false)
+
+        assertTrue(sink.supportsFormat(format))
+        assertEquals(
+            AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY,
+            sink.getFormatSupport(format)
+        )
+        verify(delegate).supportsFormat(format)
+        verify(delegate).getFormatSupport(format)
     }
 
     private fun rawPcmFormat(encoding: Int): Format = Format.Builder()

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/engine/FfmpegPcm16AudioSinkTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/engine/FfmpegPcm16AudioSinkTest.kt
@@ -1,0 +1,68 @@
+@file:androidx.annotation.OptIn(markerClass = [androidx.media3.common.util.UnstableApi::class])
+
+package moe.ouom.neriplayer.core.player.engine
+
+import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
+import androidx.media3.exoplayer.audio.AudioSink
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class FfmpegPcm16AudioSinkTest {
+    @Test
+    fun `float pcm support is hidden from the ffmpeg renderer`() {
+        val delegate = mock(AudioSink::class.java)
+        val format = rawPcmFormat(C.ENCODING_PCM_FLOAT)
+        `when`(delegate.supportsFormat(format)).thenReturn(true)
+        `when`(delegate.getFormatSupport(format))
+            .thenReturn(AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY)
+        val sink = FfmpegPcm16AudioSink(delegate)
+
+        assertFalse(sink.supportsFormat(format))
+        assertEquals(AudioSink.SINK_FORMAT_UNSUPPORTED, sink.getFormatSupport(format))
+        verify(delegate, never()).supportsFormat(format)
+        verify(delegate, never()).getFormatSupport(format)
+    }
+
+    @Test
+    fun `pcm16 support is delegated for ffmpeg fallback`() {
+        val delegate = mock(AudioSink::class.java)
+        val format = rawPcmFormat(C.ENCODING_PCM_16BIT)
+        `when`(delegate.supportsFormat(format)).thenReturn(true)
+        `when`(delegate.getFormatSupport(format))
+            .thenReturn(AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY)
+        val sink = FfmpegPcm16AudioSink(delegate)
+
+        assertTrue(sink.supportsFormat(format))
+        assertEquals(
+            AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY,
+            sink.getFormatSupport(format)
+        )
+        verify(delegate).supportsFormat(format)
+        verify(delegate).getFormatSupport(format)
+    }
+
+    @Test
+    fun `java default methods are forwarded to the wrapped sink`() {
+        val delegate = mock(AudioSink::class.java)
+        val sink = FfmpegPcm16AudioSink(delegate)
+
+        sink.setOutputStreamOffsetUs(123L)
+
+        verify(delegate).setOutputStreamOffsetUs(123L)
+    }
+
+    private fun rawPcmFormat(encoding: Int): Format = Format.Builder()
+        .setSampleMimeType(MimeTypes.AUDIO_RAW)
+        .setSampleRate(44_100)
+        .setChannelCount(2)
+        .setPcmEncoding(encoding)
+        .build()
+}

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerUrlResolverTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/url/PlayerUrlResolverTest.kt
@@ -85,6 +85,25 @@ class PlayerUrlResolverTest {
     }
 
     @Test
+    fun buildNeteaseSuccessResult_exposesFlacMimeTypeToMedia3() {
+        val result = buildNeteaseSuccessResult(
+            parsed = NeteasePlaybackResponseParser.PlaybackResult.Success(
+                url = "http://m801.music.126.net/track.flac",
+                type = "flac",
+                level = "lossless",
+                bitrateKbps = 960
+            ),
+            resolvedQualityKey = "hires",
+            fallbackDurationMs = 242_819L,
+            getLocalizedString = { it.toString() }
+        )
+
+        assertEquals("https://m801.music.126.net/track.flac", result.url)
+        assertEquals("audio/flac", result.mimeType)
+        assertEquals("audio/flac", result.audioInfo?.mimeType)
+    }
+
+    @Test
     fun inferBiliQualityKey_detectsLosslessTagsAndFlacStreams() {
         val taggedLossless = BiliAudioStreamInfo(
             id = 30280,


### PR DESCRIPTION
#385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- FLAC 优先使用内置 FFmpeg 解码器。FFmpeg 不可用或不支持 FLAC 时回退到平台解码器。
- 网易云 FLAC 流支持可恢复的分段 Range 请求。播放器会修正错误的 MIME 类型，并处理提前 EOF 和零字节响应。
- 网易云播放结果会正确暴露 `audio/flac` MIME 类型。
- 新增单元测试和 Android 仪器测试，覆盖 FFmpeg 解码能力、PCM 输出、网易云 MIME 类型及范围请求恢复逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->