### PR TITLE
fix: preserve null values in cached playback descriptors

### DIFF
--- a/app/src/main/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptor.kt
+++ b/app/src/main/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptor.kt
@@ -227,6 +227,7 @@ private fun JSONObject.putNullable(key: String, value: Any?) {
 }
 
 private fun JSONObject.optNullableString(key: String): String? {
+    if (!has(key) || isNull(key)) return null
     return optString(key).normalizedDescriptorValue()
 }
 

--- a/app/src/test/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptorTest.kt
+++ b/app/src/test/java/moe/ouom/neriplayer/core/player/url/CachedPlaybackDescriptorTest.kt
@@ -116,7 +116,7 @@ class CachedPlaybackDescriptorTest {
     }
 
     @Test
-    fun `legacy descriptor without representation identity remains readable`() {
+    fun `descriptor with nullable fields survives round trip`() {
         val descriptor = cachedPlaybackDescriptorFromAudioInfo(
             audioInfo = PlaybackAudioInfo(
                 source = PlaybackAudioSource.NETEASE,
@@ -127,7 +127,11 @@ class CachedPlaybackDescriptorTest {
             representationIdentity = null
         )
 
-        assertNotNull(descriptor.toPlaybackAudioInfo { it.toString() })
+        val decoded = decodeCachedPlaybackDescriptor(encodeCachedPlaybackDescriptor(descriptor))
+
+        assertNotNull(decoded?.toPlaybackAudioInfo { it.toString() })
+        assertNull(decoded?.representationIdentity)
+        assertNull(decoded?.codecLabel)
     }
 
     @Test


### PR DESCRIPTION
## 描述 / Description
<!--- 简要说明本次变更的目的以及解决的问题 / Briefly describe the purpose of this change and the problem it solves -->

## 类型 / Type

- [x] Bug 修复 / Bug Fix  
- [ ] 新功能 / New Feature  
- [ ] 文档更新 / Documentation Update  
- [ ] 其他（请描述）/ Other (please describe):  

## 修复或解决的问题 / Issues Fixed or Closed by This PR

## 清单 / Checklist

- [x] 我已阅读并遵循贡献指南 / I have read and followed the contribution guidelines  
- [x] 我已在本地测试这些更改 / I have tested these changes locally  
- [x] 我已更新相关文档或注释（如适用） / I have updated relevant documentation or comments (if applicable)  
- [x] 我确认本次更改没有破坏任何原有逻辑 / I confirm this change does not break existing behavior  
- [x] 我确认本次更改保持向下兼容（如适用） / I confirm this change remains backward compatible (if applicable)  
- [x] 我已运行必要的构建、测试或静态检查 / I have run the required build, tests, or static checks
- [x] 我确认没有提交密钥、Token 或其他敏感信息 / I confirm no secrets, tokens, or other sensitive information were committed  
- [x] 涉及 UI 变更时，我已补充截图或录屏（如适用） / I have added screenshots or recordings for UI changes (if applicable)  

## 其他信息 / Additional Information

<!--- 请在此补充任何与审查相关的额外信息或截图 / Please add any extra details or screenshots related to the review here.  -->

Fix nullable cached playback descriptor fields being incorrectly restored during JSON deserialization, and add a round-trip regression test to ensure nullable fields remain null after encode/decode.

Cache hit rate after fixing is shown below.

<img width="1280" height="2800" alt="Screenshot_20260902_110407_com_zoinve_neriplayer" src="https://github.com/user-attachments/assets/11daef7c-c10e-4dd0-9d69-a4de4da69aae" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- 修复 JSON 反序列化问题。缓存播放描述符中的可空字段现在可正确恢复为 `null`。
- 保持现有缓存数据的兼容性，避免可空字段被转换为非空字符串。
- 新增往返测试，验证 `representationIdentity` 和 `codecLabel` 在编码、解码后仍为 `null`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->